### PR TITLE
use `super` in NotebookApp.start

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1065,8 +1065,7 @@ class NotebookApp(JupyterApp):
         
         This method takes no arguments so all configuration and initialization
         must be done prior to calling this method."""
-        if self.subapp is not None:
-            return self.subapp.start()
+        super(NotebookApp, self).start()
 
         info = self.log.info
         for line in self.notebook_info().split("\n"):

--- a/notebook/tests/test_notebookapp.py
+++ b/notebook/tests/test_notebookapp.py
@@ -9,6 +9,7 @@ import nose.tools as nt
 
 from traitlets.tests.utils import check_help_all_output
 
+from jupyter_core.application import NoStart
 from ipython_genutils.tempdir import TemporaryDirectory
 from traitlets import TraitError
 from notebook import notebookapp
@@ -61,3 +62,11 @@ def test_invalid_nb_dir():
         with nt.assert_raises(TraitError):
             app.notebook_dir = tf
 
+def test_generate_config():
+    with TemporaryDirectory() as td:
+        app = NotebookApp(config_dir=td)
+        app.initialize(['--generate-config'])
+        with nt.assert_raises(NoStart):
+            app.start()
+        assert os.path.exists(os.path.join(td, 'jupyter_notebook_config.py'))
+    


### PR DESCRIPTION
restores the ability to generate jupyter_notebook_config.py

requires jupyter/jupyter_core#13

closes #115