### PR TITLE
Make notebook itself a little more npm install friendly,

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Jupyter Notebook nodejs dependencies",
   "author": "Jupyter Developers",
   "license": "BSD-3-Clause",
+  "main": "static-src/notebook/js/main",
   "repository": {
     "type": "git",
     "url": "https://github.com/jupyter/notebook.git"
@@ -13,7 +14,6 @@
     "clean:css": "rimraf notebook/static/style/ipython.min.css && rimraf notebook/static/style/style.min.css",
     "clean:js": "rimraf notebook/static/auth/js && rimraf notebook/static/base/js && rimraf notebook/static/edit/js && rimraf notebook/static/notebook/js && rimraf notebook/static/terminal/js && rimraf notebook/static/tree/js && rimraf notebook/static/services",
     "uninstall": "npm run clean && rimraf notebook/static/components && rimraf node_modules",
-    "postinstall": "npm run bower && npm run build",
     "bower": "bower install --allow-root --config.interactive=false",
     "build": "concurrent \"npm run build:css\" \"npm run build:js\"",
     "build:css": "concurrent \"npm run build:css:ipython\" \"npm run build:css:style\"",
@@ -26,7 +26,8 @@
     "build:js:edit": "node ./notebook/build.js edit/js/main.js edit/js/main.bundle.js",
     "build:js:tree": "node ./notebook/build.js tree/js/main.js tree/js/main.bundle.js",
     "build:js:auth": "node ./notebook/build.js auth/js/main.js auth/js/main.bundle.js",
-    "build:js:terminal": "node ./notebook/build.js terminal/js/main.js terminal/js/main.bundle.js"
+    "build:js:terminal": "node ./notebook/build.js terminal/js/main.js terminal/js/main.bundle.js",
+    "prepublish": "npm run bower && npm run build"
   },
   "devDependencies": {
     "aliasify": "^1.7.2",
@@ -36,10 +37,12 @@
     "concurrently": "^0.1.1",
     "glob": "^5.0.14",
     "less": "~2",
-    "marked": "~0.3",
     "mkdirp": "^0.5.1",
+    "rimraf": "^2.4.2"
+},
+  "dependencies": {
+    "marked": "~0.3",
     "moment": "~2.8.4",
-    "rimraf": "^2.4.2",
     "term.js": "~0.0.4",
     "text-encoding": "~0.1",
     "typeahead": "^0.2.0"


### PR DESCRIPTION
This allows other libraries to pick at bits and pieces of our source code without postinstall script trouble caused by nested devDependencies.

Specifically, this will allow @svurens to use keyboard.js in his spreadsheet widget by NPM installing the notebook.