### PR TITLE
move swagger API handler off of existing `/api`

### DIFF
--- a/notebook/services/api/handlers.py
+++ b/notebook/services/api/handlers.py
@@ -15,8 +15,9 @@ class APIHandler(web.StaticFileHandler, IPythonHandler):
     @web.authenticated
     def get(self):
         self.log.debug("Serving api")
+        self.set_header('Content-Type', 'text/x-yaml')
         return web.StaticFileHandler.get(self, 'api.yaml')
 
 default_handlers = [
-    (r"/api", APIHandler)
+    (r"/api/spec.yaml", APIHandler)
 ]


### PR DESCRIPTION
that spot was already taken

also set the content-type correctly

closes #387