### PR TITLE
Added fix for merge above on topmost cell to resolve #330

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1447,8 +1447,9 @@ define(function (require) {
             return;
         }
 
-        // Check if trying to merge above on topmost cell
-        if (indices.indexOf(-1) > -1) {
+        // Check if trying to merge above on topmost cell or wrap around
+        // when merging above, see #330
+        if (indices.filter(function(item) {return item < 0}).length > 0) {
             return;
         }
 

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1496,7 +1496,9 @@ define(function (require) {
      */
     Notebook.prototype.merge_cell_above = function () {
         var index = this.get_selected_index();
-        this.merge_cells([index-1, index], true)
+        if (index != 0) {
+            this.merge_cells([index-1, index], true)
+        }
     };
 
     /**

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1446,6 +1446,12 @@ define(function (require) {
         if (indices.length <= 1) {
             return;
         }
+
+        // Check if trying to merge above on topmost cell
+        if (indices.indexOf(-1) > -1) {
+            return;
+        }
+
         for (var i=0; i < indices.length; i++) {
             if (!this.get_cell(indices[i]).is_mergeable()) {
                 return;
@@ -1496,9 +1502,7 @@ define(function (require) {
      */
     Notebook.prototype.merge_cell_above = function () {
         var index = this.get_selected_index();
-        if (index != 0) {
-            this.merge_cells([index-1, index], true)
-        }
+        this.merge_cells([index-1, index], true)
     };
 
     /**

--- a/notebook/tests/notebook/dualmode_merge.js
+++ b/notebook/tests/notebook/dualmode_merge.js
@@ -79,7 +79,7 @@ casper.notebook_test(function () {
         this.test.assertEquals(this.get_cell_text(0), a, 'Merge cell 0 above: Cell 0 is unchanged');
         this.test.assertEquals(this.get_cell_text(1), b, 'Merge cell 0 above: Cell 1 is unchanged');
         this.test.assertEquals(this.get_cell_text(2), c, 'Merge cell 0 above: Cell 2 is unchanged');
-        this.validate_notebook_state('merge up', command, 0);
+        this.validate_notebook_state('merge up', 'command', 0);
     });
 
     // Try to merge cell 0 below with cell 1

--- a/notebook/tests/notebook/dualmode_merge.js
+++ b/notebook/tests/notebook/dualmode_merge.js
@@ -67,6 +67,21 @@ casper.notebook_test(function () {
         this.test.assert(cell_is_mergeable(2), 'Cell 2 is mergeable');
     });
 
+    // Try to merge cell 0 above, nothing should happen
+    this.then(function () {
+        this.select_cell(0);
+    });
+    this.thenEvaluate(function() {
+        IPython.notebook.merge_cell_above();
+    });
+    this.then(function() {
+        this.test.assertEquals(this.get_cells_length(), 3, 'Merge cell 0 above: There are still 3 cells');
+        this.test.assertEquals(this.get_cell_text(0), a, 'Merge cell 0 above: Cell 0 is unchanged');
+        this.test.assertEquals(this.get_cell_text(1), b, 'Merge cell 0 above: Cell 1 is unchanged');
+        this.test.assertEquals(this.get_cell_text(2), c, 'Merge cell 0 above: Cell 2 is unchanged');
+        this.validate_notebook_state('merge up', command, 0);
+    });
+
     // Try to merge cell 0 below with cell 1
     this.then(function () {
         this.select_cell(0);


### PR DESCRIPTION
Attempting to merge above on top-most cell will fail silently similar to merging down on bottom-most cell.

cc/ @Carreau 