### PR TITLE
Env variables for server root & URL in terminals

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -889,7 +889,7 @@ class NotebookApp(JupyterApp):
     def init_terminals(self):
         try:
             from .terminal import initialize
-            initialize(self.web_app)
+            initialize(self.web_app, self.notebook_dir, self.connection_url)
             self.web_app.settings['terminals_available'] = True
         except ImportError as e:
             log = self.log.debug if sys.platform == 'win32' else self.log.warn

--- a/notebook/terminal/__init__.py
+++ b/notebook/terminal/__init__.py
@@ -12,9 +12,14 @@ from notebook.utils import url_path_join as ujoin
 from .handlers import TerminalHandler, TermSocket
 from . import api_handlers
 
-def initialize(webapp):
+def initialize(webapp, notebook_dir, connection_url):
     shell = os.environ.get('SHELL') or 'sh'
-    terminal_manager = webapp.settings['terminal_manager'] = NamedTermManager(shell_command=[shell])
+    terminal_manager = webapp.settings['terminal_manager'] = NamedTermManager(
+        shell_command=[shell],
+        extra_env={'JUPYTER_SERVER_ROOT': notebook_dir,
+                   'JUPYTER_SERVER_URL': connection_url,
+                   },
+    )
     terminal_manager.log = app_log
     base_url = webapp.settings['base_url']
     handlers = [


### PR DESCRIPTION
This came up [on reddit](https://www.reddit.com/r/IPython/comments/3dz9r4/is_there_a_command_from_jupyters_terminal_to/): if you want to open a notebook or a file in the text editor from the terminal inside the notebook web interface, you can construct a URL to open. But to do that accurately, you need to know the root directory where the server is looking, and the first part of the URL. This exposes both of those as environment variables: `$JUPYTER_SERVER_ROOT` and `$JUPYTER_SERVER_URL`.