### PR TITLE
Write notebooks with Unix newlines on Windows

### DIFF
--- a/notebook/services/contents/fileio.py
+++ b/notebook/services/contents/fileio.py
@@ -71,7 +71,7 @@ def atomic_writing(path, text=True, encoding='utf-8', **kwargs):
         shutil.copy2(path, tmp_path)
 
     if text:
-        fileobj = io.open(path, 'w', encoding=encoding, **kwargs)
+        fileobj = io.open(path, 'w', encoding=encoding, newline='\n', **kwargs)
     else:
         fileobj = io.open(path, 'wb', **kwargs)
 

--- a/notebook/services/contents/fileio.py
+++ b/notebook/services/contents/fileio.py
@@ -71,7 +71,9 @@ def atomic_writing(path, text=True, encoding='utf-8', **kwargs):
         shutil.copy2(path, tmp_path)
 
     if text:
-        fileobj = io.open(path, 'w', encoding=encoding, newline='\n', **kwargs)
+        # Make sure that text files have Unix linefeeds by default
+        kwargs.setdefault('newline', '\n')
+        fileobj = io.open(path, 'w', encoding=encoding, **kwargs)
     else:
         fileobj = io.open(path, 'wb', **kwargs)
 


### PR DESCRIPTION
This avoids unnecessary notebook linefeed conversions
when working with version control from different systems.