### PR TITLE
Add rel=noreferrer to helplink URLs as sending the referrer link is unnecessary

### DIFF
--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -267,7 +267,7 @@ data-notebook-path="{{notebook_path}}"
 
                         {% for helplinks in sections %}
                             {% for link in helplinks %}
-                                <li><a href="{{link[0]}}" {{'target="_blank" title="Opens in a new window"' if link[2]}}>
+                                <li><a rel="noreferrer" href="{{link[0]}}" {{'target="_blank" title="Opens in a new window"' if link[2]}}>
                                 {{'<i class="fa fa-external-link menu-icon pull-right"></i>' if link[2]}}
                                 {{link[1]}}
                                 </a></li>


### PR DESCRIPTION
Currently, links that go to external sites are getting the referrer
url, which for things like tmpnb, is a secret. This avoids us sending
along unnecessary information to possibly third party sites.