### PR TITLE
Fix can not found terminado

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,8 +150,10 @@ install_requires = [
     'nbconvert',
     'ipykernel', # bless IPython kernel for now
 ]
+
+if sys.platform != 'win32':
+    install_requires.append('terminado>=0.3.3')
 extras_require = {
-    ':sys_platform != "win32"': ['terminado>=0.3.3'],
     'doc': ['Sphinx>=1.1'],
     'test:python_version == "2.7"': ['mock'],
     'test': ['nose', 'requests'],


### PR DESCRIPTION
After i following the REAME. but cannot start notebook:

```python
$jupyter notebook
Traceback (most recent call last):
  File "/Users/dongweiming/.virtualenvs/jupyter_notebook/bin/jupyter-notebook", line 5, in <module>
    from pkg_resources import require
  File "/Users/dongweiming/.virtualenvs/jupyter_notebook/lib/python2.7/site-packages/pkg_resources.py", line 2716, in <module>
    working_set.require(__requires__)
  File "/Users/dongweiming/.virtualenvs/jupyter_notebook/lib/python2.7/site-packages/pkg_resources.py", line 685, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/Users/dongweiming/.virtualenvs/jupyter_notebook/lib/python2.7/site-packages/pkg_resources.py", line 588, in resolve
    raise DistributionNotFound(req)
pkg_resources.DistributionNotFound: terminado>=0.3.3
```

The package in `extras_require` is not installed by default. They only can install by:

```python
python setup.py develop
```