### PR TITLE
Use window.location trick for download as ipynb

### DIFF
--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -113,12 +113,16 @@ define([
         this.element.find('#download_ipynb').click(function () {
             var base_url = that.notebook.base_url;
             var notebook_path = that.notebook.notebook_path;
+            var w = window.open('');
+            var url = utils.url_join_encode(base_url, 'files', notebook_path)
+                                + '?download=1';
             if (that.notebook.dirty) {
-                that.notebook.save_notebook({async : false});
+                that.notebook.save_notebook().then(function() {
+                    w.location = url;
+                });
+            } else {
+                w.location = url;
             }
-            
-            var url = utils.url_join_encode(base_url, 'files', notebook_path);
-            window.open(url + '?download=1');
         });
         
         this.element.find('#print_preview').click(function () {


### PR DESCRIPTION
To avoid problems with synchronous HTTP request from JS to save the notebook before downloading it.

Closes gh-239