### PR TITLE
Add Jinja Blocks to notebook.html and tree.html

### DIFF
--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -267,7 +267,7 @@ data-notebook-path="{{notebook_path}}"
 
                         {% for helplinks in sections %}
                             {% for link in helplinks %}
-                                <li><a class='help_link' href="{{link[0]}}" {{'target="_blank" title="Opens in a new window"' if link[2]}}>
+                                <li><a href="{{link[0]}}" {{'target="_blank" title="Opens in a new window"' if link[2]}}>
                                 {{'<i class="fa fa-external-link menu-icon pull-right"></i>' if link[2]}}
                                 {{link[1]}}
                                 </a></li>

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -267,7 +267,7 @@ data-notebook-path="{{notebook_path}}"
 
                         {% for helplinks in sections %}
                             {% for link in helplinks %}
-                                <li><a {% block helplink_attributes %}{% endblock %} href="{{link[0]}}" {{'target="_blank" title="Opens in a new window"' if link[2]}}>
+                                <li><a class='help_link' href="{{link[0]}}" {{'target="_blank" title="Opens in a new window"' if link[2]}}>
                                 {{'<i class="fa fa-external-link menu-icon pull-right"></i>' if link[2]}}
                                 {{link[1]}}
                                 </a></li>

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -45,7 +45,9 @@ data-notebook-path="{{notebook_path}}"
 </span>
 
 <span id="kernel_logo_widget">
+  {% block kernel_logo_widget %}
   <img class="current_kernel_logo" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"/>
+  {% endblock %}
 </span>
 
 {% endblock headercontainer %}
@@ -250,6 +252,7 @@ data-notebook-path="{{notebook_path}}"
                 </li>
                 <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Help</a>
                     <ul  id="help_menu" class="dropdown-menu">
+                        {% block help %}
                         <li id="notebook_tour" title="A quick tour of the notebook user interface"><a href="#">User Interface Tour</a></li>
                         <li id="keyboard_shortcuts" title="Opens a tooltip with all keyboard shortcuts"><a href="#">Keyboard Shortcuts</a></li>
                         <li class="divider"></li>
@@ -264,7 +267,7 @@ data-notebook-path="{{notebook_path}}"
 
                         {% for helplinks in sections %}
                             {% for link in helplinks %}
-                                <li><a href="{{link[0]}}" {{'target="_blank" title="Opens in a new window"' if link[2]}}>
+                                <li><a {% block helplink_attributes %}{% endblock %} href="{{link[0]}}" {{'target="_blank" title="Opens in a new window"' if link[2]}}>
                                 {{'<i class="fa fa-external-link menu-icon pull-right"></i>' if link[2]}}
                                 {{link[1]}}
                                 </a></li>
@@ -275,6 +278,7 @@ data-notebook-path="{{notebook_path}}"
                         {% endfor %}
                         <li class="divider"></li>
                         <li title="About IPython Notebook"><a id="notebook_about" href="#">About</a></li>
+                        {% endblock %}
                     </ul>
                 </li>
               </ul>

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -19,7 +19,7 @@ data-terminals-available="{{terminals_available}}"
       <ul id="tabs" class="nav nav-tabs">
         <li class="active"><a href="#notebooks" data-toggle="tab">Files</a></li>
         <li><a href="#running" data-toggle="tab">Running</a></li>
-        <li><a href="#clusters" data-toggle="tab" {% block clusters_tab_attributes %}{% endblock %} >Clusters</a></li>
+        <li><a href="#clusters" data-toggle="tab" class="clusters_tab_link" >Clusters</a></li>
       </ul>
       <div class="tab-content">
         <div id="notebooks" class="tab-pane active">

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -19,7 +19,7 @@ data-terminals-available="{{terminals_available}}"
       <ul id="tabs" class="nav nav-tabs">
         <li class="active"><a href="#notebooks" data-toggle="tab">Files</a></li>
         <li><a href="#running" data-toggle="tab">Running</a></li>
-        <li><a href="#clusters" data-toggle="tab">Clusters</a></li>
+        <li><a href="#clusters" data-toggle="tab" {% block clusters_tab_attributes %}{% endblock %} >Clusters</a></li>
       </ul>
       <div class="tab-content">
         <div id="notebooks" class="tab-pane active">


### PR DESCRIPTION
Added blocks to support customization to:
- the logo in the upper right.  Both tmpnb and notebooks.azureml.net use
this area to add logos.
- help links.  We add links to the help tab.  We also add a
rel="noreferrer" to each link.  These block enable us to make these
corrections without altering the primary template.
- provide a place in tree to give an attribute area.  We use this to
hide the clusters tab.