### PR TITLE
Fix bad message break notebook

### DIFF
--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -883,7 +883,7 @@ define([
         this._msg_queue = this._msg_queue.then(function() {
             return serialize.deserialize(e.data);
         }).then(function(msg) {return that._finish_ws_message(msg);})
-        .catch(utils.reject("Couldn't process kernel message", true));
+        .catch(function(error) {console.error("Couldn't process kernel message", error) });
     };
 
     Kernel.prototype._finish_ws_message = function (msg) {


### PR DESCRIPTION
Would need a test, and probably a way to display the message to the user
if it ever happen.

---

Who did the WrappedError ? was it @jasongrout ? @jdfreder ?
Do any of you rely on the `.catch()` behavior ?

How would you display the error if any ? Dialog ? 
Or  red badge in notification area which on click show a dialog with the full error message ? 