### PR TITLE
Do not trigger events only once.

### DIFF
--- a/notebook/static/notebook/js/main.js
+++ b/notebook/static/notebook/js/main.js
@@ -138,7 +138,7 @@ require([
 
     page.show();
 
-    events.one('notebook_loaded.Notebook', function () {
+    events.trigger('notebook_loaded.Notebook', function () {
         var hash = document.location.hash;
         if (hash) {
             document.location.hash = '';

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1802,7 +1802,7 @@ define(function (require) {
         function restart_and_resolve () {
             that.kernel.restart(function () {
                 // resolve when the kernel is *ready* not just started
-                that.events.one('kernel_ready.Kernel', resolve_promise);
+                that.events.trigger('kernel_ready.Kernel', resolve_promise);
             }, reject_promise);
         }
     


### PR DESCRIPTION
Kernel_ready should be triggered on kernel changed or restart.
notebook loaded can be triggered on checkpoint change.

closes #256