### PR TITLE
clusterlist is no longer part of jupyter/notebook

### DIFF
--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -72,8 +72,6 @@ define(function(){
 
     // tree
     jglobal('SessionList','tree/js/sessionlist');
-    jglobal('ClusterList','tree/js/clusterlist');
-    jglobal('ClusterItem','tree/js/clusterlist');
 
     Jupyter.version = "4.1.0.dev";
     Jupyter._target = '_blank';


### PR DESCRIPTION
These probably shouldn't be in the namespace now that the javascript doesn't exist in jupyter/notebook anymore.