### PR TITLE
use mathjax component

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "jquery": "components/jquery#~2.0",
     "jquery-ui": "components/jqueryui#~1.10",
     "marked": "~0.3",
-    "MathJax": "~2.5",
+    "MathJax": "components/MathJax#~2.5",
     "moment": "~2.8.4",
     "requirejs": "~2.1",
     "term.js": "chjj/term.js#~0.0.4",


### PR DESCRIPTION
which lacks the png fonts

for quicker installs, etc.

closes #248