### PR TITLE
Multi-cell selection

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -310,6 +310,13 @@ define(function(require){
                 env.notebook.merge_cell_below();
             }
         },
+        'merge-selected-cells' : {
+            help : 'merge selected cells',
+            help_index: 'el',
+            handler: function(env) {
+                env.notebook.merge_selected_cells();
+            }
+        },
         'close-pager' : {
             help_index : 'gd',
             handler : function (env) {

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -105,8 +105,8 @@ define(function(require){
             help_index : 'dc',
             handler : function (env) {
                 var index = env.notebook.get_selected_index();
-                if (index !== (env.notebook.ncells()-1) && index !== null) {
-                    env.notebook.select_prev(true);
+                if (index !== 0 && index !== null) {
+                    env.notebook.extend_selection('up');
                     env.notebook.focus_cell();
                 }
             }
@@ -117,7 +117,7 @@ define(function(require){
             handler : function (env) {
                 var index = env.notebook.get_selected_index();
                 if (index !== (env.notebook.ncells()-1) && index !== null) {
-                    env.notebook.select_next(true);
+                    env.notebook.extend_selection('down');
                     env.notebook.focus_cell();
                 }
             }

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -122,6 +122,13 @@ define(function(require){
                 }
             }
         },
+        'reset-selection': {
+            help: 'clear selected cells',
+            help_index: 'de',
+            handler: function(env) {
+                env.notebook.reset_selection();
+            }
+        },
         'cut-selected-cell' : {
             icon: 'fa-cut',
             help_index : 'ee',

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -100,6 +100,28 @@ define(function(require){
                 }
             }
         },
+        'extend-selection-previous' : {
+            help: 'extend selection above',
+            help_index : 'dc',
+            handler : function (env) {
+                var index = env.notebook.get_selected_index();
+                if (index !== (env.notebook.ncells()-1) && index !== null) {
+                    env.notebook.select_prev(true);
+                    env.notebook.focus_cell();
+                }
+            }
+        },
+        'extend-selection-next' : {
+            help: 'extend selection below',
+            help_index : 'dd',
+            handler : function (env) {
+                var index = env.notebook.get_selected_index();
+                if (index !== (env.notebook.ncells()-1) && index !== null) {
+                    env.notebook.select_next(true);
+                    env.notebook.focus_cell();
+                }
+            }
+        },
         'cut-selected-cell' : {
             icon: 'fa-cut',
             help_index : 'ee',

--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -55,6 +55,7 @@ define([
         
         this.placeholder = config.placeholder || '';
         this.selected = false;
+        this.in_selection = false;
         this.rendered = false;
         this.mode = 'command';
 
@@ -142,7 +143,7 @@ define([
          * Call after this.element exists to initialize the css classes
          * related to selected, rendered and mode.
          */
-        if (this.selected) {
+        if (this.in_selection) {
             this.element.addClass('selected');
         } else {
             this.element.addClass('unselected');
@@ -254,6 +255,7 @@ define([
             this.element.addClass('selected');
             this.element.removeClass('unselected');
             this.selected = true;
+            this.in_selection = true;
             return true;
         } else {
             return false;
@@ -261,19 +263,20 @@ define([
     };
 
     /**
-     * handle cell level logic when a cell is unselected
+     * handle cell level logic when the cursor moves away from a cell
      * @method unselect
+     * @param {bool} leave_selected - true to move cursor away and extend selection
      * @return is the action being taken
      */
-    Cell.prototype.unselect = function () {
-        if (this.selected) {
+    Cell.prototype.unselect = function (leave_selected) {
+        var was_selected_cell = this.selected;
+        this.selected = false;
+        if ((!leave_selected) && this.in_selection) {
+            this.in_selection = false;
             this.element.addClass('unselected');
             this.element.removeClass('selected');
-            this.selected = false;
-            return true;
-        } else {
-            return false;
         }
+        return was_selected_cell;
     };
 
     /**

--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -56,6 +56,7 @@ define([
         this.placeholder = config.placeholder || '';
         this.selected = false;
         this.in_selection = false;
+        this.selection_anchor = false;
         this.rendered = false;
         this.mode = 'command';
 
@@ -273,6 +274,7 @@ define([
         this.selected = false;
         if ((!leave_selected) && this.in_selection) {
             this.in_selection = false;
+            this.selection_anchor = false;
             this.element.addClass('unselected');
             this.element.removeClass('selected');
         }

--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -535,14 +535,14 @@ define([
     };
 
     /**
-     * handle cell level logic when a cell is unselected
+     * handle cell level logic when the cursor moves away from a cell
      * @method unselect
      * @return is the action being taken
      */
-    CodeCell.prototype.unselect = function () {
-        var cont = Cell.prototype.unselect.apply(this);
+    CodeCell.prototype.unselect = function (leave_selected) {
+        var cont = Cell.prototype.unselect.apply(this, [leave_selected]);
         if (cont) {
-            // When a code cell is usnelected, make sure that the corresponding
+            // When a code cell is unselected, make sure that the corresponding
             // tooltip and completer to that cell is closed.
             this.tooltip.remove_and_cancel_tooltip(true);
             if (this.completer !== null) {

--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -86,7 +86,7 @@ define([
         return {
             'shift-space': 'ipython.scroll-up',
             'shift-v' : 'ipython.paste-cell-before',
-            'shift-m' : 'ipython.merge-selected-cell-with-cell-after',
+            'shift-m' : 'ipython.merge-selected-cells',
             'shift-o' : 'ipython.toggle-output-scrolling-selected-cell',
             'enter' : 'ipython.enter-edit-mode',
             'space' : 'ipython.scroll-down',

--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -98,6 +98,8 @@ define([
             'up' : 'ipython.select-previous-cell',
             'k' : 'ipython.select-previous-cell',
             'j' : 'ipython.select-next-cell',
+            'shift-k': 'ipython.extend-selection-previous',
+            'shift-j': 'ipython.extend-selection-next',
             'x' : 'ipython.cut-selected-cell',
             'c' : 'ipython.copy-selected-cell',
             'v' : 'ipython.paste-cell-after',

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -725,6 +725,18 @@ define(function (require) {
         return true;
     };
 
+    /**
+     * Clear selection of multiple cells (except the cell at the cursor)
+     */
+    Notebook.prototype.reset_selection = function() {
+        var current_selection = this.get_selected_cells();
+        for (var i=0; i<current_selection.length; i++) {
+            if (!current_selection[i].selected) {
+                current_selection[i].unselect()
+            }
+        }
+    };
+
 
     // Edit/Command mode
 
@@ -778,6 +790,7 @@ define(function (require) {
         if (cell && this.mode !== 'edit') {
             cell.edit_mode();
             this.mode = 'edit';
+            this.reset_selection();
             this.events.trigger('edit_mode.Notebook');
             this.keyboard_manager.edit_mode();
         }

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1370,6 +1370,12 @@ define(function (require) {
         }
     };
 
+    /**
+     * Merge a series of cells into one
+     *
+     * @param {Array} indices - the numeric indices of the cells to be merged
+     * @param {bool} into_last - merge into the last cell instead of the first
+     */
     Notebook.prototype.merge_cells = function(indices, into_last) {
         if (indices.length <= 1) {
             return;

--- a/notebook/tests/notebook/dualmode_merge.js
+++ b/notebook/tests/notebook/dualmode_merge.js
@@ -1,7 +1,7 @@
 
 // Test
 casper.notebook_test(function () {
-    var a = 'ab\ncd';
+    var a = 'ab\n\ncd';
     var b = 'print("b")';
     var c = 'print("c")';
 
@@ -41,6 +41,7 @@ casper.notebook_test(function () {
         this.test.assertEquals(this.get_cell_text(1), 'cd', 'split; Verify that cell 1 has the second half.');
         this.validate_notebook_state('split', 'edit', 1);
         this.select_cell(0); // Move up to cell 0
+        this.evaluate(function() { IPython.notebook.extend_selection('down');});
         this.trigger_keydown('shift-m'); // Merge
         this.validate_notebook_state('merge', 'command', 0);
         this.test.assertEquals(this.get_cell_text(0), a, 'merge; Verify that cell 0 has the merged contents.');

--- a/notebook/tests/notebook/merge_cells_api.js
+++ b/notebook/tests/notebook/merge_cells_api.js
@@ -36,8 +36,8 @@ casper.notebook_test(function() {
         return IPython.notebook.get_selected_cell().get_text();
     });
     
-    this.test.assertEquals(output_above, 'a = 5\nprint(a)',
+    this.test.assertEquals(output_above, 'a = 5\n\nprint(a)',
                            'Successful merge_cell_above().');
-    this.test.assertEquals(output_below, 'a = 5\nprint(a)',
+    this.test.assertEquals(output_below, 'a = 5\n\nprint(a)',
                            'Successful merge_cell_below().');
 });


### PR DESCRIPTION
From discussion the other day: we are thinking of accepting some new features into 4.x releases, so that we can keep the user experience moving forwards while people are working on refactoring all the frontend stuff.

Multi-cell selection is perhaps the biggest thing that we've been wanting to add for a long time, so I thought I'd take a crack at it. It turned out not to be too bad (so far...).

Use: shift+j/k to select a range of cells, shift+m to merge the selected range. I haven't yet changed all the other actions which should now be able to affect a range of cells, but doing so should be mostly straightforward.

API: I've tried to keep existing API working, so stuff that assumes the selection is a single cell will act on the cell at the cursor - the most recently selected one. This makes some names a bit confusing - e.g. `Cell.unselect()` now has a `leave_selected` parameter (to move the cursor away without actually unselecting). The notebook has some very similarly named methods, like `get_selected_cell()` and `get_selected_cells()`.