### PR TITLE
Add less config for themes and apply throughout

### DIFF
--- a/notebook/static/base/less/page.less
+++ b/notebook/static/base/less/page.less
@@ -47,7 +47,7 @@ body {
 #header-spacer {
     width: 100%;
     visibility: hidden;
-    
+
     @media print {
         display: none;
     }

--- a/notebook/static/notebook/less/ansicolors.less
+++ b/notebook/static/notebook/less/ansicolors.less
@@ -4,20 +4,20 @@
 
 /* use dark versions for foreground, to improve visibility */
 .ansiblack {color: black;}
-.ansired {color: darkred;}
-.ansigreen {color: darkgreen;}
+.ansired {color: @ansired;}
+.ansigreen {color: @ansigreen;}
 .ansiyellow {color: #c4a000;}
-.ansiblue {color: darkblue;}
+.ansiblue {color: @ansiblue;}
 .ansipurple {color: darkviolet;}
-.ansicyan {color: steelblue;}
+.ansicyan {color: @ansicyan;}
 .ansigray {color: gray;}
 
 /* and light for background, for the same reason */
 .ansibgblack {background-color: black;}
-.ansibgred {background-color: red;}
-.ansibggreen {background-color: green;}
+.ansibgred {background-color: darken(@ansired, 20%);}
+.ansibggreen {background-color: darken(@ansigreen, 20%);}
 .ansibgyellow {background-color: yellow;}
-.ansibgblue {background-color: blue;}
+.ansibgblue {background-color: darken(@ansiblue, 20%);}
 .ansibgpurple {background-color: magenta;}
-.ansibgcyan {background-color: cyan;}
+.ansibgcyan {background-color: darken(@ansicyan, 20%);;}
 .ansibggray {background-color: gray;}

--- a/notebook/static/notebook/less/cell.less
+++ b/notebook/static/notebook/less/cell.less
@@ -15,7 +15,7 @@ div.cell {
     }
 
     .edit_mode &.selected {
-        border-color: green;
+        border-color: @color-muted-5;
         /* Don't border the cells when printing */
         @media print {
             border-color: transparent;
@@ -37,7 +37,7 @@ div.cell {
     margin: 0px;
     font-family: @font-family-monospace;
     text-align: right;
-    /* This has to match that of the the CodeMirror class line-height below */	
+    /* This has to match that of the the CodeMirror class line-height below */
     line-height: @code_line_height;
 }
 
@@ -82,7 +82,7 @@ div.unrecognized_cell {
     // from text_cell
     padding: 5px 5px 5px 0px;
     .hbox();
-    
+
     .inner_cell {
         .border-radius(@border-radius-base);
         padding: 5px;

--- a/notebook/static/notebook/less/highlight.less
+++ b/notebook/static/notebook/less/highlight.less
@@ -112,5 +112,3 @@ Adapted from GitHub theme
     background-repeat: no-repeat;
   }
 }
-
-.cm-s-ipython .CodeMirror div.CodeMirror-cursor { border-left: 1px solid magenta; }

--- a/notebook/static/notebook/less/highlight.less
+++ b/notebook/static/notebook/less/highlight.less
@@ -7,8 +7,6 @@ Adapted from GitHub theme
 
 @import (reference) "highlight-refs.less";
 
-@highlight-base: #000;
-
 .highlight-base{
   color: @highlight-base;
 }
@@ -26,16 +24,16 @@ Adapted from GitHub theme
 }
 
 .highlight-string{
-  color: #BA2121;
+  color: @highlight-string;
 }
 
 .highlight-comment{
-  color: #408080;
+  color: @color-muted-5;
   font-style: italic;
 }
 
 .highlight-number{
-  color: #080;
+  color: @color-accent-3;
 }
 
 .highlight-atom{
@@ -43,7 +41,7 @@ Adapted from GitHub theme
 }
 
 .highlight-keyword{
-  color: #008000;
+  color: @highlight-keyword;
   font-weight: bold;
 }
 
@@ -52,11 +50,11 @@ Adapted from GitHub theme
 }
 
 .highlight-error{
-  color: #f00;
+  color: @highlight-error;
 }
 
 .highlight-operator{
-  color: #AA22FF;
+  color: @color-accent-1;
   font-weight: bold;
 }
 
@@ -64,8 +62,12 @@ Adapted from GitHub theme
   color: #AA22FF;
 }
 
+.highlight-cursor {
+  border-left: 1px solid @color-muted-6;
+}
+
 /* previously not defined, copying from default codemirror */
-.highlight-def{ .cm-s-default.cm-def() }
+.highlight-def{ color: @color-accent-2; }
 .highlight-punctuation{ .cm-s-default.cm-punctuation() }
 .highlight-property{ .cm-s-default.cm-property() }
 .highlight-string-2{ .cm-s-default.cm-string-2() }
@@ -110,3 +112,5 @@ Adapted from GitHub theme
     background-repeat: no-repeat;
   }
 }
+
+.cm-s-ipython .CodeMirror div.CodeMirror-cursor { border-left: 1px solid magenta; }

--- a/notebook/static/notebook/less/variables.less
+++ b/notebook/static/notebook/less/variables.less
@@ -10,8 +10,8 @@
 @notebook_line_height:          20px;
 @code_line_height:              1.21429em;  // changed from 1.231 to get 17px even
 @code_padding:                  0.4em;  // 5.6 px
-@rendered_html_border_color:    black;
-@input_prompt_color:            navy;
-@output_prompt_color:           darkred;
-@output_pre_color:              black;
+@rendered_html_border_color:    @color-muted-3;
+@input_prompt_color:            @color-accent-1;
+@output_prompt_color:           @color-accent-2;
+@output_pre_color:              @color-muted-6;
 @notification_widget_bg:        rgba(240, 240, 240, 0.5);

--- a/notebook/static/style/ipython.less
+++ b/notebook/static/style/ipython.less
@@ -1,6 +1,7 @@
 // minimal imports from bootstrap - only variables and mixins
 @import "../components/bootstrap/less/variables.less";
 @import "../components/bootstrap/less/mixins.less";
+@import "../themes/default.less";
 
 // minimal imports from font-awesome
 @import "../components/font-awesome/less/variables.less";

--- a/notebook/static/style/ipython.less
+++ b/notebook/static/style/ipython.less
@@ -1,7 +1,9 @@
 // minimal imports from bootstrap - only variables and mixins
 @import "../components/bootstrap/less/variables.less";
 @import "../components/bootstrap/less/mixins.less";
-@import "../themes/default.less";
+
+// theme
+@import "../themes/theme.less";
 
 // minimal imports from font-awesome
 @import "../components/font-awesome/less/variables.less";

--- a/notebook/static/style/style.less
+++ b/notebook/static/style/style.less
@@ -33,4 +33,4 @@
 @import "../terminal/less/terminal.less";
 
 // theme
-@import "../themes/default.less";
+@import "../themes/theme.less";

--- a/notebook/static/style/style.less
+++ b/notebook/static/style/style.less
@@ -31,3 +31,6 @@
 
 // terminal
 @import "../terminal/less/terminal.less";
+
+// theme
+@import "../themes/default.less";

--- a/notebook/static/themes/default.less
+++ b/notebook/static/themes/default.less
@@ -1,0 +1,55 @@
+// Tomorrow theme, light
+
+// Muted, gray-ish colors
+@color-muted-1:   #ffffff;
+@color-muted-2:   #e0e0e0;
+@color-muted-3:   #c5c8c6;
+@color-muted-4:   #b4b7b4;
+@color-muted-5:   #969896;
+@color-muted-6:   #373b41;
+@color-muted-7:   #282a2e;
+@color-muted-8:   #1d1f21;
+
+// Bright colors
+@color-primary:   #81a2be;
+@color-error:     #cc6666;
+@color-success:   #b5bd68;
+@color-accent-1:  #de935f;
+@color-accent-2:  #f0c674;
+@color-accent-3:  #8abeb7;
+@color-accent-4:  #b294bb;
+@color-accent-5:  #a3685a;
+
+// Bootstrap overrides
+@body-bg:                 @color-muted-1;
+@brand-primary:           @color-primary;
+@brand-success:           @color-success;
+@text-color:              @color-muted-7;
+@font-family-monospace:   monospace;  // to allow user to customize their fonts
+@font-size-base:          13px;
+@table-border-color:      @color-muted-3;
+@table-border-highlight:  @color-muted-7;
+@page-backdrop-color:     @color-muted-2;
+@navbar-default-bg:       @color-muted-2;
+
+@gray-base:               @color-muted-1;
+@gray-darker:             @color-muted-2;
+@gray-dark:               @color-muted-3;
+@gray:                    @color-muted-4;
+@gray-light:              @color-muted-5;
+@gray-lighter:            @color-muted-6;
+
+// IPython colors
+@border_color:            @color-muted-4;
+
+// Highlight colors
+@highlight-base:          @color-muted-6;
+@highlight-keyword:       @color-accent-4;
+@highlight-error:         @color-error;
+@highlight-string:        @color-success;
+
+// ANSI
+@ansired:                 @color-error;
+@ansigreen:               @color-success;
+@ansicyan:                @color-accent-3;
+@ansiblue:                @color-primary;

--- a/notebook/static/themes/default.less
+++ b/notebook/static/themes/default.less
@@ -21,35 +21,6 @@
 @color-accent-5:  #a3685a;
 
 // Bootstrap overrides
-@body-bg:                 @color-muted-1;
-@brand-primary:           @color-primary;
-@brand-success:           @color-success;
-@text-color:              @color-muted-7;
 @font-family-monospace:   monospace;  // to allow user to customize their fonts
 @font-size-base:          13px;
-@table-border-color:      @color-muted-3;
-@table-border-highlight:  @color-muted-7;
-@page-backdrop-color:     @color-muted-2;
-@navbar-default-bg:       @color-muted-2;
 
-@gray-base:               @color-muted-1;
-@gray-darker:             @color-muted-2;
-@gray-dark:               @color-muted-3;
-@gray:                    @color-muted-4;
-@gray-light:              @color-muted-5;
-@gray-lighter:            @color-muted-6;
-
-// IPython colors
-@border_color:            @color-muted-4;
-
-// Highlight colors
-@highlight-base:          @color-muted-6;
-@highlight-keyword:       @color-accent-4;
-@highlight-error:         @color-error;
-@highlight-string:        @color-success;
-
-// ANSI
-@ansired:                 @color-error;
-@ansigreen:               @color-success;
-@ansicyan:                @color-accent-3;
-@ansiblue:                @color-primary;

--- a/notebook/static/themes/eighties.less
+++ b/notebook/static/themes/eighties.less
@@ -1,0 +1,57 @@
+// Eighties theme, dark
+
+// Muted, gray-ish colors
+@color-muted-1:   #2d2d2d;
+@color-muted-2:   #393939;
+@color-muted-3:   #515151;
+@color-muted-4:   #747369;
+@color-muted-5:   #a09f93;
+@color-muted-6:   #d3d0c8;
+@color-muted-7:   #f2f0ec;
+@color-muted-8:   #e8e6df;
+
+// Bright colors
+@color-primary:   #6699cc;
+@color-error:     #f2777a;
+@color-success:   #99cc99;
+@color-accent-1:  #f99157;
+@color-accent-2:  #ffcc66;
+@color-accent-3:  #66cccc;
+@color-accent-4:  #cc99cc;
+@color-accent-5:  #d27b53;
+
+// Dark theme
+
+// Bootstrap overrides
+@body-bg:                 @color-muted-1;
+@brand-primary:           @color-primary;
+@brand-success:           @color-success;
+@text-color:              @color-muted-7;
+@font-family-monospace:   monospace;  // to allow user to customize their fonts
+@font-size-base:          13px;
+@table-border-color:      @color-muted-3;
+@table-border-highlight:  @color-muted-7;
+@page-backdrop-color:     @color-muted-2;
+@navbar-default-bg:       @color-muted-2;
+
+@gray-base:               @color-muted-1;
+@gray-darker:             @color-muted-2;
+@gray-dark:               @color-muted-3;
+@gray:                    @color-muted-4;
+@gray-light:              @color-muted-5;
+@gray-lighter:            @color-muted-6;
+
+// IPython colors
+@border_color:            @color-muted-4;
+
+// Highlight colors
+@highlight-base:          @color-muted-6;
+@highlight-keyword:       @color-accent-4;
+@highlight-error:         @color-error;
+@highlight-string:        @color-success;
+
+// ANSI
+@ansired:                 @color-error;
+@ansigreen:               @color-success;
+@ansicyan:                @color-accent-3;
+@ansiblue:                @color-primary;

--- a/notebook/static/themes/eighties.less
+++ b/notebook/static/themes/eighties.less
@@ -20,38 +20,6 @@
 @color-accent-4:  #cc99cc;
 @color-accent-5:  #d27b53;
 
-// Dark theme
-
 // Bootstrap overrides
-@body-bg:                 @color-muted-1;
-@brand-primary:           @color-primary;
-@brand-success:           @color-success;
-@text-color:              @color-muted-7;
 @font-family-monospace:   monospace;  // to allow user to customize their fonts
 @font-size-base:          13px;
-@table-border-color:      @color-muted-3;
-@table-border-highlight:  @color-muted-7;
-@page-backdrop-color:     @color-muted-2;
-@navbar-default-bg:       @color-muted-2;
-
-@gray-base:               @color-muted-1;
-@gray-darker:             @color-muted-2;
-@gray-dark:               @color-muted-3;
-@gray:                    @color-muted-4;
-@gray-light:              @color-muted-5;
-@gray-lighter:            @color-muted-6;
-
-// IPython colors
-@border_color:            @color-muted-4;
-
-// Highlight colors
-@highlight-base:          @color-muted-6;
-@highlight-keyword:       @color-accent-4;
-@highlight-error:         @color-error;
-@highlight-string:        @color-success;
-
-// ANSI
-@ansired:                 @color-error;
-@ansigreen:               @color-success;
-@ansicyan:                @color-accent-3;
-@ansiblue:                @color-primary;

--- a/notebook/static/themes/theme.less
+++ b/notebook/static/themes/theme.less
@@ -1,0 +1,32 @@
+@import "eighties.less";
+
+@body-bg:                 @color-muted-1;
+@brand-primary:           @color-primary;
+@brand-success:           @color-success;
+@text-color:              @color-muted-7;
+@table-border-color:      @color-muted-3;
+@table-border-highlight:  @color-muted-7;
+@page-backdrop-color:     @color-muted-2;
+@navbar-default-bg:       @color-muted-2;
+
+@gray-base:               @color-muted-1;
+@gray-darker:             @color-muted-2;
+@gray-dark:               @color-muted-3;
+@gray:                    @color-muted-4;
+@gray-light:              @color-muted-5;
+@gray-lighter:            @color-muted-6;
+
+// IPython colors
+@border_color:            @color-muted-4;
+
+// Highlight colors
+@highlight-base:          @color-muted-6;
+@highlight-keyword:       @color-accent-4;
+@highlight-error:         @color-error;
+@highlight-string:        @color-success;
+
+// ANSI
+@ansired:                 @color-error;
+@ansigreen:               @color-success;
+@ansicyan:                @color-accent-3;
+@ansiblue:                @color-primary;

--- a/notebook/static/tree/less/tree.less
+++ b/notebook/static/tree/less/tree.less
@@ -33,7 +33,7 @@ ul.breadcrumb {
         font-size: 16px;
         margin-right: 4px;
     }
-    
+
     span {
         color: @dark_dashboard_color;
     }
@@ -59,7 +59,7 @@ ul.breadcrumb {
 
 .list_header {
     font-weight: bold;
-    background-color: @page-backdrop-color
+    background-color: @page-backdrop-color;
 }
 
 .list_placeholder {
@@ -94,7 +94,7 @@ ul.breadcrumb {
   };
   a {text-decoration: none;}
   &:hover {
-    background-color: darken(white,2%);
+    background-color: @table-border-highlight;
   }
 }
 
@@ -131,7 +131,7 @@ ul.breadcrumb {
 }
 
 .item_icon {
-    font-size: 14px; 
+    font-size: 14px;
     color: @dark_dashboard_color;
     margin-right: @dashboard_lr_pad;
     margin-left: @dashboard_lr_pad;
@@ -271,7 +271,7 @@ ul#new-menu {
                 padding-left: @dashboard_lr_pad;
                 padding-right: @dashboard_lr_pad;
                 line-height: @btn_mini_height;
-                
+
                 a:focus, a:hover {
                     text-decoration: none;
                 }


### PR DESCRIPTION
This is far from over, but I'm looking at this approach for themes. Essentially the idea is to refactor the CSS so that all colors are defined in a `theme-name.less` file. For example here I have `themes/default.less` as well as `themes/eighties.less`.

By just changing the 16 colors in the `<theme>.less` files, I have this:

### `themes/default.css` ###

![screen shot 2015-06-29 at 8 01 48 pm](https://cloud.githubusercontent.com/assets/1362219/8421221/c4bd2636-1e99-11e5-89ed-f07f847208e3.png)

Switching to...

### `themes/eighties.css` ###

![screen shot 2015-06-29 at 8 02 04 pm](https://cloud.githubusercontent.com/assets/1362219/8421225/cacb78a2-1e99-11e5-99d5-685c1e919153.png)

If we can make sure that all colors are derived from these, it would be very easy for users to add their own themes. Once this is done, we could roll the gulp task into its own repo—maybe a simple CLI or node package—specifically for creating a new Jupyter theme. Jupyter could itself load this package to generate the default theme.

One issue here is that CodeMirror styles override anything in here. In the interest of leaving CodeMirror alone I think we should just override its colors by loading the Jupyter CSS later.

This is not intended to be a final product but just a demonstration of this approach. Please let me know if you have feedback.