### PR TITLE
leave empty commit hash when none found

### DIFF
--- a/notebook/_sysinfo.py
+++ b/notebook/_sysinfo.py
@@ -46,7 +46,7 @@ def pkg_commit_hash(pkg_path):
     repo_commit, _ = proc.communicate()
     if repo_commit:
         return 'repository', repo_commit.strip().decode('ascii')
-    return '(none found)', u'<not found>'
+    return u'', u''
 
 
 def pkg_info(pkg_path):


### PR DESCRIPTION
avoids `4.0.1-<none found>` message for stable releases in About panel

Reported by @jmcorgan