### PR TITLE
swapped glass for keyboard for command palette icon

### DIFF
--- a/notebook/static-src/notebook/js/actions.js
+++ b/notebook/static-src/notebook/js/actions.js
@@ -332,7 +332,7 @@
         'command-palette': {
             help_index : 'aa',
             help: 'open the command palette',
-            icon: 'fa-search',
+            icon: 'fa-keyboard-o',
             handler : function(env){
                 env.notebook.show_command_palette();
             }


### PR DESCRIPTION
As requested in #343, changed the command palette icon from a magnifying glass to a keyboard.

The plan was to add another button for the search and replace with the magnifying glass but the command palette is currently broken, so I'll just send this PR now and leave the other changes for later (They are already done but I can't test them until that gets fixed)