### PR TITLE
Fix embedding custom.css in HTML exported notebook

### DIFF
--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -97,7 +97,8 @@ class NbconvertFileHandler(IPythonHandler):
                         "name": name[:name.rfind('.')],
                         "modified_date": (model['last_modified']
                             .strftime(text.date_format))
-                    }
+                    },
+                    "profile_dir": self.config_manager.profile_dir
                 }
             )
         except Exception as e:


### PR DESCRIPTION
`CSSHTMLHeaderPreprocessor._generate_header` uses 
`resources['profile_dir']` to find locate the custom css file.