### PR TITLE
Cut, copy, paste and delete acting on multiple cells

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -943,6 +943,7 @@ define(function (require) {
         // Always make sure we have at least one cell.
         if (new_ncells === 0) {
             this.insert_cell_below('code');
+            new_ncells = 1;
         }
 
         this.undelete_below = false;


### PR DESCRIPTION
This adapts cut, copy, paste and delete to act on the selected range of cells, using the APIs defined in the recent multicell selection PR. This should be a big improvement for editing larger notebooks.