### PR TITLE
Set contentType to JSON when sending session models

### DIFF
--- a/jupyter_notebook/static/services/contents.js
+++ b/jupyter_notebook/static/services/contents.js
@@ -117,6 +117,7 @@ define(function(require) {
             processData : false,
             type : "POST",
             data: data,
+            contentType: 'application/json',
             dataType : "json",
         };
         return utils.promising_ajax(this.api_url(path), settings);
@@ -181,6 +182,7 @@ define(function(require) {
             processData : false,
             type: "POST",
             data: JSON.stringify({copy_from: from_file}),
+            contentType: 'application/json',
             dataType : "json",
         };
         return utils.promising_ajax(url, settings);
@@ -194,6 +196,7 @@ define(function(require) {
         var url = this.api_url(path, 'checkpoints');
         var settings = {
             type : "POST",
+            contentType: false,  // no data
             dataType : "json",
         };
         return utils.promising_ajax(url, settings);
@@ -213,6 +216,7 @@ define(function(require) {
         var url = this.api_url(path, 'checkpoints', checkpoint_id);
         var settings = {
             type : "POST",
+            contentType: false,  // no data
         };
         return utils.promising_ajax(url, settings);
     };

--- a/jupyter_notebook/static/services/kernels/kernel.js
+++ b/jupyter_notebook/static/services/kernels/kernel.js
@@ -194,6 +194,7 @@ define([
             cache: false,
             type: "POST",
             data: JSON.stringify({name: this.name}),
+            contentType: 'application/json',
             dataType: "json",
             success: this._on_success(on_success),
             error: this._on_error(error)
@@ -276,6 +277,7 @@ define([
             processData: false,
             cache: false,
             type: "POST",
+            contentType: false,  // there's no data with this
             dataType: "json",
             success: this._on_success(on_success),
             error: this._on_error(error)
@@ -317,6 +319,7 @@ define([
             processData: false,
             cache: false,
             type: "POST",
+            contentType: false,  // there's no data with this
             dataType: "json",
             success: this._on_success(on_success),
             error: this._on_error(on_error)

--- a/jupyter_notebook/static/services/sessions/session.js
+++ b/jupyter_notebook/static/services/sessions/session.js
@@ -121,6 +121,7 @@ define([
             cache: false,
             type: "POST",
             data: JSON.stringify(this._get_model()),
+            contentType: 'application/json',
             dataType: "json",
             success: this._on_success(on_success),
             error: this._on_error(on_error)
@@ -168,6 +169,7 @@ define([
             cache: false,
             type: "PATCH",
             data: JSON.stringify(this._get_model()),
+            contentType: 'application/json',
             dataType: "json",
             success: this._on_success(success),
             error: this._on_error(error)


### PR DESCRIPTION
Closes ipython/ipython#8416

Should be backported to 3.2 as well, since we seem to be planning for another 3.x release.