### PR TITLE
Fix scope on restart buttons

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1637,13 +1637,13 @@ define(function (require) {
                         that.clear_all_output();
                         that.kernel.restart();
                     },
+                },
                 "Restart" : {
                     "class" : "btn-warning",
                     "click" : function() {
                         that.kernel.restart();
                     }
                 },
-                }
             }
         });
     };


### PR DESCRIPTION
Restart button was excluded since it was inside another button.