### PR TITLE
shortcut: explicit exception message

### DIFF
--- a/notebook/static/base/js/keyboard.js
+++ b/notebook/static/base/js/keyboard.js
@@ -385,10 +385,19 @@ define([
         if( typeof(shortcut) === 'string'){
             shortcut = shortcut.split(',');
         }
-        this._remove_leaf(shortcut, this._shortcuts);
-        if (!suppress_help_update) {
+        /*
+         *  The shortcut error should be explicit here, because it will be
+         *  seen by users.
+         */
+        try
+        {
+          this._remove_leaf(shortcut, this._shortcuts);
+          if (!suppress_help_update) {
             // update the keyboard shortcuts notebook help
             this.events.trigger('rebuild.QuickHelp');
+          }
+        } catch (ex) {
+          throw ('try to remove non-existing shortcut');
         }
     };
 


### PR DESCRIPTION
Hi !
Let me introducte myself. My name is Nicolas and I am a member student at
the Developpement and Research Laboratory of EPITA in Paris. For my work I
have to create custom widgets with Jupyter for the Vcsn platform.

While messing with the shortcut manager I stumbled upon a weird exception
message saying that I cannot remove a non-leaf shortcut... After a long time
(an hour or two) I finally understood that this message what actually saying
'You cannot remove a shortcut that does not exists'.

I wanted to post this patch s.t. no one has to lost time in understanding that.
Here is the commit message:

In the function remove_shortcut, if the action failed, it used to
throw an 'implementation oriented' exception message:
> throws('try to delete non-leaf')
This is not a good message for the user who wants to mess with the
shortcuts.

The solution is to leave this 'implementation oriented' exception message
and add a try-catch bloc above that catches this message and throws
a new, frendliest, exception message.
I came up with this:
> throws('try to remove non-existing shortcut')

* notebook/static/base/js/keyboard.js: (remove_shortcut) add try-catch.

Signed-off-by: Nicolas Barray <nbarray@gmail.com>