### PR TITLE
Add captions to documentation table of contents

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,16 +3,37 @@ The Jupyter notebook
 ====================
 
 .. toctree::
-    :maxdepth: 2
+   :maxdepth: 2
+   :caption: User Documentation
 
-    notebook
-    config
-    public_server
-    security
-    extending/index
-    development
-    examples/Notebook/Examples and Tutorials Index
-    changelog
+   notebook
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Configuration
+
+   config
+   public_server
+   security
+   extending/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Developer Documentation
+
+   development
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Community documentation
+   
+   examples/Notebook/Examples and Tutorials Index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: About Jupyter Notebook
+
+   changelog
 
 
 .. _old-notebook-docs:


### PR DESCRIPTION
Modified documentation table of contents into subsections with captions. The captions match the documentation captions used in Jupyter/Jupyter docs https://jupyter.readthedocs.org/en/latest/#

<img width="860" alt="screen shot 2015-09-18 at 5 23 20 am" src="https://cloud.githubusercontent.com/assets/2680980/9959194/add0e0ae-5dc6-11e5-9dda-ccbde9e2915e.png">
