### PR TITLE
Start working on opt-in data collection system

### DIFF
--- a/jupyter_notebook/analytics.py
+++ b/jupyter_notebook/analytics.py
@@ -38,7 +38,7 @@ class AnalyticsSender(object):
             try:
                 with open(self.control_file, 'r') as f:
                     self._control_info = json.load(f)
-            except OSError as e:
+            except IOError as e:
                 if e.errno == errno.ENOENT:
                     self._control_info = {}
                 else:

--- a/jupyter_notebook/analytics.py
+++ b/jupyter_notebook/analytics.py
@@ -1,0 +1,193 @@
+from datetime import datetime, timedelta
+import errno
+import json
+import os
+import os.path as osp
+import sys
+
+from jupyter_client.jsonutil import parse_date
+from tornado.httpclient import AsyncHTTPClient
+from tornado.ioloop import IOLoop
+from tornado import web
+import zmq
+from zmq.eventloop.zmqstream import ZMQStream
+
+from .base.handlers import IPythonHandler, json_errors
+from .utils import url_path_join as ujoin
+from ._version import __version__
+
+CONSENT_UNKNOWN = 0
+CONSENT_OK = 1
+CONSENT_DENIED = 2
+
+class AnalyticsSender(object):
+    _control_info = None
+    socket = None
+    enabled = False
+
+    def __init__(self, nbapp):
+        self.nbapp = nbapp
+        self.directory = osp.join(nbapp.data_dir, 'analytics')
+        self.control_file = osp.join(self.directory, 'control.json')
+        self.data_file = osp.join(nbapp.data_dir, 'analytics', 'data.json')
+        self.data = {}
+        self.ioloop = IOLoop.current()
+
+    def control_info(self):
+        if self._control_info is None:
+            try:
+                with open(self.control_file, 'r') as f:
+                    self._control_info = json.load(f)
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    self._control_info = {}
+                else:
+                    raise
+
+        return self._control_info
+
+    def store_control_info(self):
+        assert self._control_info is not None
+        try:
+            os.makedirs(self.directory)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+
+        with open(self.control_file, 'w') as f:
+            json.dump(self._control_info, f)
+
+    def read_data(self):
+        try:
+            with open(self.data_file, 'r') as f:
+                self.data = json.load(f)
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                raise
+
+    def store_data(self):
+        try:
+            os.makedirs(self.directory)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+
+        with open(self.data_file, 'w') as f:
+            json.dump(self.data, f)
+
+    def consent_status(self):
+        ci = self.control_info()
+        if 'consent' in ci:
+            return CONSENT_OK if ci['consent'] else CONSENT_DENIED
+        return CONSENT_UNKNOWN
+
+    def change_consent_status(self, status):
+        ci = self.control_info()
+        if status == CONSENT_OK:
+            if not ci.get('consent', False):
+                self.enable()
+            ci['consent'] = True
+        elif status == CONSENT_DENIED:
+            ci['consent'] = False
+        else:
+            ci.pop('consent', None)
+
+        self.store_control_info()
+
+    def last_submission(self):
+        ci = self.control_info()
+        if 'last_submission' in ci:
+            return parse_date(ci['last_submission'])
+
+        return None
+
+    def startup(self):
+        webapp = self.nbapp.web_app
+
+        consent = self.consent_status()
+        if consent == CONSENT_OK:
+            self.enable()
+        elif consent == CONSENT_UNKNOWN:
+            webapp.settings['analytics_prompt'] = True
+
+        base_url = webapp.settings['base_url']
+        webapp.add_handlers(".*$", [
+            (ujoin(base_url, r"/analytics/consent"), ConsentHandler,
+                {'sender': self}),
+        ])
+
+    def enable(self):
+        self.enabled = True
+        self.nbapp.log.info("Enabling analytics")
+        self.read_data()
+        self.record_version('jupyter_notebook', __version__)
+        self.record_version('server_python', sys.version)
+        self.schedule_send()
+
+        self.socket = zmq.Context.instance().socket(zmq.PULL)
+        port = self.socket.bind_to_random_port('tcp://127.0.0.1')
+        self.nbapp.kernel_manager.analytics_port = port
+        self.stream = ZMQStream(self.socket)
+        self.stream.on_recv(self.on_recv)
+
+    def on_recv(self, msg_parts):
+        data = json.loads(msg_parts[0])
+        msg_type = data['msg_type']
+        if msg_type == 'version':
+            self.record_version(data['project'], data['version'])
+        elif msg_type == 'feature':
+            self.record_feature(data['project'], data['feature'])
+
+    def schedule_send(self):
+        last = self.last_submission()
+        if last is None:
+            self.ioloop.add_callback(self.send)
+            return
+
+        since_last = datetime.utcnow() - self.last_submission()
+        if since_last > timedelta(days=28):
+            self.ioloop.add_callback(self.send)
+        else:
+            self.ioloop.call_later(since_last.total_seconds(), self.send)
+
+    def send(self):
+        http_client = AsyncHTTPClient()
+        # http_client.fetch('https://...', method='POST',
+        #                   body=json.dumps(self.data))
+        self.control_info()['last_submission'] = datetime.utcnow().isoformat()
+        self.store_control_info()
+
+        # Reset the data for the next month's collection
+        self.data = {}
+        self.record_version('jupyter_notebook', __version__)
+        self.record_version('server_python', sys.version)
+        self.ioloop.call_later(timedelta(days=28).total_seconds(), self.send)
+
+    def record_version(self, project, version):
+        proj_data = self.data.setdefault(project, {})
+        versions = set(proj_data.get('versions', []))
+        if version not in versions:
+            versions.add(version)
+            proj_data['versions'] = list(version)
+            self.store_data()
+
+    def record_feature(self, project, feature):
+        proj_data = self.data.setdefault(project, {})
+        features = set(proj_data.get('features', []))
+        if feature not in features:
+            features.add(feature)
+            proj_data['features'] = list(features)
+            self.store_data()
+
+class ConsentHandler(IPythonHandler):
+    def initialize(self, sender):
+        self.sender = sender
+
+    @web.authenticated
+    @json_errors
+    def post(self):
+        data = self.get_json_body()
+        if data['status']:
+            self.sender.change_consent_status(CONSENT_OK)
+        else:
+            self.sender.change_consent_status(CONSENT_DENIED)

--- a/jupyter_notebook/analytics.py
+++ b/jupyter_notebook/analytics.py
@@ -144,11 +144,12 @@ class AnalyticsSender(object):
             self.ioloop.add_callback(self.send)
             return
 
-        since_last = datetime.utcnow() - self.last_submission()
+        since_last = datetime.utcnow() - last
         if since_last > timedelta(days=28):
             self.ioloop.add_callback(self.send)
         else:
-            self.ioloop.call_later(since_last.total_seconds(), self.send)
+            to_next = (last + timedelta(days=28)) - datetime.utcnow()
+            self.ioloop.call_later(to_next.total_seconds(), self.send)
 
     def send(self):
         http_client = AsyncHTTPClient()

--- a/jupyter_notebook/notebookapp.py
+++ b/jupyter_notebook/notebookapp.py
@@ -210,6 +210,7 @@ class NotebookWebApplication(web.Application):
             config=ipython_app.config,
             jinja2_env=env,
             terminals_available=False,  # Set later if terminals are available
+            analytics_prompt=False,  # Set later if the user hasn't answered before
         )
 
         # allow custom overrides for the tornado web app.
@@ -906,6 +907,11 @@ class NotebookApp(JupyterApp):
             log = self.log.debug if sys.platform == 'win32' else self.log.warn
             log("Terminals not available (error was %s)", e)
 
+    def init_analytics(self):
+        from .analytics import AnalyticsSender
+        self.analytics = AnalyticsSender(self)
+        self.analytics.startup()
+
     def init_signal(self):
         if not sys.platform.startswith('win'):
             signal.signal(signal.SIGINT, self._handle_sigint)
@@ -1015,6 +1021,7 @@ class NotebookApp(JupyterApp):
         self.init_webapp()
         self.init_kernel_specs()
         self.init_terminals()
+        self.init_analytics()
         self.init_signal()
         self.init_server_extensions()
 


### PR DESCRIPTION
This is initial architecture for a mechanism to gather data on the tools users are using, as discussed with @njsmith.

For now, there are two kinds of data we wanted to collect: what versions of packages are in use, and how many users call particular features (especially deprecated features, to inform when they can be removed). Obviously there are many more things that might be interesting, but I think we should be taking a minimal, well justified set of data from users rather than just getting whatever we can.

My current thinking is that each of these will be a set, aggregated by month on the user's machine. So you'll see, for instance, that during the last month, a user has used numpy versions X and Y, and has called deprecated features A and B. You won't see how many times features were called - I don't think that's terribly useful anyway, because one call to a particular function inside a loop could be called millions of times. Four weeks after the last submission, or the next time after that that the server is started, it will submit and discard its data, and start collecting again.

Users who haven't previously made a choice will see a prompt of some kind in the notebook interface (not yet implemented) asking them to choose. We don't send any data until they agree, and if they say no, we don't ask again.

### Down to the technical details:

To make this mechanism readily available to all kernels, the kernels record data by sending it over a new ZMQ PUSH socket to the server. The connection file contains an extra entry `"analytics_port": N` if analytics are enabled - this shouldn't cause any problems for kernels that don't know about it. A single PULL socket on the server receives information from all kernels.

For now, the analytics messages are single-frame unsigned JSON messages, rather than routing them through our serialisation machinery. I don't think security is a big concern here - the only malicious possibility I can see is spamming the record of what's in use, and I don't see how we can prevent that given that it would ultimately be submitting to some public server.

This also requires some changes in jupyter_client (coming up) and ipykernel (not yet started). I was thinking of making a separate small package with the API to record information, so that projects wishing to use it could depend on that without depending on all the IPython/Jupyter machinery.