### PR TITLE
Command Palette on notebook. 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "requirejs": "~2.1",
     "term.js": "chjj/term.js#~0.0.4",
     "text-encoding": "~0.1",
-    "underscore": "components/underscore#~1.5"
+    "underscore": "components/underscore#~1.5",
+    "jquery-typeahead": "~2.0.0"
   }
 }

--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -45,7 +45,6 @@ def _post_save_script(model, os_path, contents_manager, **kwargs):
     log = contents_manager.log
 
     base, ext = os.path.splitext(os_path)
-    py_fname = base + '.py'
     script, resources = _script_exporter.from_filename(os_path)
     script_fname = base + resources.get('output_extension', '.txt')
     log.info("Saving script /%s", to_api_path(script_fname, contents_manager.root_dir))

--- a/notebook/static/base/js/keyboard.js
+++ b/notebook/static/base/js/keyboard.js
@@ -18,7 +18,7 @@ define([
 
     /**
      * Setup global keycodes and inverse keycodes.
-     * 
+     *
      * See http://unixpapa.com/js/key.html for a complete description. The short of
      * it is that there are different keycode sets. Firefox uses the "Mozilla keycodes"
      * and Webkit/IE use the "IE keycodes". These keycode sets are mostly the same
@@ -190,7 +190,7 @@ define([
         /**
          * Clear the pending shortcut soon, and cancel previous clearing
          * that might be registered.
-         **/ 
+         **/
          var that = this;
          clearTimeout(this._cleartimeout);
          this._cleartimeout = setTimeout(function(){that.clearqueue();}, this.delay);
@@ -225,6 +225,17 @@ define([
         }
         return dct;
     };
+    
+    ShortcutManager.prototype.get_shortcut_for_action_name = function(name){
+      var ftree = flatten_shorttree(this._shortcuts);
+      var res = {};
+      for (var sht in ftree ){
+        if(ftree[sht] === name){
+          return sht
+        }
+      }
+      return undefined;
+    }
 
     ShortcutManager.prototype.help = function () {
         var help = [];

--- a/notebook/static/base/js/keyboard.js
+++ b/notebook/static/base/js/keyboard.js
@@ -226,16 +226,16 @@ define([
         return dct;
     };
     
-    ShortcutManager.prototype.get_shortcut_for_action_name = function(name){
+    ShortcutManager.prototype.get_action_shortcut = function(name){
       var ftree = flatten_shorttree(this._shortcuts);
       var res = {};
       for (var sht in ftree ){
         if(ftree[sht] === name){
-          return sht
+          return sht;
         }
       }
       return undefined;
-    }
+    };
 
     ShortcutManager.prototype.help = function () {
         var help = [];

--- a/notebook/static/base/js/keyboard.js
+++ b/notebook/static/base/js/keyboard.js
@@ -48,12 +48,12 @@ define([
     
     // These apply to Firefox and Opera
     var _mozilla_keycodes = {
-        '; :': 59, '= +': 61, '- _': 173, 'meta': 224
+        '; :': 59, '= +': 61, '- _': 173, 'meta': 224, 'minus':173
     };
     
     // This apply to Webkit and IE
     var _ie_keycodes = {
-        '; :': 186, '= +': 187, '- _': 189
+        '; :': 186, '= +': 187, '- _': 189, 'minus':189
     };
     
     var browser = utils.browser[0];
@@ -105,7 +105,7 @@ define([
         }
 
         shortcut = shortcut.toLowerCase().replace('cmd', 'meta');
-        shortcut = shortcut.replace(/-$/, '_');  // catch shortcuts using '-' key
+        shortcut = shortcut.replace(/-$/, 'minus');  // catch shortcuts using '-' key
         shortcut = shortcut.replace(/,$/, 'comma');  // catch shortcuts using '-' key
         if(shortcut.indexOf(',') !== -1){
             var sht = shortcut.split(',');
@@ -130,7 +130,7 @@ define([
          **/
         type = type || 'keydown';
         shortcut = normalize_shortcut(shortcut);
-        shortcut = shortcut.replace(/-$/, '_');  // catch shortcuts using '-' key
+        shortcut = shortcut.replace(/-$/, 'minus');  // catch shortcuts using '-' key
         var values = shortcut.split("-");
         var modifiers = values.slice(0,-1);
         var key = values[values.length-1];
@@ -148,7 +148,7 @@ define([
          * false otherwise
          **/
         var key = inv_keycodes[event.which];
-        return ((event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) && 
+        return ((event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) &&
          (key === 'alt'|| key === 'ctrl'|| key === 'meta'|| key === 'shift'));
 
     };

--- a/notebook/static/base/less/variables.less
+++ b/notebook/static/base/less/variables.less
@@ -15,6 +15,9 @@
 @border-radius-base: 2px;
 @border-radius-large: 3px;
 @grid-gutter-width: 0px;
+@kbd-color: #888;
+@kbd-bg: transparent;
+
 @icon-font-path: "../components/bootstrap/fonts/";
 
 // Disable modal slide-in from top animation.
@@ -57,4 +60,3 @@ label {
 // preven container size to jump from 768px to 720px
 // when window width go from 768 to 769+
 @container-sm : @screen-sm-min;
-

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -335,35 +335,7 @@ define(function(require){
         'command-palette': {
             help_index : 'aa', 
             handler : function(env){
-                var form = $('<form/>');
-                var container = $('<div/>').addClass('typeahead-container');
-                var field = $('<div/>').addClass('typeahead-field');
-                var span = $('<span>').addClass('typeahead-query');
-                var input = $('<input/>').attr('type', 'search'); 
-
-                span.append(input)
-                field.append(span)
-                container.append(field)
-                form.append(container)
-                input.typeahead({
-                    order: "asc",
-                    source: {
-                        groupName: {
-                            data: [ 'california', 'washington', 'state', 'france', 'china', 'russia', 'rust', 'river' , 'repression']
-                        }
-                    },
-                    callback: {
-                        onInit: function () {console.log('this is init') }
-                    }
-                })
-                dialog.modal({
-                        title: 'Execute Action',
-                        body: $('<div/>').append(form),
-                        buttons: {
-                            OK: {'class': 'btn-primary'}
-                        },
-                        keyboard_manager: env.notebook.keyboard_manager
-                    });
+                env.notebook.show_command_palette();
             }
         }
 

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -4,8 +4,6 @@
 define(function(require){
     "use strict";
 
-    var dialog = require("base/js/dialog");
-    
     var ActionHandler = function (env) {
         this.env = env || {};
         Object.seal(this);

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -335,25 +335,34 @@ define(function(require){
         'command-palette': {
             help_index : 'aa', 
             handler : function(env){
-                var searchfield = $('<input/>').attr('type', 'text'); 
-                searchfield.typeahead({
+                var form = $('<form/>');
+                var container = $('<div/>').addClass('typeahead-container');
+                var field = $('<div/>').addClass('typeahead-field');
+                var span = $('<span>').addClass('typeahead-query');
+                var input = $('<input/>').attr('type', 'search'); 
+
+                span.append(input)
+                field.append(span)
+                container.append(field)
+                form.append(container)
+                input.typeahead({
                     order: "asc",
                     source: {
                         groupName: {
-                            data: [ 'abc', 'def', 'ghi', 'jkl' ]
+                            data: [ 'california', 'washington', 'state', 'france', 'china', 'russia', 'rust', 'river' , 'repression']
                         }
                     },
                     callback: {
                         onInit: function () {console.log('this is init') }
                     }
                 })
-
                 dialog.modal({
                         title: 'Execute Action',
-                        body: $('<div/>').append(searchfield),
+                        body: $('<div/>').append(form),
                         buttons: {
                             OK: {'class': 'btn-primary'}
-                        }
+                        },
+                        keyboard_manager: env.notebook.keyboard_manager
                     });
             }
         }

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -3,6 +3,8 @@
 
 define(function(require){
     "use strict";
+
+    var dialog = require("base/js/dialog");
     
     var ActionHandler = function (env) {
         this.env = env || {};
@@ -329,9 +331,25 @@ define(function(require){
             handler : function (env) {
                 env.pager.collapse();
             }
+        },
+        'quick-menu': {
+            help_index : 'aa', 
+            handler : function(env){
+                var searchfield = $('input').attr('type', 'text'); 
+
+                dialog.modal({
+                        title: 'Execute Action',
+                        body: $('<div/>')
+                            .append(searchfield)
+                        buttons: {
+                            OK: {'class': 'btn-primary'}
+                        }
+                    });
+            }
         }
 
     };
+
 
     /**
      * A bunch of `Advance actions` for Jupyter.

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -333,7 +333,9 @@ define(function(require){
             }
         },
         'command-palette': {
-            help_index : 'aa', 
+            help_index : 'aa',
+            help: 'open the command palette',
+            icon: 'fa-search',
             handler : function(env){
                 env.notebook.show_command_palette();
             }

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -332,15 +332,25 @@ define(function(require){
                 env.pager.collapse();
             }
         },
-        'quick-menu': {
+        'command-palette': {
             help_index : 'aa', 
             handler : function(env){
-                var searchfield = $('input').attr('type', 'text'); 
+                var searchfield = $('<input/>').attr('type', 'text'); 
+                searchfield.typeahead({
+                    order: "asc",
+                    source: {
+                        groupName: {
+                            data: [ 'abc', 'def', 'ghi', 'jkl' ]
+                        }
+                    },
+                    callback: {
+                        onInit: function () {console.log('this is init') }
+                    }
+                })
 
                 dialog.modal({
                         title: 'Execute Action',
-                        body: $('<div/>')
-                            .append(searchfield)
+                        body: $('<div/>').append(searchfield),
                         buttons: {
                             OK: {'class': 'btn-primary'}
                         }

--- a/notebook/static/notebook/js/commandpalette.js
+++ b/notebook/static/notebook/js/commandpalette.js
@@ -12,7 +12,7 @@ define(function(require){
         var field = $('<div/>').addClass('typeahead-field');
         var span = $('<span>').addClass('typeahead-query');
         var input = $('<input/>').attr('type', 'search');
-        span.append(input)
+        span.append(input);
         field
             .append(span)
             .append(
@@ -23,31 +23,36 @@ define(function(require){
                 )
             );
 
-        container.append(field)
-        form.append(container)
+        container.append(field);
+        form.append(container);
         var mod = dialog.modal({
             title: 'Execute Action',
             body: $('<div/>').append(form),
             keyboard_manager: notebook.keyboard_manager,
             show: false
         }).on('shown.bs.modal', function () {
-              input.focus()
+              input.focus();
         });
-        
+        var actions = Object.keys(IPython.notebook.keyboard_manager.actions._actions);
         input.typeahead({
             order: "asc",
             source: {
                 groupName: {
-                    data:  Object.keys(IPython.notebook.keyboard_manager.actions._actions)
+                    data:  actions
                 }
             },
             callback: {
                 onInit: function () {console.log('this is init') },
                 onSubmit: function (node, query, result, resultCount) {
                     console.log(node, query, result, resultCount);
-                    console.info(input.val(), 'has been selected')
-                    IPython.notebook.keyboard_manager.actions.call(input.val())
-                    mod.modal('hide')
+                    console.info(input.val(), 'has been selected');
+                    if (actions.indexOf(input.val()) >= 0) {
+                        IPython.notebook.keyboard_manager.actions.call(input.val());
+                    }
+                    else {
+                        console.log("No command " + input.val());
+                    }
+                    mod.modal('hide');
                 }
             }
         })

--- a/notebook/static/notebook/js/commandpalette.js
+++ b/notebook/static/notebook/js/commandpalette.js
@@ -13,7 +13,16 @@ define(function(require){
         var span = $('<span>').addClass('typeahead-query');
         var input = $('<input/>').attr('type', 'search');
         span.append(input)
-        field.append(span)
+        field
+            .append(span)
+            .append(
+                $('<span/>').addClass('typeahead-button').append(
+                    $('<button/>').attr('type', 'submit').append(
+                        $('<span/>').addClass('typeahead-search-icon')
+                        )
+                )
+            );
+
         container.append(field)
         form.append(container)
         input.typeahead({

--- a/notebook/static/notebook/js/commandpalette.js
+++ b/notebook/static/notebook/js/commandpalette.js
@@ -23,11 +23,11 @@ define(function(require){
      * wether an action have a keybinding or not.
      **/
     var get_mode_for_action_id = function(name, notebook) {
-      var shortcut = notebook.keyboard_manager.command_shortcuts.get_shortcut_for_action_name(name);
+      var shortcut = notebook.keyboard_manager.command_shortcuts.get_action_shortcut(name);
       if (shortcut) {
         return 'command-shortcut';
       }
-      shortcut = notebook.keyboard_manager.edit_shortcuts.get_shortcut_for_action_name(name);
+      shortcut = notebook.keyboard_manager.edit_shortcuts.get_action_shortcut(name);
       if (shortcut) {
         return 'edit-shortcut';
       }
@@ -133,8 +133,8 @@ define(function(require){
             display: 'display'
           };
 
-          var short = notebook.keyboard_manager.command_shortcuts.get_shortcut_for_action_name(action_id) ||
-            notebook.keyboard_manager.edit_shortcuts.get_shortcut_for_action_name(action_id);
+          var short = notebook.keyboard_manager.command_shortcuts.get_action_shortcut(action_id) ||
+            notebook.keyboard_manager.edit_shortcuts.get_action_shortcut(action_id);
           if (short) {
             short = QH.humanize_sequence(short);
           }

--- a/notebook/static/notebook/js/commandpalette.js
+++ b/notebook/static/notebook/js/commandpalette.js
@@ -101,6 +101,8 @@ define(function(require){
                     key:actions[i],
                     modesht: mode(actions[i]),
                     group:group,
+                    icon: IPython.keyboard_manager.actions.get(actions[i]).icon,
+                    help: IPython.keyboard_manager.actions.get(actions[i]).help
                    })
         }
         input.typeahead({
@@ -111,7 +113,7 @@ define(function(require){
             group: ["group", "{{group}} extension"],
             searchOnFocus: true,
             mustSelectItem: true,
-            template: '{{display}}  <div class="pull-right {{modesht}}"><kbd>{{shortcut}}</kbd></div>',
+            template: '<i class="fa fa-icon {{icon}}"></i>{{display}}  <div class="pull-right {{modesht}}"><kbd>{{shortcut}}</kbd></div>',
             order: "asc",
             source: src,
             callback: {

--- a/notebook/static/notebook/js/commandpalette.js
+++ b/notebook/static/notebook/js/commandpalette.js
@@ -1,0 +1,41 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+define(function(require){
+    "use strict";
+
+    var $ = require("jquery");
+    var dialog = require("base/js/dialog");
+    var CommandPalette = function(notebook) {
+        var form = $('<form/>');
+        var container = $('<div/>').addClass('typeahead-container');
+        var field = $('<div/>').addClass('typeahead-field');
+        var span = $('<span>').addClass('typeahead-query');
+        var input = $('<input/>').attr('type', 'search');
+        span.append(input)
+        field.append(span)
+        container.append(field)
+        form.append(container)
+        input.typeahead({
+            order: "asc",
+            source: {
+                groupName: {
+                    data: [ 'california', 'washington', 'state', 'france', 'china', 'russia', 'rust', 'river' , 'repression']
+                }
+            },
+            callback: {
+                onInit: function () {console.log('this is init') }
+            }
+        })
+        dialog.modal({
+            title: 'Execute Action',
+            body: $('<div/>').append(form),
+            buttons: {
+                OK: {'class': 'btn-primary'}
+            },
+            keyboard_manager: notebook.keyboard_manager
+        });
+    }
+    return {'CommandPalette': CommandPalette};
+});
+

--- a/notebook/static/notebook/js/commandpalette.js
+++ b/notebook/static/notebook/js/commandpalette.js
@@ -29,7 +29,7 @@ define(function(require){
             order: "asc",
             source: {
                 groupName: {
-                    data: [ 'california', 'washington', 'state', 'france', 'china', 'russia', 'rust', 'river' , 'repression']
+                    data:  Object.keys(IPython.notebook.keyboard_manager.actions._actions)
                 }
             },
             callback: {

--- a/notebook/static/notebook/js/commandpalette.js
+++ b/notebook/static/notebook/js/commandpalette.js
@@ -25,6 +25,15 @@ define(function(require){
 
         container.append(field)
         form.append(container)
+        var mod = dialog.modal({
+            title: 'Execute Action',
+            body: $('<div/>').append(form),
+            keyboard_manager: notebook.keyboard_manager,
+            show: false
+        }).on('shown.bs.modal', function () {
+              input.focus()
+        });
+        
         input.typeahead({
             order: "asc",
             source: {
@@ -33,17 +42,17 @@ define(function(require){
                 }
             },
             callback: {
-                onInit: function () {console.log('this is init') }
+                onInit: function () {console.log('this is init') },
+                onSubmit: function (node, query, result, resultCount) {
+                    console.log(node, query, result, resultCount);
+                    console.info(input.val(), 'has been selected')
+                    IPython.notebook.keyboard_manager.actions.call(input.val())
+                    mod.modal('hide')
+                }
             }
         })
-        dialog.modal({
-            title: 'Execute Action',
-            body: $('<div/>').append(form),
-            buttons: {
-                OK: {'class': 'btn-primary'}
-            },
-            keyboard_manager: notebook.keyboard_manager
-        });
+
+        mod.modal('show')
     }
     return {'CommandPalette': CommandPalette};
 });

--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -84,6 +84,7 @@ define([
 
     KeyboardManager.prototype.get_default_command_shortcuts = function() {
         return {
+            'cmd-shift-P': 'ipython.command-palette',
             'shift-space': 'ipython.scroll-up',
             'shift-v' : 'ipython.paste-cell-before',
             'shift-m' : 'ipython.merge-selected-cells',

--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -73,6 +73,7 @@ define([
 
     KeyboardManager.prototype.get_default_edit_shortcuts = function() {
         return {
+            'cmdtrl-shift-p'      : 'ipython.command-palette',
             'esc'                 : 'ipython.go-to-command-mode',
             'ctrl-m'              : 'ipython.go-to-command-mode',
             'up'                  : 'ipython.move-cursor-up-or-previous-cell',
@@ -84,7 +85,7 @@ define([
 
     KeyboardManager.prototype.get_default_command_shortcuts = function() {
         return {
-            'shift-p': 'ipython.command-palette',
+            'cmdtrl-shift-p': 'ipython.command-palette',
             'shift-space': 'ipython.scroll-up',
             'shift-v' : 'ipython.paste-cell-before',
             'shift-m' : 'ipython.merge-selected-cells',

--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -84,7 +84,7 @@ define([
 
     KeyboardManager.prototype.get_default_command_shortcuts = function() {
         return {
-            'cmd-shift-P': 'ipython.command-palette',
+            'shift-p': 'ipython.command-palette',
             'shift-space': 'ipython.scroll-up',
             'shift-v' : 'ipython.paste-cell-before',
             'shift-m' : 'ipython.merge-selected-cells',

--- a/notebook/static/notebook/js/main.js
+++ b/notebook/static/notebook/js/main.js
@@ -22,6 +22,7 @@ require([
     'notebook/js/kernelselector',
     'codemirror/lib/codemirror',
     'notebook/js/about',
+    'typeahead',
     // only loaded, not used, please keep sure this is loaded last
     'custom/custom'
 ], function(
@@ -45,6 +46,7 @@ require([
     kernelselector,
     CodeMirror,
     about,
+    typeahead,
     // please keep sure that even if not used, this is loaded last
     custom
     ) {

--- a/notebook/static/notebook/js/maintoolbar.js
+++ b/notebook/static/notebook/js/maintoolbar.js
@@ -55,7 +55,8 @@ define([
             ],
             'run_int'],
          ['<add_celltype_list>'],
-         ['<add_celltoolbar_list>']
+         ['<add_celltoolbar_list>'],
+         [['ipython.command-palette']]
         ];
         this.construct(grps);
     };

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -172,8 +172,7 @@ define(function (require) {
         // ii) to prevent the div from scrolling up when the last cell is being
         // edited, but is too low on the page, which browsers will do automatically.
         var end_space = $('<div/>')
-            .addClass('end_space')
-            .html('<kbd>Cmd-Shift-P</kbd> for Command palette');
+            .addClass('end_space');
         end_space.dblclick(function (e) {
             var ncells = that.ncells();
             that.insert_cell_below('code',ncells-1);

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -27,6 +27,7 @@ define(function (require) {
     var rawcell_celltoolbar = require('notebook/js/celltoolbarpresets/rawcell');
     var slideshow_celltoolbar = require('notebook/js/celltoolbarpresets/slideshow');
     var scrollmanager = require('notebook/js/scrollmanager');
+    var commandpalette = require('notebook/js/commandpalette');
 
     /**
      * Contains and manages cells.
@@ -319,6 +320,11 @@ define(function (require) {
         };
     };
     
+
+    Notebook.prototype.show_command_palette = function() {
+        var x = new commandpalette.CommandPalette(this);
+    }
+
     /**
      * Trigger a warning dialog about missing functionality from newer minor versions
      */

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -171,7 +171,9 @@ define(function (require) {
         // i) provide a margin between the last cell and the end of the notebook
         // ii) to prevent the div from scrolling up when the last cell is being
         // edited, but is too low on the page, which browsers will do automatically.
-        var end_space = $('<div/>').addClass('end_space');
+        var end_space = $('<div/>')
+            .addClass('end_space')
+            .html('<kbd>Cmd-Shift-P</kbd> for Command palette');
         end_space.dblclick(function (e) {
             var ncells = that.ncells();
             that.insert_cell_below('code',ncells-1);

--- a/notebook/static/notebook/js/quickhelp.js
+++ b/notebook/static/notebook/js/quickhelp.js
@@ -70,6 +70,7 @@ define([
         // these are the standard symbol that are used in MacOS native menus
         // cf http://apple.stackexchange.com/questions/55727/
         // for htmlentities and/or unicode value
+        'meta':'⌘',
         'cmd':'⌘',
         'shift':'⇧',
         'alt':'⌥',
@@ -98,6 +99,7 @@ define([
     var default_humanize_map = {
         'shift':'Shift',
         'alt':'Alt',
+        'meta': 'Alt',
         'up':'Up',
         'down':'Down',
         'left':'Left',
@@ -144,7 +146,7 @@ define([
         var sh = _.map(shortcut.split('-'), humanize_key ).join(joinchar);
         return sh;
     }
-
+    
 
     QuickHelp.prototype.show_keyboard_shortcuts = function () {
         /**
@@ -292,5 +294,7 @@ define([
         return div;
     };
 
-    return {'QuickHelp': QuickHelp};
+    return {'QuickHelp': QuickHelp,
+      humanize_shortcut: humanize_shortcut
+  };
 });

--- a/notebook/static/notebook/less/commandpalette.less
+++ b/notebook/static/notebook/less/commandpalette.less
@@ -1,0 +1,39 @@
+ul.typeahead-list i{
+    margin-left: -10px;
+    width: 18px;
+}
+
+ul.typeahead-list {
+  max-height: 80vh;
+  overflow:auto;
+}
+
+.cmd-palette {
+  & .modal-body{
+    padding: 7px;
+  }
+  
+  & form {
+    background: white;
+  }
+  
+  & input {
+    outline:none;
+  }
+}
+
+.no-shortcut{
+    display:none;
+}
+
+.command-shortcut:before{
+    content:"(command)";
+    padding-right:3px;
+    color:@gray-light;
+}
+
+.edit-shortcut:before{
+    content:"(edit)";
+    padding-right:3px;
+    color:@gray-light;
+}

--- a/notebook/static/notebook/less/notebook.less
+++ b/notebook/static/notebook/less/notebook.less
@@ -88,3 +88,19 @@ p {
         background-color: @page-backdrop-color;
     }
 }
+
+
+kbd{
+    border-radius: 5px;
+    &.command-sht{
+       color: #80DBC4; 
+    }
+
+    &.edit-sht{
+        color: #CABD81
+    }
+
+    &.no-sht{
+        display:none;
+    }
+}

--- a/notebook/static/notebook/less/notebook.less
+++ b/notebook/static/notebook/less/notebook.less
@@ -89,18 +89,18 @@ p {
     }
 }
 
-
-kbd{
-    border-radius: 5px;
-    &.command-sht{
-       color: #80DBC4; 
-    }
-
-    &.edit-sht{
-        color: #CABD81
-    }
-
-    &.no-sht{
+.no-sht{
         display:none;
-    }
+}
+
+.command-sht:before{
+    content:"(command)";
+    padding-right:3px;
+    color:#ccc
+}
+
+.edit-sht:before{
+    content:"(edit)";
+    padding-right:3px;
+    color:#ccc
 }

--- a/notebook/static/notebook/less/notebook.less
+++ b/notebook/static/notebook/less/notebook.less
@@ -135,3 +135,8 @@ ul.typeahead-list i{
     width: 18px;
     border: thin solid transparent;
 }
+
+ul.typeahead-list {
+  max-height: 80vh;
+  overflow:auto;
+}

--- a/notebook/static/notebook/less/notebook.less
+++ b/notebook/static/notebook/less/notebook.less
@@ -89,22 +89,6 @@ p {
     }
 }
 
-.no-shortcut{
-    display:none;
-}
-
-.command-shortcut:before{
-    content:"(command)";
-    padding-right:3px;
-    color:@gray-light;
-}
-
-.edit-shortcut:before{
-    content:"(edit)";
-    padding-right:3px;
-    color:@gray-light;
-}
-
 kbd {
     border-style: solid;
     border-width: 1px;
@@ -114,14 +98,4 @@ kbd {
     padding-right: 2px;
     padding-top: 1px;
     padding-bottom: 1px;
-}
-
-ul.typeahead-list i{
-    margin-left: -10px;
-    width: 18px;
-}
-
-ul.typeahead-list {
-  max-height: 80vh;
-  overflow:auto;
 }

--- a/notebook/static/notebook/less/notebook.less
+++ b/notebook/static/notebook/less/notebook.less
@@ -104,3 +104,28 @@ p {
     padding-right:3px;
     color:#ccc
 }
+
+.end_space {
+
+    margin-left: auto;
+    margin-right:auto;
+    margin-top:50px;
+    font-size: 20pt;
+    font-weight: bold;
+    width:500px;
+    color: #aaa;
+    
+    & kbd {
+      color: #aaa;
+      border-color: #aaa;
+    }
+
+}
+
+kbd {
+    background: transparent;
+    border: 1px solid #888;
+    box-shadow: none;
+    border-radius: 5px;
+    color: #888;
+}

--- a/notebook/static/notebook/less/notebook.less
+++ b/notebook/static/notebook/less/notebook.less
@@ -129,3 +129,9 @@ kbd {
     border-radius: 5px;
     color: #888;
 }
+
+ul.typeahead-list i{
+    margin-left: -10px;
+    width: 18px;
+    border: thin solid transparent;
+}

--- a/notebook/static/notebook/less/notebook.less
+++ b/notebook/static/notebook/less/notebook.less
@@ -96,38 +96,19 @@ p {
 .command-shortcut:before{
     content:"(command)";
     padding-right:3px;
-    color:#ccc
+    color:@gray-light;
 }
 
 .edit-shortcut:before{
     content:"(edit)";
     padding-right:3px;
-    color:#ccc
-}
-
-.end_space {
-
-    margin-left: auto;
-    margin-right:auto;
-    margin-top:50px;
-    font-size: 20pt;
-    font-weight: bold;
-    width:500px;
-    color: #aaa;
-    
-    & kbd {
-      color: #aaa;
-      border-color: #aaa;
-    }
-
+    color:@gray-light;
 }
 
 kbd {
-    background: transparent;
-    border: 1px solid #888;
+    border-style: solid;
+    border-width: 1px;
     box-shadow: none;
-    border-radius: 3px;
-    color: #888;
     margin: 2px;
     padding-left: 2px;
     padding-right: 2px;
@@ -138,7 +119,6 @@ kbd {
 ul.typeahead-list i{
     margin-left: -10px;
     width: 18px;
-    border: thin solid transparent;
 }
 
 ul.typeahead-list {

--- a/notebook/static/notebook/less/notebook.less
+++ b/notebook/static/notebook/less/notebook.less
@@ -89,17 +89,17 @@ p {
     }
 }
 
-.no-sht{
-        display:none;
+.no-shortcut{
+    display:none;
 }
 
-.command-sht:before{
+.command-shortcut:before{
     content:"(command)";
     padding-right:3px;
     color:#ccc
 }
 
-.edit-sht:before{
+.edit-shortcut:before{
     content:"(edit)";
     padding-right:3px;
     color:#ccc
@@ -126,8 +126,13 @@ kbd {
     background: transparent;
     border: 1px solid #888;
     box-shadow: none;
-    border-radius: 5px;
+    border-radius: 3px;
     color: #888;
+    margin: 2px;
+    padding-left: 2px;
+    padding-right: 2px;
+    padding-top: 1px;
+    padding-bottom: 1px;
 }
 
 ul.typeahead-list i{

--- a/notebook/static/notebook/less/quickhelp.less
+++ b/notebook/static/notebook/less/quickhelp.less
@@ -1,5 +1,6 @@
 .quickhelp {
     .hbox();
+    line-height: 1.8em;
 }
 .shortcut_key {
     display: inline-block;
@@ -12,4 +13,3 @@
     display: inline-block;
     .box-flex1();
 }
-

--- a/notebook/static/style/style.less
+++ b/notebook/static/style/style.less
@@ -28,6 +28,7 @@
 
 // notebook
 @import "../notebook/less/style.less";
+@import "../notebook/less/commandpalette.less";
 
 // terminal
 @import "../terminal/less/terminal.less";

--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -37,8 +37,13 @@
             moment: 'components/moment/moment',
             codemirror: 'components/codemirror',
             termjs: 'components/term.js/src/term',
+            typeahead: 'components/jquery-typeahead/dist/jquery.typeahead'
           },
           shim: {
+            typeahead: {
+              deps: ["jquery"],
+              exports: "typeahead"
+            },
             underscore: {
               exports: '_'
             },

--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="{{ base_url }}custom/custom.css" type="text/css" />
     <script src="{{static_url("components/es6-promise/promise.min.js")}}" type="text/javascript" charset="utf-8"></script>
     <script src="{{static_url("components/requirejs/require.js") }}" type="text/javascript" charset="utf-8"></script>
+    <script src="{{static_url("components/jquery-typeahead/dist/jquery.typeahead.css") }}" type="text/javascript" charset="utf-8"></script>
     <script>
       require.config({
           {% if version_hash %}

--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -8,6 +8,7 @@
     {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="{{static_url("base/images/favicon.ico") }}">{% endblock %}
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link rel="stylesheet" href="{{static_url("components/jquery-ui/themes/smoothness/jquery-ui.min.css") }}" type="text/css" />
+    <link rel="stylesheet" href="{{static_url("components/jquery-typeahead/dist/jquery.typeahead.min.css") }}" type="text/css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     {% block stylesheet %}
@@ -16,7 +17,6 @@
     <link rel="stylesheet" href="{{ base_url }}custom/custom.css" type="text/css" />
     <script src="{{static_url("components/es6-promise/promise.min.js")}}" type="text/javascript" charset="utf-8"></script>
     <script src="{{static_url("components/requirejs/require.js") }}" type="text/javascript" charset="utf-8"></script>
-    <script src="{{static_url("components/jquery-typeahead/dist/jquery.typeahead.css") }}" type="text/javascript" charset="utf-8"></script>
     <script>
       require.config({
           {% if version_hash %}

--- a/notebook/tests/base/keyboard.js
+++ b/notebook/tests/base/keyboard.js
@@ -13,6 +13,13 @@ var to_normalize = [
 var unshifted = "` 1 2 3 4 5 6 7 8 9 0 - = q w e r t y u i o p [ ] \\ a s d f g h j k l ; ' z x c v b n m , . /";
 //  shifted   = '~ ! @ # $ % ^ & * ( ) _ + Q W E R T Y U I O P { } |  A S D F G H J K L : " Z X C V B N M < > ?';
 
+var ambiguous_expect = function(ch){
+    // `-` is ambiguous in shortcut context as a separator, so map it to `minus`
+    if(ch === '-'){
+        return 'minus';
+    }
+    return ch;
+};
 
 casper.notebook_test(function () {
     var that = this;
@@ -24,7 +31,7 @@ casper.notebook_test(function () {
                 var sc2 = IPython.keyboard.event_to_shortcut(e);
                 return sc2;
             }, item);
-            this.test.assertEquals(result, item, 'Shortcut to event roundtrip: '+item);
+            this.test.assertEquals(result, ambiguous_expect(item), 'Shortcut to event roundtrip: '+item);
         });
     });
 

--- a/tools/build-main.js
+++ b/tools/build-main.js
@@ -22,9 +22,14 @@ var rjs_config = {
     moment: 'components/moment/moment',
     codemirror: 'components/codemirror',
     termjs: 'components/term.js/src/term',
+    typeahead: 'components/jquery-typeahead/dist/jquery.typeahead',
     contents: 'empty:'
   },
   shim: {
+    typeahead: {
+            deps: ["jquery"],
+            exports: "typeahead"
+          },
     underscore: {
       exports: '_'
     },


### PR DESCRIPTION
Mainly openig PR to start discussion. 

I would like to start working on a **command palette** (cf atom screenshot) for the notebook. Something aka Mac OS Spotlight. It's called **command palette** in atom, so let's use this name, we can bikeshed on the name later. 

This would allow to expose a much bigger number of action to end-user without binding to a keyboard shortcut, and made them easy to find.

From a prototype I did at SciPy, I think it can be done correctly in about a week. 
And by correctly I mean with respect to the current API we have for the notebook. We all know that current API is not perfect, but we have enough hook to make something useful in a short amount of time.

I think it would be nice small project with high visibility and rapid user feedback that might help a lot of user and push for 4.1 adoption. Also one of the things I enjoyed when joining the project was to get small things that help people a lot. We might also want some design work to be done on the UI. 
So I think it would be a nice project for @svurens, @jdfreder and me to collaborate on. 

Technically I am torn in between twitter [typeahead](https://github.com/twitter/typeahead.js) and jQuery [typeahead](http://www.runningcoder.org/jquerytypeahead/), twitter one have stalled since April, so I went for second one. So I have no issue if we change. 

Thought ? Would @svurens like to work on that ?

--- 

<img width="1453" alt="screen shot 2015-08-05 at 14 23 15" src="https://cloud.githubusercontent.com/assets/335567/9098363/41e18250-3b7e-11e5-8c49-96c7adad25cf.png">