### PR TITLE
Fix small docs errors and add hidden index for clean doc builds

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -152,7 +152,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/source/extending/contents.rst
+++ b/docs/source/extending/contents.rst
@@ -65,6 +65,7 @@ Models may contain the following entries:
 +--------------------+-----------+------------------------------+
 
 .. _modelcontent:
+
 Certain model fields vary in structure depending on the ``type`` field of the
 model.  There are three model types: **notebook**, **file**, and **directory** .
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,3 +13,27 @@ The Jupyter notebook
     development
     examples/Notebook/Examples and Tutorials Index
     changelog
+
+
+.. _old-notebook-docs:
+.. Comment: The following hidden table of contents enables `make html`
+   to build without error. If this hidden toctree is removed the build will
+   error that the old ipynb generated docs are not included in a table of contents.
+   These older docs can be accessed via the Examples and Tutorials section of
+   the current docs and the nbviewer link at the top and bottom of that page.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   examples/Notebook/Examples and Tutorials Index
+   examples/Notebook/What is the Jupyter Notebook
+   examples/Notebook/Notebook Basics
+   examples/Notebook/Running Code
+   examples/Notebook/Working With Markdown Cells
+   examples/Notebook/Configuring the Notebook and Server
+   examples/Notebook/Custom Keyboard Shortcuts
+   examples/Notebook/JavaScript Notebook Extensions
+   examples/Notebook/Importing Notebooks
+   examples/Notebook/Connecting with the Qt Console
+   examples/Notebook/Typesetting Equations


### PR DESCRIPTION
This PR contains edits to allow `make html` execute with no errors or warnings. This will be useful for automating build and test of docs in the future.

`conf.py`  disabled html_static_path since it is not currently used
`contents.rst` fix spacing error
`index.rst` Added a hidden table of contents to prevent the docs generated from older ipynb docs from causing warnings.