### PR TITLE
remove 'name' arg from file_exists docstring

### DIFF
--- a/notebook/services/contents/manager.py
+++ b/notebook/services/contents/manager.py
@@ -168,10 +168,8 @@ class ContentsManager(LoggingConfigurable):
 
         Parameters
         ----------
-        name : string
-            The name of the file you are checking.
         path : string
-            The relative path to the file's directory (with '/' as separator)
+            The API path of a file to check for.
 
         Returns
         -------
@@ -188,7 +186,7 @@ class ContentsManager(LoggingConfigurable):
         Parameters
         ----------
         path : string
-            The relative path to the file's directory (with '/' as separator)
+            The API path of a file or directory to check for.
 
         Returns
         -------


### PR DESCRIPTION
Only path is used, not separate name, path.

closes ipython/ipython#8646