### PR TITLE
Fix symlink issue with Win/Py2

### DIFF
--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -148,6 +148,10 @@ def install_nbextension(path, overwrite=False, symlink=False, user=False, prefix
     # make sure nbextensions dir exists
     ensure_dir_exists(nbext)
     
+    # forcing symlink parameter to False if os.symlink does not exist (e.g., on Windows machines running python 2)
+    if 'symlink' not in dir(os):
+        symlink = False
+    
     if isinstance(path, (list, tuple)):
         raise TypeError("path must be a string pointing to a single extension to install; call this function multiple times to install multiple extensions")
     


### PR DESCRIPTION
Addresses issue #302 by adding check for symlink before using. (Alternative workaround already available for symlink=False, so just sets parameter as such if os.symlink does not exist.)