### PR TITLE
install MathJax safe config

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -150,6 +150,7 @@ def find_package_data():
     static_data.extend([
         mj('MathJax.js'),
         mj('config', 'TeX-AMS_HTML-full.js'),
+        mj('config', 'Safe.js'),
         mj('jax', 'output', 'HTML-CSS', '*.js'),
     ])
     for tree in [


### PR DESCRIPTION
MathJax safe mode is enabled, but a full (non-dev) install omits the Safe.js config file, causing it to fail to load.