### PR TITLE
Fix the "original notebook" links in the docs

### DIFF
--- a/docs/source/examples/Notebook/Configuring the Notebook and Server.rst
+++ b/docs/source/examples/Notebook/Configuring the Notebook and Server.rst
@@ -1,5 +1,5 @@
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Configuring%20the%20Notebook%20and%20Server.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Configuring%20the%20Notebook%20and%20Server.ipynb>`__
 
 Configuring the Notebook and Server
 ===================================
@@ -185,4 +185,4 @@ For example, in Firefox, go to the Preferences panel, Advanced section,
 Network tab, click 'Settings...', and add the address of the notebook
 server to the 'No proxy for' field.
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Configuring%20the%20Notebook%20and%20Server.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Configuring%20the%20Notebook%20and%20Server.ipynb>`__

--- a/docs/source/examples/Notebook/Connecting with the Qt Console.rst
+++ b/docs/source/examples/Notebook/Connecting with the Qt Console.rst
@@ -1,5 +1,5 @@
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Connecting%20with%20the%20Qt%20Console.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Connecting%20with%20the%20Qt%20Console.ipynb>`__
 
 Connecting to an existing IPython kernel using the Qt Console
 =============================================================
@@ -64,4 +64,4 @@ connection information and start the Qt Console for you automatically.
 
     %qtconsole
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Connecting%20with%20the%20Qt%20Console.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Connecting%20with%20the%20Qt%20Console.ipynb>`__

--- a/docs/source/examples/Notebook/Custom Keyboard Shortcuts.rst
+++ b/docs/source/examples/Notebook/Custom Keyboard Shortcuts.rst
@@ -1,5 +1,5 @@
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Custom%20Keyboard%20Shortcuts.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Custom%20Keyboard%20Shortcuts.ipynb>`__
 
 Keyboard Shortcut Customization
 ===============================
@@ -68,4 +68,4 @@ back to it's initial behavior:
     
     Jupyter.keyboard_manager.command_shortcuts.add_shortcut('r', 'ipython.change-selected-cell-to-raw-cell');
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Custom%20Keyboard%20Shortcuts.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Custom%20Keyboard%20Shortcuts.ipynb>`__

--- a/docs/source/examples/Notebook/Examples and Tutorials Index.rst
+++ b/docs/source/examples/Notebook/Examples and Tutorials Index.rst
@@ -1,5 +1,5 @@
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Examples%20and%20Tutorials%20Index.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Examples%20and%20Tutorials%20Index.ipynb>`__
 
 
 
@@ -33,4 +33,4 @@ Examples
    Console <Connecting%20with%20the%20Qt%20Console.html>`__
 -  `Typesetting Equations <Typesetting%20Equations.html>`__
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Examples%20and%20Tutorials%20Index.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Examples%20and%20Tutorials%20Index.ipynb>`__

--- a/docs/source/examples/Notebook/Importing Notebooks.rst
+++ b/docs/source/examples/Notebook/Importing Notebooks.rst
@@ -1,5 +1,5 @@
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Importing%20Notebooks.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Importing%20Notebooks.ipynb>`__
 
 Importing Jupyter Notebooks as Modules
 ======================================
@@ -283,4 +283,4 @@ and import the notebook from ``IPython.utils``
 This approach can even import functions and classes that are defined in
 a notebook using the ``%%cython`` magic.
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Importing%20Notebooks.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Importing%20Notebooks.ipynb>`__

--- a/docs/source/examples/Notebook/JavaScript Notebook Extensions.rst
+++ b/docs/source/examples/Notebook/JavaScript Notebook Extensions.rst
@@ -1,5 +1,5 @@
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/JavaScript%20Notebook%20Extensions.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/JavaScript%20Notebook%20Extensions.ipynb>`__
 
 Embrasing web standards
 =======================
@@ -386,4 +386,4 @@ depending of the tag on each cell
 
     %load soln/celldiff.js
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/JavaScript%20Notebook%20Extensions.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/JavaScript%20Notebook%20Extensions.ipynb>`__

--- a/docs/source/examples/Notebook/Notebook Basics.rst
+++ b/docs/source/examples/Notebook/Notebook Basics.rst
@@ -1,5 +1,5 @@
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Notebook%20Basics.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Notebook%20Basics.ipynb>`__
 
 Notebook Basics
 ===============
@@ -263,4 +263,4 @@ order:
 5. Cell editing: ``x``, ``c``, ``v``, ``d``, ``z``, ``shift+=``
 6. Kernel operations: ``i``, ``.``
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Notebook%20Basics.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Notebook%20Basics.ipynb>`__

--- a/docs/source/examples/Notebook/Running Code.rst
+++ b/docs/source/examples/Notebook/Running Code.rst
@@ -1,5 +1,5 @@
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Running%20Code.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Running%20Code.ipynb>`__
 
 Running Code
 ============
@@ -151,4 +151,4 @@ Beyond a certain point, output will scroll automatically:
         print(2**i - 1)
 
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Running%20Code.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Running%20Code.ipynb>`__

--- a/docs/source/examples/Notebook/Typesetting Equations.rst
+++ b/docs/source/examples/Notebook/Typesetting Equations.rst
@@ -1,5 +1,5 @@
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Typesetting%20Equations.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Typesetting%20Equations.ipynb>`__
 
 The Markdown parser included in the Jupyter Notebook is MathJax-aware.
 This means that you can freely mix in mathematical expressions using the
@@ -235,4 +235,4 @@ Display
 
    x=4
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Typesetting%20Equations.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Typesetting%20Equations.ipynb>`__

--- a/docs/source/examples/Notebook/What is the Jupyter Notebook.rst
+++ b/docs/source/examples/Notebook/What is the Jupyter Notebook.rst
@@ -1,5 +1,5 @@
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/What%20is%20the%20Jupyter%20Notebook.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/What%20is%20the%20Jupyter%20Notebook.ipynb>`__
 
 What is the Jupyter Notebook?
 =============================
@@ -133,4 +133,4 @@ This service loads the notebook document from the URL and renders it as
 a static web page. The resulting web page may thus be shared with others
 **without their needing to install the Jupyter Notebook**.
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/What%20is%20the%20Jupyter%20Notebook.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/What%20is%20the%20Jupyter%20Notebook.ipynb>`__

--- a/docs/source/examples/Notebook/Working With Markdown Cells.rst
+++ b/docs/source/examples/Notebook/Working With Markdown Cells.rst
@@ -1,5 +1,5 @@
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Working%20With%20Markdown%20Cells.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Working%20With%20Markdown%20Cells.ipynb>`__
 
 Markdown Cells
 ==============
@@ -261,4 +261,4 @@ When you run the notebook in a password-protected manner, local file
 access is restricted to authenticated users unless read-only views are
 active.
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/source/examples/Notebook/Working%20With%20Markdown%20Cells.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Working%20With%20Markdown%20Cells.ipynb>`__

--- a/docs/source/template.tpl
+++ b/docs/source/template.tpl
@@ -2,7 +2,7 @@
 
 {% macro notebooklink() -%}
 
-`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/ipython/ipython/blob/master/docs/{{ resources['metadata']['path'] }}/{{ resources['metadata']['name'] | replace(' ', '%20') }}.ipynb>`__
+`View the original notebook on nbviewer <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/{{ resources['metadata']['path'] }}/{{ resources['metadata']['name'] | replace(' ', '%20') }}.ipynb>`__
 
 
 {%- endmacro %}


### PR DESCRIPTION
Accidentally was pointing to ipython/ipython, doh!