### PR TITLE
Start working on removing global JS IPython

### DIFF
--- a/examples/Notebook/Custom Keyboard Shortcuts.ipynb
+++ b/examples/Notebook/Custom Keyboard Shortcuts.ipynb
@@ -38,7 +38,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The keypress `r` in command mode is by default bound to change the type of a cell ro `raw`. This action will thus be unavaillable from the keyboard now."
+    "\"By default the keypress `r`, while in command mode, changes the type of the selected cell to `raw`.  This shortcut is overridden by the code in the previous cell, and thus the action no longer be available via the keypress `r`.\""
    ]
   },
   {

--- a/examples/Notebook/Custom Keyboard Shortcuts.ipynb
+++ b/examples/Notebook/Custom Keyboard Shortcuts.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Starting with IPython 2.0 keyboard shortcuts in command and edit mode are fully customizable. These customizations are made using the IPython JavaScript API. Here is an example that makes the `r` key available for running a cell:"
+    "Starting with IPython 2.0 keyboard shortcuts in command and edit mode are fully customizable. These customizations are made using the Jupyter JavaScript API. Here is an example that makes the `r` key available for running a cell:"
    ]
   },
   {
@@ -24,7 +24,7 @@
    "source": [
     "%%javascript\n",
     "\n",
-    "IPython.keyboard_manager.command_shortcuts.add_shortcut('r', {\n",
+    "Jupyter.keyboard_manager.command_shortcuts.add_shortcut('r', {\n",
     "    help : 'run cell',\n",
     "    help_index : 'zz',\n",
     "    handler : function (event) {\n",
@@ -32,6 +32,13 @@
     "        return false;\n",
     "    }}\n",
     ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The keypress `r` in command mode is by default bound to change the type of a cell ro `raw`. This action will thus be unavaillable from the keyboard now."
    ]
   },
   {
@@ -55,7 +62,7 @@
    "source": [
     "%%javascript\n",
     "\n",
-    "IPython.keyboard_manager.command_shortcuts.add_shortcut('r', function (event) {\n",
+    "Jupyter.keyboard_manager.command_shortcuts.add_shortcut('r', function (event) {\n",
     "    IPython.notebook.execute_cell();\n",
     "    return false;\n",
     "});"
@@ -78,14 +85,36 @@
    "source": [
     "%%javascript\n",
     "\n",
-    "IPython.keyboard_manager.command_shortcuts.remove_shortcut('r');"
+    "Jupyter.keyboard_manager.command_shortcuts.remove_shortcut('r');"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you want your keyboard shortcuts to be active for all of your notebooks, put the above API calls into your `<profile>/static/custom/custom.js` file."
+    "If you want your keyboard shortcuts to be active for all of your notebooks, put the above API calls into your `custom.js` file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "Of course we provide name for majority of existing action so that you do not have to re-write everything, here is for example how to bind `r` back to it's initial behavior:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%javascript\n",
+    "\n",
+    "Jupyter.keyboard_manager.command_shortcuts.add_shortcut('r', 'ipython.change-selected-cell-to-raw-cell');"
    ]
   }
  ],

--- a/notebook/static/auth/js/loginwidget.js
+++ b/notebook/static/auth/js/loginwidget.js
@@ -2,10 +2,9 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'base/js/utils',
     'jquery',
-], function(IPython, utils, $){
+], function(utils, $){
     "use strict";
 
     var LoginWidget = function (selector, options) {
@@ -17,7 +16,6 @@ define([
             this.bind_events();
         }
     };
-
 
 
     LoginWidget.prototype.bind_events = function () {
@@ -35,9 +33,6 @@ define([
             );
         });
     };
-
-    // Set module variables
-    IPython.LoginWidget = LoginWidget;
 
     return {'LoginWidget': LoginWidget};
 });

--- a/notebook/static/base/js/dialog.js
+++ b/notebook/static/base/js/dialog.js
@@ -5,7 +5,6 @@ define(function(require) {
     "use strict";
 
     var CodeMirror = require('codemirror/lib/codemirror');
-    var IPython = require('base/js/namespace');
     var $ = require('jquery');
     
     /**
@@ -204,9 +203,6 @@ define(function(require) {
         kernel_modal : kernel_modal,
         edit_metadata : edit_metadata,
     };
-
-    // Backwards compatability.
-    IPython.dialog = dialog;
 
     return dialog;
 });

--- a/notebook/static/base/js/keyboard.js
+++ b/notebook/static/base/js/keyboard.js
@@ -9,11 +9,10 @@
  */
 
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/utils',
     'underscore',
-], function(IPython, $, utils, _) {
+], function($, utils, _) {
     "use strict";
 
 
@@ -446,9 +445,6 @@ define([
         shortcut_to_event : shortcut_to_event,
         event_to_shortcut : event_to_shortcut,
     };
-
-    // For backwards compatibility.
-    IPython.keyboard = keyboard;
 
     return keyboard;
 });

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -2,7 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 var IPython = IPython || {};
-define([], function(){
+define(function(){
+    var utils = require('base/js/utils');
+    IPython.utils = utils;
+    IPython.load_extensions = utils.load_extensions;
+
     "use strict";
     IPython.version = "4.0.0.dev";
     IPython._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -61,6 +61,7 @@ define(function(){
     jglobal('Completer','notebook/js/completer');
     jglobal('Notebook','notebook/js/notebook');
     jglobal('Tooltip','notebook/js/tooltip');
+    jglobal('Toolbar','notebook/js/toolbar');
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
-//
-//
 
 
 var Jupyter = Jupyter || {};
@@ -9,7 +7,7 @@ var Jupyter = Jupyter || {};
 var jprop = function(name, module_path){
     Object.defineProperty(Jupyter, name, {
       get: function() { 
-          console.warn('accessing `'+name+'` is deprecated. Use require("'+module_path+'")');
+          console.warn('accessing `'+name+'` is deprecated. Use `require("'+module_path+'")`');
           return require(module_path); 
       },
       enumerable: true,
@@ -20,7 +18,7 @@ var jprop = function(name, module_path){
 var jglobal = function(name, module_path){
     Object.defineProperty(Jupyter, name, {
       get: function() { 
-          console.warn('accessing `'+name+'` is deprecated. Use require("'+module_path+'").'+name);
+          console.warn('accessing `'+name+'` is deprecated. Use `require("'+module_path+'").'+name+'`');
           return require(module_path)[name]; 
       },
       enumerable: true,

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -51,6 +51,9 @@ define(function(){
     jglobal('Session','services/sessions/session');
     jglobal('LoginWidget','auth/js/loginwidget');
     jglobal('Page','base/js/page');
+    jglobal('TextCell','base/js/textcell');
+    jglobal('MarkdownCell','base/js/textcell');
+    jglobal('RawCell','base/js/textcell');
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -60,6 +60,7 @@ define(function(){
     jglobal('KeyboardManager','notebook/js/keyboardmanager');
     jglobal('Completer','notebook/js/completer');
     jglobal('Notebook','notebook/js/notebook');
+    jglobal('Tooltip','notebook/js/tooltip');
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -64,6 +64,7 @@ define(function(){
     jglobal('Toolbar','notebook/js/toolbar');
     jglobal('SaveWidget','notebook/js/savewidget');
     jglobal('Pager','notebook/js/pager');
+    jglobal('QuickHelp','notebook/js/quickhelp');
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -6,6 +6,7 @@ define(function(){
     var utils = require('base/js/utils');
     IPython.security = require('base/js/security');
     IPython.keyboard = require('base/js/keyboard');
+    IPython.dialog = require('base/js/dialog');
     IPython.utils = utils;
     IPython.load_extensions = utils.load_extensions;
 

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -63,6 +63,7 @@ define(function(){
     jglobal('Tooltip','notebook/js/tooltip');
     jglobal('Toolbar','notebook/js/toolbar');
     jglobal('SaveWidget','notebook/js/savewidget');
+    jglobal('Pager','notebook/js/pager');
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -1,29 +1,56 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
+//
+//
+
 
 var Jupyter = Jupyter || {};
+
+var jprop = function(name, module_path){
+    Object.defineProperty(Jupyter, name, {
+      get: function() { 
+          console.warn('accessing `'+name+'` is deprecated. Use require("'+module_path+'")');
+          return require(module_path); 
+      },
+      enumerable: true,
+      configurable: false
+    });
+}
+
+var jglobal = function(name, module_path){
+    Object.defineProperty(Jupyter, name, {
+      get: function() { 
+          console.warn('accessing `'+name+'` is deprecated. Use require("'+module_path+'").'+name);
+          return require(module_path)[name]; 
+      },
+      enumerable: true,
+      configurable: false
+    });
+}
+
 define(function(){
     "use strict";
 
     // expose modules
-    Jupyter.utils = require('base/js/utils');
-    Jupyter.load_extensions = Jupyter.utils.load_extensions;
-     
-    Jupyter.security = require('base/js/security');
-    Jupyter.keyboard = require('base/js/keyboard');
-    Jupyter.dialog = require('base/js/dialog');
+    
+    jprop('utils','base/js/utils')
+    
+    //Jupyter.load_extensions = Jupyter.utils.load_extensions;
+    // 
+    jprop('security','base/js/security');
+    jprop('keyboard','base/js/keyboard');
+    jprop('dialog','base/js/dialog');
 
 
-    // exposed constructors
-    var comm = require('services/kernels/comm');
-    Jupyter.CommManager = comm.CommManager;
-    Jupyter.Comm = comm.Comm;
+    //// exposed constructors
+    jglobal('CommManager','services/kernels/comm')
+    jglobal('Comm','services/kernels/comm')
 
-    Jupyter.NotificationWidget = require('base/js/notificationwidget').NotificationWidget;
-    Jupyter.Kernel = require('services/kernels/kernel').Kernel;
-    Jupyter.Session = require('services/kernels/session').Session;
-    Jupyter.LoginWidget = require('auth/js/loginwidget').LoginWidget
-    Jupyter.Page = require('base/js/page').Page;
+    jglobal('NotificationWidget','base/js/notificationwidget');
+    jglobal('Kernel','services/kernels/kernel');
+    jglobal('Session','services/sessions/session');
+    jglobal('LoginWidget','auth/js/loginwidget');
+    jglobal('Page','base/js/page');
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -5,6 +5,7 @@ var IPython = IPython || {};
 define(function(){
     var utils = require('base/js/utils');
     IPython.security = require('base/js/security');
+    IPython.keyboard = require('base/js/keyboard');
     IPython.utils = utils;
     IPython.load_extensions = utils.load_extensions;
 

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -23,6 +23,7 @@ define(function(){
     Jupyter.Kernel = require('services/kernels/kernel').Kernel;
     Jupyter.Session = require('services/kernels/session').Session;
     Jupyter.LoginWidget = require('auth/js/loginwidget').LoginWidget
+    Jupyter.Page = require('base/js/page').Page;
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -62,6 +62,7 @@ define(function(){
     jglobal('Notebook','notebook/js/notebook');
     jglobal('Tooltip','notebook/js/tooltip');
     jglobal('Toolbar','notebook/js/toolbar');
+    jglobal('SaveWidget','notebook/js/savewidget');
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -70,6 +70,7 @@ define(function(){
     jglobal('MainToolBar','notebook/js/maintoolbar');
     jglobal('NotebookNotificationArea','notebook/js/notificationarea');
     jglobal('NotebookTour', 'notebook/js/tour');
+    jglobal('MenuBar', 'notebook/js/menubar');
 
     // tree
     jglobal('SessionList','tree/js/sessionlist');

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -40,6 +40,7 @@ define(function(){
     jprop('security','base/js/security');
     jprop('keyboard','base/js/keyboard');
     jprop('dialog','base/js/dialog');
+    jprop('mathjaxutils','notebook/js/mathjaxutils');
 
 
     //// exposed constructors

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -54,6 +54,7 @@ define(function(){
     jglobal('TextCell','base/js/textcell');
     jglobal('MarkdownCell','base/js/textcell');
     jglobal('RawCell','base/js/textcell');
+    jglobal('Cell','base/js/cell');
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -1,17 +1,20 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-var IPython = IPython || {};
+var Jupyter = Jupyter || {};
 define(function(){
     var utils = require('base/js/utils');
-    IPython.security = require('base/js/security');
-    IPython.keyboard = require('base/js/keyboard');
-    IPython.dialog = require('base/js/dialog');
-    IPython.utils = utils;
-    IPython.load_extensions = utils.load_extensions;
+    Jupyter.security = require('base/js/security');
+    Jupyter.keyboard = require('base/js/keyboard');
+    Jupyter.dialog = require('base/js/dialog');
+    Jupyter.utils = utils;
+    Jupyter.load_extensions = utils.load_extensions;
 
     "use strict";
-    IPython.version = "4.0.0.dev";
-    IPython._target = '_blank';
-    return IPython;
+    Jupyter.version = "4.0.0.dev";
+    Jupyter._target = '_blank';
+    return Jupyter;
 });
+
+// deprecated since 4.0, remove in 5+
+var IPython = Jupyter

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -55,6 +55,7 @@ define(function(){
     jglobal('MarkdownCell','base/js/textcell');
     jglobal('RawCell','base/js/textcell');
     jglobal('Cell','base/js/cell');
+    jglobal('OutputArea','notebook/js/outputarea');
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -59,6 +59,7 @@ define(function(){
     jglobal('OutputArea','notebook/js/outputarea');
     jglobal('KeyboardManager','notebook/js/keyboardmanager');
     jglobal('Completer','notebook/js/completer');
+    jglobal('Notebook','notebook/js/notebook');
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -67,9 +67,14 @@ define(function(){
     jglobal('MarkdownCell','notebook/js/textcell');
     jglobal('RawCell','notebook/js/textcell');
     jglobal('Cell','notebook/js/cell');
+    jglobal('MainToolBar','notebook/js/maintoolbar');
+    jglobal('NotebookNotificationArea','notebook/js/notificationarea');
+    jglobal('NotebookTour', 'notebook/js/tour');
 
     // tree
     jglobal('SessionList','tree/js/sessionlist');
+    jglobal('ClusterList','tree/js/clusterlist');
+    jglobal('ClusterItem','tree/js/clusterlist');
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -3,15 +3,20 @@
 
 var Jupyter = Jupyter || {};
 define(function(){
-    var utils = require('base/js/utils');
+    "use strict";
+
+    Jupyter.utils = require('base/js/utils');
     Jupyter.security = require('base/js/security');
     Jupyter.keyboard = require('base/js/keyboard');
     Jupyter.dialog = require('base/js/dialog');
     Jupyter.NotificationWidget = require('base/js/notificationwidget');
-    Jupyter.utils = utils;
     Jupyter.load_extensions = utils.load_extensions;
 
-    "use strict";
+    var comm = require('services/kernels/comm');
+
+    Juppyter.CommManager = comm.CommManager;
+    Juppyter.Comm = comm.Comm;
+
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';
     return Jupyter;

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -52,12 +52,9 @@ define(function(){
     jglobal('Session','services/sessions/session');
     jglobal('LoginWidget','auth/js/loginwidget');
     jglobal('Page','base/js/page');
-    jglobal('TextCell','base/js/textcell');
-    jglobal('MarkdownCell','base/js/textcell');
-    jglobal('RawCell','base/js/textcell');
-    jglobal('Cell','base/js/cell');
 
     // notebook
+    jglobal('TextCell','notebook/js/textcell');
     jglobal('OutputArea','notebook/js/outputarea');
     jglobal('KeyboardManager','notebook/js/keyboardmanager');
     jglobal('Completer','notebook/js/completer');
@@ -67,6 +64,9 @@ define(function(){
     jglobal('SaveWidget','notebook/js/savewidget');
     jglobal('Pager','notebook/js/pager');
     jglobal('QuickHelp','notebook/js/quickhelp');
+    jglobal('MarkdownCell','notebook/js/textcell');
+    jglobal('RawCell','notebook/js/textcell');
+    jglobal('Cell','notebook/js/cell');
 
     // tree
     jglobal('SessionList','tree/js/sessionlist');

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -56,6 +56,8 @@ define(function(){
     jglobal('MarkdownCell','base/js/textcell');
     jglobal('RawCell','base/js/textcell');
     jglobal('Cell','base/js/cell');
+
+    // notebook
     jglobal('OutputArea','notebook/js/outputarea');
     jglobal('KeyboardManager','notebook/js/keyboardmanager');
     jglobal('Completer','notebook/js/completer');
@@ -65,6 +67,9 @@ define(function(){
     jglobal('SaveWidget','notebook/js/savewidget');
     jglobal('Pager','notebook/js/pager');
     jglobal('QuickHelp','notebook/js/quickhelp');
+
+    // tree
+    jglobal('SessionList','tree/js/sessionlist');
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -7,6 +7,7 @@ define(function(){
     Jupyter.security = require('base/js/security');
     Jupyter.keyboard = require('base/js/keyboard');
     Jupyter.dialog = require('base/js/dialog');
+    Jupyter.NotificationWidget = require('base/js/notificationwidget');
     Jupyter.utils = utils;
     Jupyter.load_extensions = utils.load_extensions;
 

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -57,6 +57,7 @@ define(function(){
     jglobal('RawCell','base/js/textcell');
     jglobal('Cell','base/js/cell');
     jglobal('OutputArea','notebook/js/outputarea');
+    jglobal('KeyboardManager','notebook/js/keyboardmanager');
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -58,6 +58,7 @@ define(function(){
     jglobal('Cell','base/js/cell');
     jglobal('OutputArea','notebook/js/outputarea');
     jglobal('KeyboardManager','notebook/js/keyboardmanager');
+    jglobal('Completer','notebook/js/completer');
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -21,6 +21,8 @@ define(function(){
 
     Jupyter.NotificationWidget = require('base/js/notificationwidget').NotificationWidget;
     Jupyter.Kernel = require('services/kernels/kernel').Kernel;
+    Jupyter.Session = require('services/kernels/session').Session;
+    Jupyter.LoginWidget = require('auth/js/loginwidget').LoginWidget
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -4,6 +4,7 @@
 var IPython = IPython || {};
 define(function(){
     var utils = require('base/js/utils');
+    IPython.security = require('base/js/security');
     IPython.utils = utils;
     IPython.load_extensions = utils.load_extensions;
 

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -5,17 +5,22 @@ var Jupyter = Jupyter || {};
 define(function(){
     "use strict";
 
+    // expose modules
     Jupyter.utils = require('base/js/utils');
+    Jupyter.load_extensions = Jupyter.utils.load_extensions;
+     
     Jupyter.security = require('base/js/security');
     Jupyter.keyboard = require('base/js/keyboard');
     Jupyter.dialog = require('base/js/dialog');
-    Jupyter.NotificationWidget = require('base/js/notificationwidget');
-    Jupyter.load_extensions = utils.load_extensions;
 
+
+    // exposed constructors
     var comm = require('services/kernels/comm');
+    Jupyter.CommManager = comm.CommManager;
+    Jupyter.Comm = comm.Comm;
 
-    Juppyter.CommManager = comm.CommManager;
-    Juppyter.Comm = comm.Comm;
+    Jupyter.NotificationWidget = require('base/js/notificationwidget').NotificationWidget;
+    Jupyter.Kernel = require('services/kernels/kernel').Kernel;
 
     Jupyter.version = "4.0.0.dev";
     Jupyter._target = '_blank';

--- a/notebook/static/base/js/notificationwidget.js
+++ b/notebook/static/base/js/notificationwidget.js
@@ -2,9 +2,8 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
-], function(IPython, $) {
+], function($) {
     "use strict";
 
     /**
@@ -166,9 +165,6 @@ define([
     NotificationWidget.prototype.get_message = function () {
         return this.inner.html();
     };
-
-    // For backwards compatibility.
-    IPython.NotificationWidget = NotificationWidget;
 
     return {'NotificationWidget': NotificationWidget};
 });

--- a/notebook/static/base/js/page.js
+++ b/notebook/static/base/js/page.js
@@ -2,10 +2,9 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/events',
-], function(IPython, $, events){
+], function($, events){
     "use strict";
 
     var Page = function () {
@@ -59,7 +58,5 @@ define([
         $('div#site').height($(window).height() - $('#header').height());
     };
 
-    // Register self in the global namespace for convenience.
-    IPython.Page = Page;
     return {'Page': Page};
 });

--- a/notebook/static/base/js/security.js
+++ b/notebook/static/base/js/security.js
@@ -2,10 +2,8 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
-    'jquery',
     'components/google-caja/html-css-sanitizer-minified',
-], function(IPython, $) {
+], function(sanitize) {
     "use strict";
     
     var noop = function (x) { return x; };
@@ -59,7 +57,7 @@ define([
          * sanitize just the css in style tags in a block of html
          * called by sanitize_html, if allow_css is true
          */
-        var h = $("<div/>").append(html);
+        var h = document.createElement('div').append(html);
         var style_tags = h.find("style");
         if (!style_tags.length) {
             // no style tags to sanitize
@@ -122,8 +120,6 @@ define([
         caja: caja,
         sanitize_html: sanitize_html
     };
-
-    IPython.security = security;
 
     return security;
 });

--- a/notebook/static/base/js/security.js
+++ b/notebook/static/base/js/security.js
@@ -2,8 +2,9 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
+    'jquery',
     'components/google-caja/html-css-sanitizer-minified',
-], function(sanitize) {
+], function($, sanitize) {
     "use strict";
     
     var noop = function (x) { return x; };
@@ -57,7 +58,7 @@ define([
          * sanitize just the css in style tags in a block of html
          * called by sanitize_html, if allow_css is true
          */
-        var h = document.createElement('div').append(html);
+        var h = $("<div/>").append(html);
         var style_tags = h.find("style");
         if (!style_tags.length) {
             // no style tags to sanitize

--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -2,17 +2,16 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
     'codemirror/lib/codemirror',
     'moment',
     // silently upgrades CodeMirror
     'codemirror/mode/meta',
-], function(IPython, $, CodeMirror, moment){
+], function($, CodeMirror, moment){
     "use strict";
     
     var load_extensions = function () {
-        // load one or more IPython notebook extensions with requirejs
+        // load one or more Jupyter notebook extensions with requirejs
         
         var extensions = [];
         var extension_names = arguments;
@@ -39,8 +38,6 @@ define([
         );
     };
     
-    IPython.load_extensions = load_extensions;
-
     /**
      * Wait for a config section to load, and then load the extensions specified
      * in a 'load_extensions' key inside it.
@@ -505,7 +502,7 @@ define([
     
     var from_absolute_cursor_pos = function (cm, cursor_pos) {
         /**
-         * turn absolute cursor postion into CodeMirror col, ch cursor
+         * turn absolute cursor position into CodeMirror col, ch cursor
          */
         var i, line, next_line;
         var offset = 0;
@@ -881,8 +878,5 @@ define([
         time: time,
     };
 
-    // Backwards compatability.
-    IPython.utils = utils;
-    
     return utils;
 }); 

--- a/notebook/static/edit/js/savewidget.js
+++ b/notebook/static/edit/js/savewidget.js
@@ -2,13 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/utils',
     'base/js/dialog',
     'base/js/keyboard',
     'moment',
-], function(IPython, $, utils, dialog, keyboard, moment) {
+], function($, utils, dialog, keyboard, moment) {
     "use strict";
 
     var SaveWidget = function (selector, options) {

--- a/notebook/static/notebook/js/about.js
+++ b/notebook/static/notebook/js/about.js
@@ -9,7 +9,7 @@ require([
     'use strict';
     $('#notebook_about').click(function () {
         // use underscore template to auto html escape
-        var text = 'You are using IPython notebook.<br/><br/>';
+        var text = 'You are using Jupyter notebook.<br/><br/>';
         text = text + 'The version of the notebook server is ';
         text = text + _.template('<b><%- version %></b>')({ version: sys_info.ipython_version });
         if (sys_info.commit_hash) {
@@ -23,7 +23,7 @@ require([
         body.append($('<h4/>').text('Current Kernel Information:'));
         body.append(kinfo);
         dialog.modal({
-            title: 'About IPython Notebook',
+            title: 'About Jupyter Notebook',
             body: body,
             buttons: { 'OK': {} }
         });

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -10,7 +10,7 @@ define(function(require){
     };
 
     /**
-     *  A bunch of predefined `Simple Actions` used by IPython.
+     *  A bunch of predefined `Simple Actions` used by Jupyter.
      *  `Simple Actions` have the following keys:
      *  help (optional): a short string the describe the action.
      *      will be used in various context, like as menu name, tool tips on buttons,
@@ -29,7 +29,7 @@ define(function(require){
      *  avoid conflict the prefix should be all lowercase and end with a dot `.`
      *  in the absence of a prefix the behavior of the action is undefined.
      *
-     *  All action provided by IPython are prefixed with `ipython.`.
+     *  All action provided by Jupyter are prefixed with `ipython.`.
      *
      *  One can register extra actions or replace an existing action with another one is possible
      *  but is considered undefined behavior.
@@ -298,7 +298,7 @@ define(function(require){
     };
 
     /**
-     * A bunch of `Advance actions` for IPython.
+     * A bunch of `Advance actions` for Jupyter.
      * Cf `Simple Action` plus the following properties.
      *
      * handler: first argument of the handler is the event that triggerd the action
@@ -412,7 +412,7 @@ define(function(require){
         return source[subkey].handler;
     };
 
-    // Will actually generate/register all the IPython actions
+    // Will actually generate/register all the Jupyter actions
     var fun = function(){
         var final_actions = {};
         var k;

--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -11,15 +11,13 @@
 
 
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/utils',
     'codemirror/lib/codemirror',
     'codemirror/addon/edit/matchbrackets',
     'codemirror/addon/edit/closebrackets',
     'codemirror/addon/comment/comment'
-], function(IPython, $, utils, CodeMirror, cm_match, cm_closeb, cm_comment) {
-    // TODO: remove IPython dependency here 
+], function($, utils, CodeMirror, cm_match, cm_closeb, cm_comment) {
     "use strict";
     
     var overlayHack = CodeMirror.scrollbarModel.native.prototype.overlayHack;
@@ -319,7 +317,7 @@ define([
     };
 
     /**
-     * Delegates keyboard shortcut handling to either IPython keyboard
+     * Delegates keyboard shortcut handling to either Jupyter keyboard
      * manager when in command mode, or CodeMirror when in edit mode
      *
      * @method handle_keyevent
@@ -590,7 +588,7 @@ define([
                 // On 3.0 and below, these things were regex.
                 // But now should be string for json-able config. 
                 // We should get rid of assuming they might be already 
-                // in a later version of IPython. 
+                // in a later version of Jupyter.
                 var re = regs[i];
                 if(typeof(re) === 'string'){
                     re = new RegExp(re) 
@@ -709,9 +707,6 @@ define([
             cell.events.trigger('unrecognized_cell.Cell', {cell: cell});
         });
     };
-
-    // Backwards compatibility.
-    IPython.Cell = Cell;
 
     return {
         Cell: Cell,

--- a/notebook/static/notebook/js/completer.js
+++ b/notebook/static/notebook/js/completer.js
@@ -2,13 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/utils',
     'base/js/keyboard',
     'notebook/js/contexthint',
     'codemirror/lib/codemirror',
-], function(IPython, $, utils, keyboard, CodeMirror) {
+], function($, utils, keyboard, CodeMirror) {
     "use strict";
 
     // easier key mapping
@@ -408,9 +407,6 @@ define([
             that.carry_on_completion();
         }, 50);
     };
-
-    // For backwards compatability.
-    IPython.Completer = Completer;
 
     return {'Completer': Completer};
 });

--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -9,11 +9,10 @@
  */
 
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/utils',
     'base/js/keyboard',
-], function(IPython, $, utils, keyboard) {
+], function($, utils, keyboard) {
     "use strict";
     
     // Main keyboard manager for the notebook
@@ -222,10 +221,6 @@ define([
             }
         });
     };
-
-
-    // For backwards compatibility.
-    IPython.KeyboardManager = KeyboardManager;
 
     return {'KeyboardManager': KeyboardManager};
 });

--- a/notebook/static/notebook/js/maintoolbar.js
+++ b/notebook/static/notebook/js/maintoolbar.js
@@ -3,11 +3,10 @@
 
 define([
     'require',
-    'base/js/namespace',
     'jquery',
     './toolbar',
     './celltoolbar'
-], function(require, IPython, $, toolbar, celltoolbar) {
+], function(require, $, toolbar, celltoolbar) {
     "use strict";
 
     var MainToolBar = function (selector, options) {
@@ -157,9 +156,6 @@ define([
         wrapper.append(label).append(select);
         return wrapper;
     };
-
-    // Backwards compatibility.
-    IPython.MainToolBar = MainToolBar;
 
     return {'MainToolBar': MainToolBar};
 });

--- a/notebook/static/notebook/js/mathjaxutils.js
+++ b/notebook/static/notebook/js/mathjaxutils.js
@@ -2,11 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/utils',
     'base/js/dialog',
-], function(IPython, $, utils, dialog) {
+], function($, utils, dialog) {
     "use strict";
 
     var init = function () {
@@ -44,19 +43,19 @@ define([
                         "If you have administrative access to the notebook server and" +
                         " a working internet connection, you can install a local copy" +
                         " of MathJax for offline use with the following command on the server" +
-                        " at a Python or IPython prompt:"
+                        " at a Python or Jupyter prompt:"
                     )
                 ).append(
                     $("<pre></pre>").addClass('dialog').text(
-                        ">>> from IPython.external import mathjax; mathjax.install_mathjax()"
+                        ">>> from Jupyter.external import mathjax; mathjax.install_mathjax()"
                     )
                 ).append(
                     $("<p></p>").addClass('dialog').text(
-                        "This will try to install MathJax into the IPython source directory."
+                        "This will try to install MathJax into the Jupyter source directory."
                     )
                 ).append(
                     $("<p></p>").addClass('dialog').text(
-                        "If IPython is installed to a location that requires" +
+                        "If Jupyter is installed to a location that requires" +
                         " administrative privileges to write, you will need to make this call as" +
                         " an administrator, via 'sudo'."
                     )
@@ -245,8 +244,6 @@ define([
         remove_math : remove_math,
         replace_math : replace_math
     };
-
-    IPython.mathjaxutils = mathjaxutils;
 
     return mathjaxutils;
 });

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -16,7 +16,7 @@ define([
         /**
          * Constructor
          *
-         * A MenuBar Class to generate the menubar of IPython notebook
+         * A MenuBar Class to generate the menubar of Jupyter notebook
          *
          * Parameters:
          *  selector: string
@@ -413,9 +413,6 @@ define([
         });
         
     };
-
-    // Backwards compatability.
-    IPython.MenuBar = MenuBar;
 
     return {'MenuBar': MenuBar};
 });

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1140,7 +1140,7 @@ define(function (require) {
             keyboard_manager: this.keyboard_manager,
             title : "Use markdown headings",
             body : $("<p/>").text(
-                'IPython no longer uses special heading cells. ' + 
+                'Jupyter no longer uses special heading cells. ' + 
                 'Instead, write your headings in Markdown cells using # characters:'
             ).append($('<pre/>').text(
                 '## This is a level 2 heading'
@@ -1618,7 +1618,7 @@ define(function (require) {
     };
     
     /**
-     * Prompt the user to restart the IPython kernel.
+     * Prompt the user to restart the Jupyter kernel.
      */
     Notebook.prototype.restart_kernel = function () {
         var that = this;
@@ -2032,7 +2032,7 @@ define(function (require) {
      */
     Notebook.prototype.trust_notebook = function () {
         var body = $("<div>").append($("<p>")
-            .text("A trusted IPython notebook may execute hidden malicious code ")
+            .text("A trusted Jupyter notebook may execute hidden malicious code ")
             .append($("<strong>")
                 .append(
                     $("<em>").text("when you open it")
@@ -2042,7 +2042,7 @@ define(function (require) {
             ).append(
                 " For more information, see the "
             ).append($("<a>").attr("href", "http://ipython.org/ipython-doc/2/notebook/security.html")
-                .text("IPython security documentation")
+                .text("Jupyter security documentation")
             ).append(".")
         );
 
@@ -2508,10 +2508,6 @@ define(function (require) {
         this.events.trigger('checkpoint_deleted.Notebook');
         this.load_notebook(this.notebook_path);
     };
-
-
-    // For backwards compatability.
-    IPython.Notebook = Notebook;
 
     return {'Notebook': Notebook};
 });

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -179,7 +179,7 @@ define(function (require) {
     };
 
     /**
-     * Bind JavaScript events: key presses and custom IPython events.
+     * Bind JavaScript events: key presses and custom Jupyter events.
      */
     Notebook.prototype.bind_events = function () {
         var that = this;
@@ -2237,7 +2237,7 @@ define(function (require) {
             "current notebook format will be used.";
             
             if (nbmodel.nbformat > orig_nbformat) {
-                msg += " Older versions of IPython may not be able to read the new format.";
+                msg += " Older versions of Jupyter may not be able to read the new format.";
             } else {
                 msg += " Some features of the original notebook may not be available.";
             }

--- a/notebook/static/notebook/js/notificationarea.js
+++ b/notebook/static/notebook/js/notificationarea.js
@@ -1,11 +1,10 @@
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/utils',
     'base/js/dialog',
     'base/js/notificationarea',
     'moment'
-], function(IPython, $, utils, dialog, notificationarea, moment) {
+], function($, utils, dialog, notificationarea, moment) {
     "use strict";
     var NotificationArea = notificationarea.NotificationArea;
     
@@ -340,8 +339,5 @@ define([
         });
     };
 
-    // Backwards compatibility.
-    IPython.NotificationArea = NotebookNotificationArea;
-    
     return {'NotebookNotificationArea': NotebookNotificationArea};
 });

--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -2,14 +2,13 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jqueryui',
     'base/js/utils',
     'base/js/security',
     'base/js/keyboard',
     'notebook/js/mathjaxutils',
     'components/marked/lib/marked',
-], function(IPython, $, utils, security, keyboard, mathjaxutils, marked) {
+], function($, utils, security, keyboard, mathjaxutils, marked) {
     "use strict";
 
     /**
@@ -961,9 +960,6 @@ define([
         "application/javascript" : append_javascript,
         "application/pdf" : append_pdf
     };
-
-    // For backwards compatability.
-    IPython.OutputArea = OutputArea;
 
     return {'OutputArea': OutputArea};
 });

--- a/notebook/static/notebook/js/pager.js
+++ b/notebook/static/notebook/js/pager.js
@@ -2,10 +2,9 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jqueryui',
     'base/js/utils',
-], function(IPython, $, utils) {
+], function($, utils) {
     "use strict";
 
     var Pager = function (pager_selector, options) {
@@ -132,7 +131,7 @@ define([
                 .attr('type',"text/css")
         )
         .append(
-                $('<title>').text("IPython Pager")
+                $('<title>').text("Jupyter Pager")
         );
         var pager_body = $(w.document.body);
         pager_body.css('overflow','scroll');
@@ -161,9 +160,6 @@ define([
         // notebook.
         $('.end_space').css('height', Math.max(this.pager_element.height(), this._default_end_space));
     };
-
-    // Backwards compatability.
-    IPython.Pager = Pager;
 
     return {'Pager': Pager};
 });

--- a/notebook/static/notebook/js/quickhelp.js
+++ b/notebook/static/notebook/js/quickhelp.js
@@ -2,11 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/utils',
     'base/js/dialog',
-], function(IPython, $, utils, dialog) {
+], function($, utils, dialog) {
     "use strict";
     var platform = utils.platform;
 
@@ -173,7 +172,7 @@ define([
         doc.append(
             $('<button/>').addClass('close').attr('data-dismiss','alert').html('&times;')
         ).append(
-            'The IPython Notebook has two different keyboard input modes. <b>Edit mode</b> '+
+            'The Jupyter Notebook has two different keyboard input modes. <b>Edit mode</b> '+
             'allows you to type code/text into a cell and is indicated by a green cell '+
             'border. <b>Command mode</b> binds the keyboard to notebook level actions '+
             'and is indicated by a grey cell border.'
@@ -292,9 +291,6 @@ define([
         div.append(sub_div);
         return div;
     };
-
-    // Backwards compatability.
-    IPython.QuickHelp = QuickHelp;
 
     return {'QuickHelp': QuickHelp};
 });

--- a/notebook/static/notebook/js/savewidget.js
+++ b/notebook/static/notebook/js/savewidget.js
@@ -2,13 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/utils',
     'base/js/dialog',
     'base/js/keyboard',
     'moment',
-], function(IPython, $, utils, dialog, keyboard, moment) {
+], function($, utils, dialog, keyboard, moment) {
     "use strict";
 
     var SaveWidget = function (selector, options) {
@@ -216,9 +215,6 @@ define([
             this.set_save_status("(autosaved)");
         }
     };
-
-    // Backwards compatibility.
-    IPython.SaveWidget = SaveWidget;
 
     return {'SaveWidget': SaveWidget};
 

--- a/notebook/static/notebook/js/textcell.js
+++ b/notebook/static/notebook/js/textcell.js
@@ -2,7 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'base/js/utils',
     'jquery',
     'notebook/js/cell',
@@ -14,7 +13,7 @@ define([
     'codemirror/lib/codemirror',
     'codemirror/mode/gfm/gfm',
     'notebook/js/codemirror-ipythongfm'
-], function(IPython,
+], function(
     utils,
     $,
     cell,
@@ -359,11 +358,6 @@ define([
         }
         return cont;
     };
-
-    // Backwards compatability.
-    IPython.TextCell = TextCell;
-    IPython.MarkdownCell = MarkdownCell;
-    IPython.RawCell = RawCell;
 
     var textcell = {
         TextCell: TextCell,

--- a/notebook/static/notebook/js/toolbar.js
+++ b/notebook/static/notebook/js/toolbar.js
@@ -2,9 +2,8 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery'
-], function(IPython, $) {
+], function($) {
     "use strict";
 
     /**
@@ -53,27 +52,6 @@ define([
      *          ...
      *      ]
      *
-     *  For backward compatibility this also support the
-     *  old methods of adding a button directly bound to callbacks:
-     *  @example
-     *      # deprecate, do not use
-     *      IPython.toolbar.add_buttons_group([
-     *          {
-     *            label:'my button',
-     *            icon:'icon-hdd',
-     *            callback:function(){alert('hoho')},
-     *            id : 'my_button_id',    // this is optional
-     *          },
-     *          {
-     *            label:'my second button',
-     *            icon:'icon-play',
-     *            callback:function(){alert('be carefull I cut')}
-     *          }
-     *        ],
-     *        "my_button_group_id"
-     *      )
-     *
-     *  @method add_buttons_group
      *  @param list {List}
      *      List of button of the group, with the following paramter for each :
      *      @param list.label {string} text to show on button hover
@@ -153,9 +131,6 @@ define([
     ToolBar.prototype.toggle = function () {
         this.element.toggle();
     };
-
-    // Backwards compatibility.
-    IPython.ToolBar = ToolBar;
 
     return {'ToolBar': ToolBar};
 });

--- a/notebook/static/notebook/js/tooltip.js
+++ b/notebook/static/notebook/js/tooltip.js
@@ -2,10 +2,9 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/utils',
-], function(IPython, $, utils) {
+], function($, utils) {
     "use strict";
 
     // tooltip constructor
@@ -318,9 +317,6 @@ define([
         // keep scroll top to be sure to always see the first line
         this.text.scrollTop(0);
     };
-
-    // Backwards compatibility.
-    IPython.Tooltip = Tooltip;
 
     return {'Tooltip': Tooltip};
 });

--- a/notebook/static/notebook/js/tour.js
+++ b/notebook/static/notebook/js/tour.js
@@ -2,10 +2,9 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
     'bootstraptour',
-], function(IPython, $, Tour) {
+], function($, Tour) {
     "use strict";
 
     var tour_style = "<div class='popover tour'>\n" +
@@ -113,7 +112,7 @@ define([
                 title: "Fin.",
                 placement: 'bottom',
                 orphan: true,
-                content: "This concludes the IPython Notebook User Interface Tour. Happy hacking!"
+                content: "This concludes the Jupyter Notebook User Interface Tour. Happy hacking!"
             }
         ];
 
@@ -158,9 +157,6 @@ define([
         this.notebook.focus_cell(); 
         this.notebook.edit_mode();
     };
-
-    // For backwards compatability.
-    IPython.NotebookTour = NotebookTour;
 
     return {'Tour': NotebookTour};
 

--- a/notebook/static/services/kernels/comm.js
+++ b/notebook/static/services/kernels/comm.js
@@ -2,10 +2,9 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/utils',
-], function(IPython, $, utils) {
+], function($, utils) {
     "use strict";
 
     //-----------------------------------------------------------------------
@@ -208,10 +207,6 @@ define([
         this._callback('close', msg);
     };
     
-    // For backwards compatability.
-    IPython.CommManager = CommManager;
-    IPython.Comm = Comm;
-
     return {
         'CommManager': CommManager,
         'Comm': Comm

--- a/notebook/static/services/kernels/comm.js
+++ b/notebook/static/services/kernels/comm.js
@@ -34,7 +34,7 @@ define([
     CommManager.prototype.new_comm = function (target_name, data, callbacks, metadata) {
         /**
          * Create a new Comm, register it, and open its Kernel-side counterpart
-         * Mimics the auto-registration in `Comm.__init__` in the IPython Comm
+         * Mimics the auto-registration in `Comm.__init__` in the Jupyter Comm
          */
         var comm = new Comm(target_name);
         this.register_comm(comm);

--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -30,7 +30,7 @@ define([
 
         this.kernel_service_url = kernel_service_url;
         this.kernel_url = null;
-        this.ws_url = ws_url || IPython.utils.get_body_data("wsUrl");
+        this.ws_url = ws_url || utils.get_body_data("wsUrl");
         if (!this.ws_url) {
             // trailing 's' in https will become wss for secure web sockets
             this.ws_url = location.protocol.replace('http', 'ws') + "//" + location.host;

--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -2,13 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/utils',
     './comm',
     './serialize',
     'base/js/events'
-], function(IPython, $, utils, comm, serialize, events) {
+], function($, utils, comm, serialize, events) {
     "use strict";
 
     /**
@@ -1057,9 +1056,6 @@ define([
             }
         }
     };
-
-    // Backwards compatability.
-    IPython.Kernel = Kernel;
 
     return {'Kernel': Kernel};
 });

--- a/notebook/static/services/sessions/session.js
+++ b/notebook/static/services/sessions/session.js
@@ -2,11 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/utils',
     'services/kernels/kernel',
-], function(IPython, $, utils, kernel) {
+], function($, utils, kernel) {
     "use strict";
 
     /**
@@ -309,11 +308,9 @@ define([
         this.name = "SessionAlreadyStarting";
         this.message = (message || "");
     };
+    
     SessionAlreadyStarting.prototype = Error.prototype;
     
-    // For backwards compatability.
-    IPython.Session = Session;
-
     return {
         Session: Session,
         SessionAlreadyStarting: SessionAlreadyStarting

--- a/notebook/static/tree/js/clusterlist.js
+++ b/notebook/static/tree/js/clusterlist.js
@@ -2,10 +2,9 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/utils',
-], function(IPython, $, utils) {
+], function($, utils) {
     "use strict";
 
     var ClusterList = function (selector, options) {
@@ -181,10 +180,6 @@ define([
             $.ajax(url, settings);
         });
     };
-
-    // For backwards compatability.
-    IPython.ClusterList = ClusterList;
-    IPython.ClusterItem = ClusterItem;
 
     return {
         'ClusterList': ClusterList,

--- a/notebook/static/tree/js/main.js
+++ b/notebook/static/tree/js/main.js
@@ -39,6 +39,8 @@ require([
     loginwidget){
     "use strict";
 
+    IPython.NotebookList = notebooklist.NotebookList;
+
     page = new page.Page();
     
     var common_options = {

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -874,9 +874,5 @@ define([
             .append(cancel_button);
     };
 
-
-    // Backwards compatability.
-    IPython.NotebookList = NotebookList;
-
     return {'NotebookList': NotebookList};
 });

--- a/notebook/static/tree/js/sessionlist.js
+++ b/notebook/static/tree/js/sessionlist.js
@@ -2,10 +2,9 @@
 // Distributed under the terms of the Modified BSD License.
 
 define([
-    'base/js/namespace',
     'jquery',
     'base/js/utils',
-], function(IPython, $, utils) {
+], function($, utils) {
     "use strict";
 
     var SesssionList = function (options) {
@@ -77,9 +76,6 @@ define([
         }
         this.events.trigger('sessions_loaded.Dashboard', this.sessions);
     };
-
-    // Backwards compatability.
-    IPython.SesssionList = SesssionList;
 
     return {'SesssionList': SesssionList};
 });

--- a/setupbase.py
+++ b/setupbase.py
@@ -17,12 +17,10 @@ import os
 import sys
 
 from distutils import log
-from distutils.command.build_py import build_py
 from distutils.cmd import Command
-from distutils.errors import DistutilsExecError
 from fnmatch import fnmatch
 from glob import glob
-from subprocess import Popen, PIPE, check_call
+from subprocess import check_call
 
 #-------------------------------------------------------------------------------
 # Useful globals and utility functions
@@ -377,7 +375,7 @@ class CompileCSS(Command):
 
 class JavascriptVersion(Command):
     """write the javascript version to notebook javascript"""
-    description = "Write IPython version to javascript"
+    description = "Write Jupyter version to javascript"
     user_options = []
     
     def initialize_options(self):
@@ -393,12 +391,12 @@ class JavascriptVersion(Command):
         with open(nsfile, 'w') as f:
             found = False
             for line in lines:
-                if line.strip().startswith("IPython.version"):
-                    line = '    IPython.version = "{0}";\n'.format(version)
+                if line.strip().startswith("Jupyter.version"):
+                    line = '    Jupyter.version = "{0}";\n'.format(version)
                     found = True
                 f.write(line)
             if not found:
-                raise RuntimeError("Didn't find IPython.version line in %s" % nsfile)
+                raise RuntimeError("Didn't find Jupyter.version line in %s" % nsfile)
 
 
 def css_js_prerelease(command):


### PR DESCRIPTION
1) rename to jupyter.
2) Start removing this weird "we require the global namespace to add ourself to it"

Note that 2 is all or nothing, or requireJS complain that `module Xyz has not yet be loaded in current contex`.

So if we agreed to trop the IPython/Jupyter global (at least to store module) for 4.0 that would be great and simplify things a lot.

