### PR TITLE
rework restart-run-all dialog

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -10,6 +10,7 @@ define(function(require){
         Object.seal(this);
     };
 
+    var $ = require('jquery');
     var events =  require('base/js/events');
 
     /**
@@ -87,10 +88,7 @@ define(function(require){
             help: 'restart the kernel, then re-run the whole notebook',
             help_index: 'be',
             handler: function (env) {
-                var notebook = env.notebook;
-                notebook.restart_kernel().then(function() {
-                    notebook.execute_all_cells();
-                });
+                env.notebook.restart_run_all();
             }
         },
         'restart': {
@@ -98,6 +96,18 @@ define(function(require){
             help_index: 'bf',
             handler: function (env) {
                 env.notebook.restart_kernel();
+            },
+        },
+        'restart-run-all-no-confirm': {
+            help: 'restart the kernel, then re-run the whole notebook (no confirmation dialog)',
+            handler: function (env) {
+                env.notebook.restart_run_all({confirm: false});
+            }
+        },
+        'restart-no-confirm': {
+            help: 'restart the kernel (no confirmation dialog)',
+            handler: function (env) {
+                env.notebook.restart_kernel({confirm: false});
             },
         },
         'run-all-cells-above':{
@@ -507,7 +517,7 @@ define(function(require){
         'rename-notebook':{
             help: "Rename current notebook",
             handler : function (env, event) {
-                env.notebook.save_widget.rename_notebook({notebook: env.notebook})
+                env.notebook.save_widget.rename_notebook({notebook: env.notebook});
             }
         },
         'save-notebook':{

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -84,38 +84,38 @@ define(function(require){
                 env.notebook.execute_all_cells();
             }
         },
-        'restart-run-all': {
-            help: 'restart the kernel, then re-run the whole notebook',
+        'restart-run-all-dialog': {
+            help: 'restart the kernel, then re-run the whole notebook (with dialog)',
             handler: function (env) {
                 env.notebook.restart_run_all();
             }
         },
-        'restart-clear-output': {
-            help: 'restart the kernel and clear all output',
+        'restart-clear-output-dialog': {
+            help: 'restart the kernel and clear all output (with dialog)',
             handler: function (env) {
                 env.notebook.restart_clear_output();
             }
         },
-        'restart': {
-            help: 'restart the kernel',
+        'restart-dialog': {
+            help: 'restart the kernel (with dialog)',
             help_index: 'bf',
             handler: function (env) {
                 env.notebook.restart_kernel();
             },
         },
-        'restart-run-all-no-confirm': {
+        'restart-run-all': {
             help: 'restart the kernel, then re-run the whole notebook (no confirmation dialog)',
             handler: function (env) {
                 env.notebook.restart_run_all({confirm: false});
             }
         },
-        'restart-clear-output-no-confirm': {
+        'restart-clear-output': {
             help: 'restart the kernel and clear all output (no confirmation dialog)',
             handler: function (env) {
                 env.notebook.restart_clear_output({confirm: false});
             }
         },
-        'restart-no-confirm': {
+        'restart': {
             help: 'restart the kernel (no confirmation dialog)',
             handler: function (env) {
                 env.notebook.restart_kernel({confirm: false});

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -86,9 +86,14 @@ define(function(require){
         },
         'restart-run-all': {
             help: 'restart the kernel, then re-run the whole notebook',
-            help_index: 'be',
             handler: function (env) {
                 env.notebook.restart_run_all();
+            }
+        },
+        'restart-clear-output': {
+            help: 'restart the kernel and clear all output',
+            handler: function (env) {
+                env.notebook.restart_clear_output();
             }
         },
         'restart': {
@@ -102,6 +107,12 @@ define(function(require){
             help: 'restart the kernel, then re-run the whole notebook (no confirmation dialog)',
             handler: function (env) {
                 env.notebook.restart_run_all({confirm: false});
+            }
+        },
+        'restart-clear-output-no-confirm': {
+            help: 'restart the kernel and clear all output (no confirmation dialog)',
+            handler: function (env) {
+                env.notebook.restart_clear_output({confirm: false});
             }
         },
         'restart-no-confirm': {

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -202,6 +202,8 @@ define([
             '#find_and_replace' : 'ipython.find-and-replace-dialog',
             '#save_checkpoint': 'ipython.save-notebook',
             '#restart_kernel': 'ipython.restart-kernel',
+            '#restart_clear_output': 'ipython.restart-clear-output',
+            '#restart_run_all': 'ipython.restart-run-all',
             '#int_kernel': 'ipython.interrupt-kernel',
             '#cut_cell': 'ipython.cut-selected-cell',
             '#copy_cell': 'ipython.copy-selected-cell',
@@ -258,9 +260,6 @@ define([
         });
         
         // Kernel
-        this.element.find('#restart_run_all').click(function () {
-            that.actions.call('ipython.restart-run-all');
-        });
         this.element.find('#reconnect_kernel').click(function () {
             that.notebook.kernel.reconnect();
         });

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -201,9 +201,9 @@ define([
         var id_actions_dict = {
             '#find_and_replace' : 'ipython.find-and-replace-dialog',
             '#save_checkpoint': 'ipython.save-notebook',
-            '#restart_kernel': 'ipython.restart-kernel',
-            '#restart_clear_output': 'ipython.restart-clear-output',
-            '#restart_run_all': 'ipython.restart-run-all',
+            '#restart_kernel': 'ipython.restart-kernel-dialog',
+            '#restart_clear_output': 'ipython.restart-clear-output-dialog',
+            '#restart_run_all': 'ipython.restart-run-all-dialog',
             '#int_kernel': 'ipython.interrupt-kernel',
             '#cut_cell': 'ipython.cut-selected-cell',
             '#copy_cell': 'ipython.copy-selected-cell',

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -240,6 +240,10 @@ data-notebook-path="{{notebook_path | urlencode}}"
                             title="Restart the Kernel">
                             <a href="#">Restart</a>
                         </li>
+                        <li id="restart_clear_output"
+                            title="Restart the Kernel and clear all output">
+                            <a href="#">Restart &amp; Clear Output</a>
+                        </li>
                         <li id="restart_run_all"
                             title="Restart the Kernel and re-run the notebook">
                             <a href="#">Restart &amp; Run All</a>


### PR DESCRIPTION
- give Restart & Run All action its own dialog
- add Restart & Run All button to regular restart dialog
- add `-no-confirm` version of both restart and restart-run-all actions, so they are available for shortcuts, etc.

closes #440


Kernel  Menu:

<img width="391" alt="screen shot 2015-09-20 at 15 50 16" src="https://cloud.githubusercontent.com/assets/151929/9981005/7b258b92-5faf-11e5-8c3e-2fcff655f890.PNG">

Restart & Run All dialog:

<img width="735" alt="screen shot 2015-09-20 at 15 50 22" src="https://cloud.githubusercontent.com/assets/151929/9981008/95079514-5faf-11e5-9511-16efadcaa9ab.PNG">

Restart dialog:

<img width="725" alt="screen shot 2015-09-20 at 15 50 31" src="https://cloud.githubusercontent.com/assets/151929/9981009/a03c0ea6-5faf-11e5-9ccf-bdce436accc1.PNG">
