### PR TITLE
Remove bootstrap dependency in menubar.js

### DIFF
--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -7,9 +7,8 @@ define([
     'base/js/dialog',
     'base/js/utils',
     'notebook/js/tour',
-    'bootstrap',
     'moment',
-], function($, IPython, dialog, utils, tour, bootstrap, moment) {
+], function($, IPython, dialog, utils, tour, moment) {
     "use strict";
     
     var MenuBar = function (selector, options) {


### PR DESCRIPTION
I looked through  all of the selector references, to make sure no bootstrap injected functions were used, and I couldn't find any.  It probably doesn't matter, require.js doesn't seem to completely isolate jquery, so bootstrap, even if imported elsewhere, will be available in menu on the jquery object (this is one of the things I tackled in the npm-ify PR).

closes #113