### PR TITLE
Only hide top-level-header.

### DIFF
--- a/notebook/static/base/less/page.less
+++ b/notebook/static/base/less/page.less
@@ -17,7 +17,7 @@ body {
     overflow: visible;
 }
 
-#header {
+body > #header {
     /* Initially hidden to prevent FLOUC */
     display: none;
     background-color: @body-bg;

--- a/notebook/static/notebook/less/notebook.less
+++ b/notebook/static/notebook/less/notebook.less
@@ -79,7 +79,7 @@ p {
     transition: height .2s ease;
 }
 
-.notebook_app #header {
+.notebook_app > #header {
     .box-shadow(@global-shadow);
 }
 


### PR DESCRIPTION
closes jupyter/nbconvert#100