### PR TITLE
Fix up some issues with the Mathjax examples in the docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,6 +42,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.autosummary',
+    'sphinx.ext.mathjax',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/examples/Notebook/Typesetting Equations.ipynb
+++ b/docs/source/examples/Notebook/Typesetting Equations.ipynb
@@ -13,11 +13,10 @@
    "source": [
     "# Motivating Examples\n",
     "\n",
-    "---\n",
-    "\n",
     "## The Lorenz Equations\n",
     "### Source\n",
-    "```\\begin{align}\n",
+    "```\n",
+    "\\begin{align}\n",
     "\\dot{x} & = \\sigma(y-x) \\\\\n",
     "\\dot{y} & = \\rho x - y - xz \\\\\n",
     "\\dot{z} & = -\\beta z + xy\n",
@@ -37,7 +36,8 @@
    "source": [
     "## The Cauchy-Schwarz Inequality\n",
     "### Source\n",
-    "```\\begin{equation*}\n",
+    "```\n",
+    "\\begin{equation*}\n",
     "\\left( \\sum_{k=1}^n a_k b_k \\right)^2 \\leq \\left( \\sum_{k=1}^n a_k^2 \\right) \\left( \\sum_{k=1}^n b_k^2 \\right)\n",
     "\\end{equation*}\n",
     "```\n",
@@ -53,7 +53,8 @@
    "source": [
     "## A Cross Product Formula\n",
     "### Source\n",
-    "```\\begin{equation*}\n",
+    "```\n",
+    "\\begin{equation*}\n",
     "\\mathbf{V}_1 \\times \\mathbf{V}_2 =  \\begin{vmatrix}\n",
     "\\mathbf{i} & \\mathbf{j} & \\mathbf{k} \\\\\n",
     "\\frac{\\partial X}{\\partial u} &  \\frac{\\partial Y}{\\partial u} & 0 \\\\\n",
@@ -77,7 +78,8 @@
    "source": [
     "## The probability of getting \\(k\\) heads when flipping \\(n\\) coins is\n",
     "### Source\n",
-    "```\\begin{equation*}\n",
+    "```\n",
+    "\\begin{equation*}\n",
     "P(E)   = {n \\choose k} p^k (1-p)^{ n-k} \n",
     "\\end{equation*}\n",
     "```\n",
@@ -93,7 +95,8 @@
    "source": [
     "## An Identity of Ramanujan\n",
     "### Source\n",
-    "```\\begin{equation*}\n",
+    "```\n",
+    "\\begin{equation*}\n",
     "\\frac{1}{\\Bigl(\\sqrt{\\phi \\sqrt{5}}-\\phi\\Bigr) e^{\\frac25 \\pi}} =\n",
     "1+\\frac{e^{-2\\pi}} {1+\\frac{e^{-4\\pi}} {1+\\frac{e^{-6\\pi}}\n",
     "{1+\\frac{e^{-8\\pi}} {1+\\ldots} } } } \n",
@@ -113,7 +116,8 @@
    "source": [
     "## A Rogers-Ramanujan Identity\n",
     "### Source\n",
-    "```\\begin{equation*}\n",
+    "```\n",
+    "\\begin{equation*}\n",
     "1 +  \\frac{q^2}{(1-q)}+\\frac{q^6}{(1-q)(1-q^2)}+\\cdots =\n",
     "\\prod_{j=0}^{\\infty}\\frac{1}{(1-q^{5j+2})(1-q^{5j+3})},\n",
     "\\quad\\quad \\text{for $|q|<1$}. \n",
@@ -133,7 +137,8 @@
    "source": [
     "## Maxwell's Equations\n",
     "### Source\n",
-    "```\\begin{align}\n",
+    "```\n",
+    "\\begin{align}\n",
     "\\nabla \\times \\vec{\\mathbf{B}} -\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{E}}}{\\partial t} & = \\frac{4\\pi}{c}\\vec{\\mathbf{j}} \\\\   \\nabla \\cdot \\vec{\\mathbf{E}} & = 4 \\pi \\rho \\\\\n",
     "\\nabla \\times \\vec{\\mathbf{E}}\\, +\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{B}}}{\\partial t} & = \\vec{\\mathbf{0}} \\\\\n",
     "\\nabla \\cdot \\vec{\\mathbf{B}} & = 0 \n",
@@ -153,8 +158,6 @@
    "source": [
     "# Equation Numbering and References\n",
     "\n",
-    "---\n",
-    "\n",
     "Equation numbering and referencing will be available in a future version of the Jupyter notebook."
    ]
   },
@@ -162,17 +165,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Inline Typesetting (Mixing Markdown and TeX)\n",
-    "\n",
-    "---\n",
+    "## Inline Typesetting (Mixing Markdown and TeX)\n",
     "\n",
     "While display equations look good for a page of samples, the ability to mix math and *formatted* **text** in a paragraph is also important.\n",
     "\n",
-    "## Source\n",
-    "``` This expression $\\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in a **[Markdown-formatted](http://daringfireball.net/projects/markdown/)** sentence.  \n",
+    "### Source\n",
     "```\n",
-    "## Display\n",
-    "This expression $\\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in a **[Markdown-formatted](http://daringfireball.net/projects/markdown/)** sentence.  "
+    "This expression $\\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in a [Markdown-formatted](http://daringfireball.net/projects/markdown/) sentence.  \n",
+    "```\n",
+    "\n",
+    "### Display\n",
+    "This expression $\\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in a [Markdown-formatted](http://daringfireball.net/projects/markdown/) sentence.  "
    ]
   },
   {
@@ -180,8 +183,6 @@
    "metadata": {},
    "source": [
     "# Other Syntax\n",
-    "\n",
-    "---\n",
     "\n",
     "You will notice in other places on the web that `$$` are needed explicitly to begin and end MathJax typesetting.  This is **not** required if you will be using TeX environments, but the Jupyter notebook will accept this syntax on legacy notebooks.  \n",
     "\n",

--- a/docs/source/examples/Notebook/Typesetting Equations.rst
+++ b/docs/source/examples/Notebook/Typesetting Equations.rst
@@ -12,16 +12,22 @@ below, as well as the Markdown+TeX source.
 Motivating Examples
 ===================
 
---------------
-
 The Lorenz Equations
 --------------------
 
 Source
 ~~~~~~
 
-``\begin{align} \dot{x} & = \sigma(y-x) \\ \dot{y} & = \rho x - y - xz \\ \dot{z} & = -\beta z + xy \end{align}``
-### Display
+::
+
+    \begin{align}
+    \dot{x} & = \sigma(y-x) \\
+    \dot{y} & = \rho x - y - xz \\
+    \dot{z} & = -\beta z + xy
+    \end{align}
+
+Display
+~~~~~~~
 
 .. raw:: latex
 
@@ -32,13 +38,19 @@ Source
    \end{align}
 
 The Cauchy-Schwarz Inequality
------------------------------
+=============================
 
 Source
-~~~~~~
+------
 
-``\begin{equation*} \left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right) \end{equation*}``
-### Display
+::
+
+    \begin{equation*}
+    \left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)
+    \end{equation*}
+
+Display
+-------
 
 .. raw:: latex
 
@@ -47,13 +59,23 @@ Source
    \end{equation*}
 
 A Cross Product Formula
------------------------
+=======================
 
 Source
-~~~~~~
+------
 
-``\begin{equation*} \mathbf{V}_1 \times \mathbf{V}_2 =  \begin{vmatrix} \mathbf{i} & \mathbf{j} & \mathbf{k} \\ \frac{\partial X}{\partial u} &  \frac{\partial Y}{\partial u} & 0 \\ \frac{\partial X}{\partial v} &  \frac{\partial Y}{\partial v} & 0 \end{vmatrix}   \end{equation*}``
-### Display
+::
+
+    \begin{equation*}
+    \mathbf{V}_1 \times \mathbf{V}_2 =  \begin{vmatrix}
+    \mathbf{i} & \mathbf{j} & \mathbf{k} \\
+    \frac{\partial X}{\partial u} &  \frac{\partial Y}{\partial u} & 0 \\
+    \frac{\partial X}{\partial v} &  \frac{\partial Y}{\partial v} & 0
+    \end{vmatrix}  
+    \end{equation*}
+
+Display
+-------
 
 .. raw:: latex
 
@@ -66,13 +88,19 @@ Source
    \end{equation*}
 
 The probability of getting (k) heads when flipping (n) coins is
----------------------------------------------------------------
+===============================================================
 
 Source
-~~~~~~
+------
 
-``\begin{equation*} P(E)   = {n \choose k} p^k (1-p)^{ n-k}  \end{equation*}``
-### Display
+::
+
+    \begin{equation*}
+    P(E)   = {n \choose k} p^k (1-p)^{ n-k} 
+    \end{equation*}
+
+Display
+-------
 
 .. raw:: latex
 
@@ -81,13 +109,21 @@ Source
    \end{equation*}
 
 An Identity of Ramanujan
-------------------------
+========================
 
 Source
-~~~~~~
+------
 
-``\begin{equation*} \frac{1}{\Bigl(\sqrt{\phi \sqrt{5}}-\phi\Bigr) e^{\frac25 \pi}} = 1+\frac{e^{-2\pi}} {1+\frac{e^{-4\pi}} {1+\frac{e^{-6\pi}} {1+\frac{e^{-8\pi}} {1+\ldots} } } }  \end{equation*}``
-### Display
+::
+
+    \begin{equation*}
+    \frac{1}{\Bigl(\sqrt{\phi \sqrt{5}}-\phi\Bigr) e^{\frac25 \pi}} =
+    1+\frac{e^{-2\pi}} {1+\frac{e^{-4\pi}} {1+\frac{e^{-6\pi}}
+    {1+\frac{e^{-8\pi}} {1+\ldots} } } } 
+    \end{equation*}
+
+Display
+-------
 
 .. raw:: latex
 
@@ -98,13 +134,21 @@ Source
    \end{equation*}
 
 A Rogers-Ramanujan Identity
----------------------------
+===========================
 
 Source
-~~~~~~
+------
 
-``\begin{equation*} 1 +  \frac{q^2}{(1-q)}+\frac{q^6}{(1-q)(1-q^2)}+\cdots = \prod_{j=0}^{\infty}\frac{1}{(1-q^{5j+2})(1-q^{5j+3})}, \quad\quad \text{for $|q|<1$}.  \end{equation*}``
-### Display
+::
+
+    \begin{equation*}
+    1 +  \frac{q^2}{(1-q)}+\frac{q^6}{(1-q)(1-q^2)}+\cdots =
+    \prod_{j=0}^{\infty}\frac{1}{(1-q^{5j+2})(1-q^{5j+3})},
+    \quad\quad \text{for $|q|<1$}. 
+    \end{equation*}
+
+Display
+-------
 
 .. raw:: latex
 
@@ -115,13 +159,21 @@ Source
    \end{equation*}
 
 Maxwell's Equations
--------------------
+===================
 
 Source
-~~~~~~
+------
 
-``\begin{align} \nabla \times \vec{\mathbf{B}} -\, \frac1c\, \frac{\partial\vec{\mathbf{E}}}{\partial t} & = \frac{4\pi}{c}\vec{\mathbf{j}} \\   \nabla \cdot \vec{\mathbf{E}} & = 4 \pi \rho \\ \nabla \times \vec{\mathbf{E}}\, +\, \frac1c\, \frac{\partial\vec{\mathbf{B}}}{\partial t} & = \vec{\mathbf{0}} \\ \nabla \cdot \vec{\mathbf{B}} & = 0  \end{align}``
-### Display
+::
+
+    \begin{align}
+    \nabla \times \vec{\mathbf{B}} -\, \frac1c\, \frac{\partial\vec{\mathbf{E}}}{\partial t} & = \frac{4\pi}{c}\vec{\mathbf{j}} \\   \nabla \cdot \vec{\mathbf{E}} & = 4 \pi \rho \\
+    \nabla \times \vec{\mathbf{E}}\, +\, \frac1c\, \frac{\partial\vec{\mathbf{B}}}{\partial t} & = \vec{\mathbf{0}} \\
+    \nabla \cdot \vec{\mathbf{B}} & = 0 
+    \end{align}
+
+Display
+-------
 
 .. raw:: latex
 
@@ -134,15 +186,11 @@ Source
 Equation Numbering and References
 =================================
 
---------------
-
 Equation numbering and referencing will be available in a future version
 of the Jupyter notebook.
 
 Inline Typesetting (Mixing Markdown and TeX)
 ============================================
-
---------------
 
 While display equations look good for a page of samples, the ability to
 mix math and *formatted* **text** in a paragraph is also important.
@@ -150,16 +198,20 @@ mix math and *formatted* **text** in a paragraph is also important.
 Source
 ------
 
-``This expression $\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in a **[Markdown-formatted](http://daringfireball.net/projects/markdown/)** sentence.``
-## Display This expression :math:`\sqrt{3x-1}+(1+x)^2` is an example of
-a TeX inline equation in a
-**`Markdown-formatted <http://daringfireball.net/projects/markdown/>`__**
+::
+
+    This expression $\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in a [Markdown-formatted](http://daringfireball.net/projects/markdown/) sentence.  
+
+Display
+-------
+
+This expression :math:`\sqrt{3x-1}+(1+x)^2` is an example of a TeX
+inline equation in a
+`Markdown-formatted <http://daringfireball.net/projects/markdown/>`__
 sentence.
 
 Other Syntax
 ============
-
---------------
 
 You will notice in other places on the web that ``$$`` are needed
 explicitly to begin and end MathJax typesetting. This is **not**
@@ -167,7 +219,7 @@ required if you will be using TeX environments, but the Jupyter notebook
 will accept this syntax on legacy notebooks.
 
 Source
-~~~~~~
+------
 
 ::
 
@@ -203,7 +255,7 @@ Source
     $$
 
 Display
-~~~~~~~
+-------
 
 .. math::
 


### PR DESCRIPTION
Fix the display of code samples in the Mathjax example doc, and squash some warnings when building the docs.

This still doesn't make most of the examples display, because pandoc makes the \begin{} & \end{} block into a raw latex block, which isn't rendered in the HTML output. Not sure what to do about that.