### PR TITLE
data_dir is not .ipython/kernel anymore.

### DIFF
--- a/jupyter_notebook/notebookapp.py
+++ b/jupyter_notebook/notebookapp.py
@@ -788,10 +788,6 @@ class NotebookApp(JupyterApp):
         self.kernel_spec_manager = self.kernel_spec_manager_class(
             parent=self,
         )
-        # FIXME: temporarily add .ipython/kernels to the kernel search path
-        self.kernel_spec_manager.kernel_dirs.append(
-            os.path.join(self.data_dir, 'kernels'),
-        )
         self.kernel_manager = self.kernel_manager_class(
             parent=self,
             log=self.log,

--- a/jupyter_notebook/tests/launchnotebook.py
+++ b/jupyter_notebook/tests/launchnotebook.py
@@ -67,13 +67,15 @@ class NotebookTestBase(TestCase):
     @classmethod
     def setup_class(cls):
         cls.home_dir = TemporaryDirectory()
+        data_dir = TemporaryDirectory()
         cls.env_patch = patch.dict('os.environ', {
             'HOME': cls.home_dir.name,
             'IPYTHONDIR': pjoin(cls.home_dir.name, '.ipython'),
+            'JUPYTER_DATA_DIR' : data_dir.name
         })
         cls.env_patch.start()
         cls.config_dir = TemporaryDirectory()
-        cls.data_dir = TemporaryDirectory()
+        cls.data_dir = data_dir
         cls.runtime_dir = TemporaryDirectory()
         cls.notebook_dir = TemporaryDirectory()
         app = cls.notebook = NotebookApp(


### PR DESCRIPTION
On OSX, items ~/Library/Jupyter/ which screw up where things find
kernels and anyway is already at the beginning of the search paths
lists.