### PR TITLE
fixes #391

### DIFF
--- a/notebook/static/base/js/dialog.js
+++ b/notebook/static/base/js/dialog.js
@@ -6,7 +6,9 @@ define(function(require) {
 
     var CodeMirror = require('codemirror/lib/codemirror');
     var $ = require('jquery');
-    
+    // bootstrap is required for calling .modal(...) on elements
+    require('bootstrap');
+
     /**
      * A wrapper around bootstrap modal for easier use
      * Pass it an option dictionary with the following properties:


### PR DESCRIPTION
add `require('bootstrap');` in [`base/js/dialog.js`](https://github.com/jupyter/notebook/blob/master/notebook/static/base/js/dialog.js)