### PR TITLE
Modify the check_call invocation to fix break on Windows

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -293,7 +293,7 @@ def mtime(path):
 def run(cmd, *args, **kwargs):
     """Echo a command before running it"""
     log.info(" ".join(cmd))
-    return check_call(cmd, *args, **kwargs)
+    return check_call(cmd, shell = True, *args, **kwargs)
 
 
 class Bower(Command):


### PR DESCRIPTION
When I attempted to install the development version of notebook on my Windows 7 machine, I received the following error:

    >> python setup.py build

    running build
    running build_py
    running jsversion
    running css
    running jsdeps
    installing build dependencies with npm
    npm install
    rebuilding js and css failed (not a problem)
    [WinError 2] The system cannot find the file specified
    checking package data
    Traceback (most recent call last):
      File "setup.py", line 190, in <module>
        main()
      File "setup.py", line 187, in main
        setup(**setup_args)
      File "C:\Anaconda3\lib\distutils\core.py", line 148, in setup
        dist.run_commands()
      File "C:\Anaconda3\lib\distutils\dist.py", line 955, in run_commands
        self.run_command(cmd)
      File "C:\Anaconda3\lib\distutils\dist.py", line 974, in run_command
        cmd_obj.run()
      File "C:\Anaconda3\lib\distutils\command\build.py", line 126, in run
        self.run_command(cmd_name)
      File "C:\Anaconda3\lib\distutils\cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "C:\Anaconda3\lib\distutils\dist.py", line 974, in run_command
        cmd_obj.run()
      File "C:\Users\jclutter\Source\Python\IPython\t\notebook\setupbase.py", line 508, in run
        command.run(self)
      File "C:\Users\jclutter\Source\Python\IPython\t\notebook\setupbase.py", line 199, in run
        check_package_data(self.package_data)
      File "C:\Users\jclutter\Source\Python\IPython\t\notebook\setupbase.py", line 189, in check_package_data
        assert os.path.exists(path), "Missing package data: %s" % path
    AssertionError: Missing package data: notebook\static\auth\js\main.min.js

Although the bottom error highlights a missing `main.min.js`, this is a red herring.  The real issue is at the top, `[WinError 2] The system cannot find the specified`.

After some investigation, I found that the `bower` program was not being execute.  This led to an investigation of the run command.  I was unable to execute commands from the python shell unless I added the `shell = True` parameter to the `check_call` invocation.  I made this change here and was able to perform the installation of Jupyter/notebook.  

Documentation for the `subprocess` module implies that there could be security issues when using `shell = True`.