### PR TITLE
Add command-line interface to enable/disable nbextensions

### DIFF
--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -24,7 +24,6 @@ from jupyter_core.paths import jupyter_data_dir, jupyter_path, SYSTEM_JUPYTER_PA
 from ipython_genutils.path import ensure_dir_exists
 from ipython_genutils.py3compat import string_types, cast_unicode_py2
 from ipython_genutils.tempdir import TemporaryDirectory
-from notebook.services.config import ConfigManager
 from ._version import __version__
 
 class ArgumentConflict(ValueError):
@@ -332,6 +331,8 @@ class EnableNBExtensionApp(JupyterApp):
               }
 
     def enable_nbextension(self, name):
+        # Local import to avoid circular import issue on Py 2
+        from notebook.services.config import ConfigManager
         cm = ConfigManager(parent=self, config=self.config)
         cm.update(self.section, {"load_extensions": {name: True}})
 
@@ -357,6 +358,8 @@ class DisableNBExtensionApp(JupyterApp):
               }
 
     def disable_nbextension(self, name):
+        # Local import to avoid circular import issue on Py 2
+        from notebook.services.config import ConfigManager
         cm = ConfigManager(parent=self, config=self.config)
         # We're using a dict as a set - updating with None removes the key
         cm.update(self.section, {"load_extensions": {name: None}})

--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -371,6 +371,8 @@ class DisableNBExtensionApp(JupyterApp):
         # Local import to avoid circular import issue on Py 2
         from notebook.services.config import ConfigManager
         cm = ConfigManager(parent=self, config=self.config)
+        if name not in cm.get(self.section).get('load_extensions', {}):
+            sys.exit('{} is not enabled in section {}'.format(name, self.section))
         # We're using a dict as a set - updating with None removes the key
         cm.update(self.section, {"load_extensions": {name: None}})
 

--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -288,6 +288,9 @@ class InstallNBExtensionApp(JupyterApp):
     verbose = Enum((0,1,2), default_value=1, config=True,
         help="Verbosity level"
     )
+
+    def _config_file_name_default(self):
+        return 'jupyter_notebook_config'
     
     def install_extensions(self):
         if len(self.extra_args)>1:
@@ -330,6 +333,9 @@ class EnableNBExtensionApp(JupyterApp):
     aliases = {'section': 'EnableNBExtensionApp.section',
               }
 
+    def _config_file_name_default(self):
+        return 'jupyter_notebook_config'
+
     def enable_nbextension(self, name):
         # Local import to avoid circular import issue on Py 2
         from notebook.services.config import ConfigManager
@@ -356,6 +362,9 @@ class DisableNBExtensionApp(JupyterApp):
 
     aliases = {'section': 'DisableNBExtensionApp.section',
               }
+
+    def _config_file_name_default(self):
+        return 'jupyter_notebook_config'
 
     def disable_nbextension(self, name):
         # Local import to avoid circular import issue on Py 2

--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -344,8 +344,9 @@ class EnableNBExtensionApp(JupyterApp):
 
     def start(self):
         if not self.extra_args:
-            self.print_help()
             sys.exit('No extensions specified')
+        elif len(self.extra_args) > 1:
+            sys.exit('Please specify one extension at a time')
 
         self.enable_nbextension(self.extra_args[0])
 
@@ -375,8 +376,9 @@ class DisableNBExtensionApp(JupyterApp):
 
     def start(self):
         if not self.extra_args:
-            self.print_help()
             sys.exit('No extensions specified')
+        elif len(self.extra_args) > 1:
+            sys.exit('Please specify one extension at a time')
 
         self.disable_nbextension(self.extra_args[0])
 


### PR DESCRIPTION
i.e. to enable cite2c, you'd use `jupyter nbextension enable cite2c/main`.

Open questions:

1. Should these commands accept multiple extension names in one call? `nbextension install` currently doesn't, so there's a symmetry argument, but it would be easy to handle more than one if necessary.

2. Especially for disable, should it give an error if you try to disable something that's not enabled? Currently it will just pass silently. Enable could also fail if it's already enabled, but that seems less useful.