### PR TITLE
Fix documentation links to notebook examples

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -152,6 +152,9 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
+# NOTE: Sphinx's 'make html' builder will throw a warning about an unfound
+#       _static directory. Do not remove or comment out html_static_path
+#       since it is needed to properly generate _static in the build directory
 html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -152,7 +152,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/source/notebook.rst
+++ b/docs/source/notebook.rst
@@ -223,9 +223,7 @@ example, in the ``pandas`` data analysis package). This is known as IPython's
 
 .. seealso::
 
-    `Basic Output`_  example notebook
-
-    `Rich Output`_  example notebook
+   `Rich Output`_  example notebook
 
 Markdown cells
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #467 and the broken link to an example notebook.

Revert change in ``conf.py`` from PR #441. Sphinx's ``make html`` builder was warning that ``_static`` was unfound/unused, and the html_static_path was commented out to correct the warning.

Unfortunately, ``_static`` was used later in the build sequence of documentation (that occurs after the ``make html`` builder's check).

In addition, I removed the Basic output link since I could find no matching link in the Jupyter notebook or IPython docs. As an aside the Rich Output link sends the reader to https://nbviewer.jupyter.org/github/ipython/ipython/blob/3.x/examples/IPython%20Kernel/Rich%20Output.ipynb where there may be an injection error.
<img width="972" alt="screen shot 2015-09-20 at 10 39 28 pm" src="https://cloud.githubusercontent.com/assets/2680980/9985837/88f1e3a4-5fe8-11e5-9a43-e65db772e2b1.png">
