### PR TITLE
 tree rename dialog - focus filename without extension

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -663,7 +663,12 @@ define([
                         return false;
                     }
                 });
-                input.focus().select();
+                input.focus();
+                if (input.val().indexOf(".") > 0) {
+                    input[0].setSelectionRange(0,input.val().indexOf("."));
+                } else {
+                    input.select();
+                }
             }
         });
     };


### PR DESCRIPTION
focus only the relevant part of the filename on rename dialog
this selects all prior to the first dot in the filename

(i accidently saved some files without extension, which led me to create this pr..)