### PR TITLE
Catch error adding link to notebook list

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -295,7 +295,11 @@ define([
         for (var i=0; i<len; i++) {
             model = list.content[i];
             item = this.new_item(i+offset, true);
-            this.add_link(model, item);
+            try {
+                this.add_link(model, item);
+            } catch(err) {
+                console.log('Error adding link: ' + err)
+            }
         }
         // Trigger an event when we've finished drawing the notebook list.
         events.trigger('draw_notebook_list.NotebookList');


### PR DESCRIPTION
Part of the fix for gh-223.

If a filename can't be decoded in the current encoding, Python escapes the undecodable bytes as unpaired surrogates, which JS doesn't like building a URL from.

This doesn't make the undecodable filename openable, but it stops it from breaking the listing of other files.

The real fix is to set up the locale encoding correctly so that the filenames can be decoded.