### PR TITLE
increase completer z-index to be in front of pager

### DIFF
--- a/notebook/static/notebook/less/completer.less
+++ b/notebook/static/notebook/less/completer.less
@@ -1,6 +1,6 @@
 .completions {
     position: absolute;
-    z-index: 10;
+    z-index: 110;
     overflow: hidden;
     border: 1px solid @border_color;
     .corner-all;


### PR DESCRIPTION
This lets tab completion still be readable when an introspection pane is open. 