### PR TITLE
Add links to the REST API documentation (what there is on the wiki)

### DIFF
--- a/notebook/services/contents/handlers.py
+++ b/notebook/services/contents/handlers.py
@@ -1,4 +1,7 @@
-"""Tornado handlers for the contents web service."""
+"""Tornado handlers for the contents web service.
+
+Preliminary documentation at https://github.com/ipython/ipython/wiki/IPEP-27%3A-Contents-Service
+"""
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.

--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -1,4 +1,7 @@
-"""Tornado handlers for kernels."""
+"""Tornado handlers for kernels.
+
+Preliminary documentation at https://github.com/ipython/ipython/wiki/IPEP-16%3A-Notebook-multi-directory-dashboard-and-URL-mapping#kernels-api
+"""
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.

--- a/notebook/services/kernelspecs/handlers.py
+++ b/notebook/services/kernelspecs/handlers.py
@@ -1,4 +1,7 @@
-"""Tornado handlers for kernel specifications."""
+"""Tornado handlers for kernel specifications.
+
+Preliminary documentation at https://github.com/ipython/ipython/wiki/IPEP-25%3A-Registry-of-installed-kernels#rest-api
+"""
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.

--- a/notebook/services/sessions/handlers.py
+++ b/notebook/services/sessions/handlers.py
@@ -1,4 +1,7 @@
-"""Tornado handlers for the sessions web service."""
+"""Tornado handlers for the sessions web service.
+
+Preliminary documentation at https://github.com/ipython/ipython/wiki/IPEP-16%3A-Notebook-multi-directory-dashboard-and-URL-mapping#sessions-api
+"""
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.

--- a/notebook/static/notebook/js/kernelselector.js
+++ b/notebook/static/notebook/js/kernelselector.js
@@ -34,6 +34,8 @@ define([
     };
     
     KernelSelector.prototype.request_kernelspecs = function() {
+        // Preliminary documentation for kernelspecs api is at 
+        // https://github.com/ipython/ipython/wiki/IPEP-25%3A-Registry-of-installed-kernels#rest-api
         var url = utils.url_join_encode(this.notebook.base_url, 'api/kernelspecs');
         utils.promising_ajax(url).then($.proxy(this._got_kernelspecs, this));
     };

--- a/notebook/static/services/contents.js
+++ b/notebook/static/services/contents.js
@@ -11,6 +11,9 @@ define(function(require) {
         /**
          * Constructor
          *
+         * Preliminary documentation for the REST API is at 
+         * https://github.com/ipython/ipython/wiki/IPEP-27%3A-Contents-Service
+         *
          * A contents handles passing file operations
          * to the back-end.  This includes checkpointing
          * with the normal file operations.

--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -16,6 +16,9 @@ define([
      * by.  the `Session` object. Once created, this object should be
      * used to communicate with the kernel.
      * 
+     * Preliminary documentation for the REST API is at
+     * https://github.com/ipython/ipython/wiki/IPEP-16%3A-Notebook-multi-directory-dashboard-and-URL-mapping#kernels-api
+     * 
      * @class Kernel
      * @param {string} kernel_service_url - the URL to access the kernel REST api
      * @param {string} ws_url - the websockets URL

--- a/notebook/static/services/sessions/session.js
+++ b/notebook/static/services/sessions/session.js
@@ -13,6 +13,9 @@ define([
      * should be used to start kernels and then shut them down -- for
      * all other operations, the kernel object should be used.
      *
+     * Preliminary documentation for the REST API is at 
+     * https://github.com/ipython/ipython/wiki/IPEP-16%3A-Notebook-multi-directory-dashboard-and-URL-mapping#sessions-api
+     *
      * Options should include:
      *  - notebook_path: the path (not including name) to the notebook
      *  - kernel_name: the type of kernel (e.g. python3)


### PR DESCRIPTION
I can never seem to find the docs for the REST API.  This adds links to the most likely places to look in the code to find these docs.