### PR TITLE
avoid double-encoding base_url

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -564,7 +564,7 @@ class FilesRedirectHandler(IPythonHandler):
         cm = self.contents_manager
         if cm.dir_exists(path):
             # it's a *directory*, redirect to /tree
-            url = url_path_join(self.base_url, 'tree', path)
+            url = url_path_join(self.base_url, 'tree', url_escape(path))
         else:
             orig_path = path
             # otherwise, redirect to /files
@@ -580,8 +580,7 @@ class FilesRedirectHandler(IPythonHandler):
             if not cm.file_exists(path=path):
                 raise web.HTTPError(404)
 
-            url = url_path_join(self.base_url, 'files', path)
-        url = url_escape(url)
+            url = url_path_join(self.base_url, 'files', url_escape(path))
         self.log.debug("Redirecting %s to %s", self.request.path, url)
         self.redirect(url)
     

--- a/notebook/jstest.py
+++ b/notebook/jstest.py
@@ -222,6 +222,7 @@ class JSController(TestController):
         self.section = section
         self.xunit = xunit
         self.url = url
+        self.base_url = '/a@b/'
         self.slimer_failure = re.compile('^FAIL.*', flags=re.MULTILINE)
         js_test_dir = get_js_test_dir()
         includes = '--includes=' + os.path.join(js_test_dir,'util.js')
@@ -264,7 +265,7 @@ class JSController(TestController):
             self.server_port = 0
             self._init_server()
             if self.server_port:
-                self.cmd.append("--port=%i" % self.server_port)
+                self.cmd.append('--url=http://localhost:%i%s' % (self.server_port, self.base_url))
             else:
                 # don't launch tests if the server didn't start
                 self.cmd = [sys.executable, '-c', 'raise SystemExit(1)']
@@ -310,7 +311,7 @@ class JSController(TestController):
             '-m', 'notebook',
             '--no-browser',
             '--notebook-dir', self.nbdir.name,
-            '--NotebookApp.base_url=/e%40mail/',
+            '--NotebookApp.base_url=%s' % self.base_url,
         ]
         # ipc doesn't work on Windows, and darwin has crazy-long temp paths,
         # which run afoul of ipc's maximum path length.

--- a/notebook/jstest.py
+++ b/notebook/jstest.py
@@ -222,6 +222,8 @@ class JSController(TestController):
         self.section = section
         self.xunit = xunit
         self.url = url
+        # run with a base URL that would be escaped,
+        # to test that we don't double-escape URLs
         self.base_url = '/a@b/'
         self.slimer_failure = re.compile('^FAIL.*', flags=re.MULTILINE)
         js_test_dir = get_js_test_dir()

--- a/notebook/jstest.py
+++ b/notebook/jstest.py
@@ -310,6 +310,7 @@ class JSController(TestController):
             '-m', 'notebook',
             '--no-browser',
             '--notebook-dir', self.nbdir.name,
+            '--NotebookApp.base_url=/e%40mail/',
         ]
         # ipc doesn't work on Windows, and darwin has crazy-long temp paths,
         # which run afoul of ipc's maximum path length.

--- a/notebook/notebook/handlers.py
+++ b/notebook/notebook/handlers.py
@@ -34,8 +34,7 @@ class NotebookHandler(IPythonHandler):
         if model['type'] != 'notebook':
             # not a notebook, redirect to files
             return FilesRedirectHandler.redirect_to_files(self, path)
-        name = url_escape(path.rsplit('/', 1)[-1])
-        path = url_escape(path)
+        name = path.rsplit('/', 1)[-1]
         self.write(self.render_template('notebook.html',
             notebook_path=path,
             notebook_name=name,

--- a/notebook/services/contents/handlers.py
+++ b/notebook/services/contents/handlers.py
@@ -87,9 +87,9 @@ class ContentsHandler(APIHandler):
         path : unicode
             The API path of the file, such as "foo/bar.txt".
         """
-        return url_escape(url_path_join(
-            self.base_url, 'api', 'contents', path
-        ))
+        return url_path_join(
+            self.base_url, 'api', 'contents', url_escape(path)
+        )
 
     def _finish_model(self, model, location=True):
         """Finish a JSON request with a model, setting relevant headers, etc."""
@@ -280,8 +280,8 @@ class CheckpointsHandler(APIHandler):
         checkpoint = yield gen.maybe_future(cm.create_checkpoint(path))
         data = json.dumps(checkpoint, default=date_default)
         location = url_path_join(self.base_url, 'api/contents',
-            path, 'checkpoints', checkpoint['id'])
-        self.set_header('Location', url_escape(location))
+            url_escape(path), 'checkpoints', url_escape(checkpoint['id']))
+        self.set_header('Location', location)
         self.set_status(201)
         self.finish(data)
 

--- a/notebook/services/contents/tests/test_contents_api.py
+++ b/notebook/services/contents/tests/test_contents_api.py
@@ -338,7 +338,7 @@ class APITest(NotebookTestBase):
     def _check_created(self, resp, path, type='notebook'):
         self.assertEqual(resp.status_code, 201)
         location_header = py3compat.str_to_unicode(resp.headers['Location'])
-        self.assertEqual(location_header, url_escape(url_path_join(u'/api/contents', path)))
+        self.assertEqual(location_header, url_path_join(self.url_prefix, u'api/contents', url_escape(path)))
         rjson = resp.json()
         self.assertEqual(rjson['name'], path.rsplit('/', 1)[-1])
         self.assertEqual(rjson['path'], path)

--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -43,8 +43,8 @@ class MainKernelHandler(APIHandler):
 
         kernel_id = km.start_kernel(kernel_name=model['name'])
         model = km.kernel_model(kernel_id)
-        location = url_path_join(self.base_url, 'api', 'kernels', kernel_id)
-        self.set_header('Location', url_escape(location))
+        location = url_path_join(self.base_url, 'api', 'kernels', url_escape(kernel_id))
+        self.set_header('Location', location)
         self.set_status(201)
         self.finish(json.dumps(model))
 

--- a/notebook/services/kernels/tests/test_kernels_api.py
+++ b/notebook/services/kernels/tests/test_kernels_api.py
@@ -63,29 +63,33 @@ class KernelAPITest(NotebookTestBase):
         # POST request
         r = self.kern_api._req('POST', '')
         kern1 = r.json()
-        self.assertEqual(r.headers['location'], '/api/kernels/' + kern1['id'])
+        self.assertEqual(r.headers['location'], url_path_join(self.url_prefix, 'api/kernels', kern1['id']))
         self.assertEqual(r.status_code, 201)
         self.assertIsInstance(kern1, dict)
 
-        self.assertEqual(r.headers['Content-Security-Policy'], (
-                            "frame-ancestors 'self'; "
-                            "report-uri /api/security/csp-report; "
-                            "default-src 'none'"
-        ))
+        report_uri = url_path_join(self.url_prefix, 'api/security/csp-report')
+        expected_csp = '; '.join([
+            "frame-ancestors 'self'",
+            'report-uri ' + report_uri,
+            "default-src 'none'"
+        ])
+        self.assertEqual(r.headers['Content-Security-Policy'], expected_csp)
 
     def test_main_kernel_handler(self):
         # POST request
         r = self.kern_api.start()
         kern1 = r.json()
-        self.assertEqual(r.headers['location'], '/api/kernels/' + kern1['id'])
+        self.assertEqual(r.headers['location'], url_path_join(self.url_prefix, 'api/kernels', kern1['id']))
         self.assertEqual(r.status_code, 201)
         self.assertIsInstance(kern1, dict)
 
-        self.assertEqual(r.headers['Content-Security-Policy'], (
-                            "frame-ancestors 'self'; "
-                            "report-uri /api/security/csp-report; "
-                            "default-src 'none'"
-        ))
+        report_uri = url_path_join(self.url_prefix, 'api/security/csp-report')
+        expected_csp = '; '.join([
+            "frame-ancestors 'self'",
+            'report-uri ' + report_uri,
+            "default-src 'none'"
+        ])
+        self.assertEqual(r.headers['Content-Security-Policy'], expected_csp)
 
         # GET request
         r = self.kern_api.list()
@@ -110,7 +114,7 @@ class KernelAPITest(NotebookTestBase):
 
         # Restart a kernel
         r = self.kern_api.restart(kern2['id'])
-        self.assertEqual(r.headers['Location'], '/api/kernels/'+kern2['id'])
+        self.assertEqual(r.headers['Location'], url_path_join(self.url_prefix, 'api/kernels', kern2['id']))
         rekern = r.json()
         self.assertEqual(rekern['id'], kern2['id'])
         self.assertEqual(rekern['name'], kern2['name'])

--- a/notebook/services/sessions/handlers.py
+++ b/notebook/services/sessions/handlers.py
@@ -12,7 +12,7 @@ from tornado import web
 
 from ...base.handlers import APIHandler, json_errors
 from jupyter_client.jsonutil import date_default
-from notebook.utils import url_path_join, url_escape
+from notebook.utils import url_path_join
 from jupyter_client.kernelspec import NoSuchKernel
 
 
@@ -64,7 +64,7 @@ class SessionRootHandler(APIHandler):
                 return
 
         location = url_path_join(self.base_url, 'api', 'sessions', model['id'])
-        self.set_header('Location', url_escape(location))
+        self.set_header('Location', location)
         self.set_status(201)
         self.finish(json.dumps(model, default=date_default))
 

--- a/notebook/services/sessions/tests/test_sessions_api.py
+++ b/notebook/services/sessions/tests/test_sessions_api.py
@@ -92,7 +92,7 @@ class SessionAPITest(NotebookTestBase):
         newsession = resp.json()
         self.assertIn('id', newsession)
         self.assertEqual(newsession['notebook']['path'], 'foo/nb1.ipynb')
-        self.assertEqual(resp.headers['Location'], '/api/sessions/{0}'.format(newsession['id']))
+        self.assertEqual(resp.headers['Location'], self.url_prefix + 'api/sessions/{0}'.format(newsession['id']))
 
         sessions = self.sess_api.list().json()
         self.assertEqual(sessions, [newsession])

--- a/notebook/static/auth/js/loginwidget.js
+++ b/notebook/static/auth/js/loginwidget.js
@@ -21,13 +21,13 @@ define([
     LoginWidget.prototype.bind_events = function () {
         var that = this;
         this.element.find("button#logout").click(function () {
-            window.location = utils.url_join_encode(
+            window.location = utils.url_path_join(
                 that.base_url,
                 "logout"
             );
         });
         this.element.find("button#login").click(function () {
-            window.location = utils.url_join_encode(
+            window.location = utils.url_path_join(
                 that.base_url,
                 "login"
             );

--- a/notebook/static/edit/js/menubar.js
+++ b/notebook/static/edit/js/menubar.js
@@ -54,8 +54,8 @@ define([
             var parent = utils.url_path_split(editor.file_path)[0];
             editor.contents.new_untitled(parent, {type: "file"}).then(
                 function (data) {
-                    w.location = utils.url_join_encode(
-                        that.base_url, 'edit', data.path
+                    w.location = utils.url_path_join(
+                        that.base_url, 'edit', utils.encode_uri_components(data.path)
                     );
                 },
                 function(error) {
@@ -75,8 +75,9 @@ define([
             that.save_widget.rename();
         });
         this.element.find('#download-file').click(function () {
-            window.open(utils.url_join_encode(
-                that.base_url, 'files', that.editor.file_path
+            window.open(utils.url_path_join(
+                that.base_url, 'files',
+                utils.encode_uri_components(that.editor.file_path)
             ) + '?download=1');
         });
         

--- a/notebook/static/edit/js/savewidget.js
+++ b/notebook/static/edit/js/savewidget.js
@@ -119,11 +119,11 @@ define([
 
     SaveWidget.prototype.update_address_bar = function (path) {
         var state = {path : path};
-        window.history.replaceState(state, "", utils.url_join_encode(
+        window.history.replaceState(state, "", utils.url_path_join(
             this.editor.base_url,
             "edit",
-            path)
-        );
+            utils.encode_uri_components(path)
+        ));
     };
 
     SaveWidget.prototype.update_last_modified = function (last_modified) {

--- a/notebook/static/notebook/js/kernelselector.js
+++ b/notebook/static/notebook/js/kernelselector.js
@@ -36,7 +36,7 @@ define([
     KernelSelector.prototype.request_kernelspecs = function() {
         // Preliminary documentation for kernelspecs api is at 
         // https://github.com/ipython/ipython/wiki/IPEP-25%3A-Registry-of-installed-kernels#rest-api
-        var url = utils.url_join_encode(this.notebook.base_url, 'api/kernelspecs');
+        var url = utils.url_path_join(this.notebook.base_url, 'api/kernelspecs');
         utils.promising_ajax(url).then($.proxy(this._got_kernelspecs, this));
     };
     
@@ -292,8 +292,9 @@ define([
         var parent = utils.url_path_split(that.notebook.notebook_path)[0];
         that.notebook.contents.new_untitled(parent, {type: "notebook"}).then(
             function (data) {
-                var url = utils.url_join_encode(
-                    that.notebook.base_url, 'notebooks', data.path
+                var url = utils.url_path_join(
+                    that.notebook.base_url, 'notebooks',
+                    utils.encode_uri_components(data.path)
                 );
                 url += "?kernel_name=" + kernel_name;
                 w.location = url;

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -69,8 +69,8 @@ define([
 
     MenuBar.prototype._nbconvert = function (format, download) {
         download = download || false;
-        var notebook_path = this.notebook.notebook_path;
-        var url = utils.url_join_encode(
+        var notebook_path = utils.encode_uri_components(this.notebook.notebook_path);
+        var url = utils.url_path_join(
             this.base_url,
             'nbconvert',
             format,
@@ -92,7 +92,7 @@ define([
          * Update header spacer size.
          */
         console.warn('`_size_header` is deprecated and will be removed in future versions.'+
-                     ' Please trigger the `resize-header.Page` manually if you rely on it.')
+                     ' Please trigger the `resize-header.Page` manually if you rely on it.');
         this.events.trigger('resize-header.Page');
     };
 
@@ -104,7 +104,11 @@ define([
         
         this.element.find('#open_notebook').click(function () {
             var parent = utils.url_path_split(that.notebook.notebook_path)[0];
-            window.open(utils.url_join_encode(that.base_url, 'tree', parent), IPython._target);
+            window.open(
+                utils.url_path_join(
+                    that.base_url, 'tree',
+                    utils.encode_uri_components(parent)
+                ), IPython._target);
         });
         this.element.find('#copy_notebook').click(function () {
             if (that.notebook.dirty) {
@@ -115,10 +119,11 @@ define([
         });
         this.element.find('#download_ipynb').click(function () {
             var base_url = that.notebook.base_url;
-            var notebook_path = that.notebook.notebook_path;
+            var notebook_path = utils.encode_uri_components(that.notebook.notebook_path);
             var w = window.open('');
-            var url = utils.url_join_encode(base_url, 'files', notebook_path)
-                                + '?download=1';
+            var url = utils.url_path_join(
+                base_url, 'files', notebook_path
+            ) + '?download=1';
             if (that.notebook.dirty) {
                 that.notebook.save_notebook().then(function() {
                     w.location = url;
@@ -231,13 +236,13 @@ define([
             }
             var id_act = id_actions_dict[idx];
             if(!that.actions.exists(id_act)){
-                console.warn('actions', id_act, 'does not exist, still binding it in case it will be defined later...' )
+                console.warn('actions', id_act, 'does not exist, still binding it in case it will be defined later...');
             }
             // Immediately-Invoked Function Expression cause JS.
             (function(that, id_act, idx){
                 that.element.find(idx).click(function(event){
-                    that.actions.call(id_act, event)
-                })
+                    that.actions.call(id_act, event);
+                });
             })(that, id_act, idx);
         }
 

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -2293,8 +2293,8 @@ define(function (require) {
         var parent = utils.url_path_split(this.notebook_path)[0];
         this.contents.copy(this.notebook_path, parent).then(
             function (data) {
-                w.location = utils.url_join_encode(
-                    base_url, 'notebooks', data.path
+                w.location = utils.url_path_join(
+                    base_url, 'notebooks', utils.encode_uri_components(data.path)
                 );
             },
             function(error) {

--- a/notebook/static/notebook/js/savewidget.js
+++ b/notebook/static/notebook/js/savewidget.js
@@ -142,10 +142,10 @@ define([
         var base_url = this.notebook.base_url;
         var path = this.notebook.notebook_path;
         var state = {path : path};
-        window.history.replaceState(state, "", utils.url_join_encode(
+        window.history.replaceState(state, "", utils.url_path_join(
             base_url,
             "notebooks",
-            path)
+            utils.encode_uri_components(path))
         );
     };
 

--- a/notebook/static/services/config.js
+++ b/notebook/static/services/config.js
@@ -25,7 +25,8 @@ function($, utils) {
     };
 
     ConfigSection.prototype.api_url = function() {
-        return utils.url_join_encode(this.base_url, 'api/config', this.section_name);
+        return utils.url_path_join(this.base_url, 'api/config',
+            utils.encode_uri_components(this.section_name));
     };
     
     ConfigSection.prototype._load_done = function() {

--- a/notebook/static/services/contents.js
+++ b/notebook/static/services/contents.js
@@ -43,9 +43,11 @@ define(function(require) {
 
 
     Contents.prototype.api_url = function() {
-        var url_parts = [this.base_url, 'api/contents'].concat(
-                                Array.prototype.slice.apply(arguments));
-        return utils.url_join_encode.apply(null, url_parts);
+        var url_parts = [
+            this.base_url, 'api/contents',
+            utils.url_join_encode.apply(null, arguments),
+        ];
+        return utils.url_path_join.apply(null, url_parts);
     };
 
     /**

--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -274,7 +274,7 @@ define([
             }
         };
 
-        var url = utils.url_join_encode(this.kernel_url, 'interrupt');
+        var url = utils.url_path_join(this.kernel_url, 'interrupt');
         $.ajax(url, {
             processData: false,
             cache: false,
@@ -316,7 +316,7 @@ define([
             }
         };
 
-        var url = utils.url_join_encode(this.kernel_url, 'restart');
+        var url = utils.url_path_join(this.kernel_url, 'restart');
         $.ajax(url, {
             processData: false,
             cache: false,
@@ -362,7 +362,8 @@ define([
                 that.id = data.id;
                 that.name = data.name;
             }
-            that.kernel_url = utils.url_join_encode(that.kernel_service_url, that.id);
+            that.kernel_url = utils.url_path_join(that.kernel_service_url,
+                encodeURIComponent(that.id));
             if (success) {
                 success(data, status, xhr);
             }
@@ -394,7 +395,8 @@ define([
          * @param {Object} data - information about the kernel including id
          */
         this.id = data.id;
-        this.kernel_url = utils.url_join_encode(this.kernel_service_url, this.id);
+        this.kernel_url = utils.url_path_join(this.kernel_service_url,
+            encodeURIComponent(this.id));
         this.start_channels();
     };
 
@@ -441,7 +443,7 @@ define([
         
         this.ws = new this.WebSocket([
                 that.ws_url,
-                utils.url_join_encode(that.kernel_url, 'channels'),
+                utils.url_path_join(that.kernel_url, 'channels'),
                 "?session_id=" + that.session_id
             ].join('')
         );
@@ -883,20 +885,17 @@ define([
         this._msg_queue = this._msg_queue.then(function() {
             return serialize.deserialize(e.data);
         }).then(function(msg) {return that._finish_ws_message(msg);})
-        .catch(function(error) {console.error("Couldn't process kernel message", error) });
+        .catch(function(error) { console.error("Couldn't process kernel message", error); });
     };
 
     Kernel.prototype._finish_ws_message = function (msg) {
         switch (msg.channel) {
             case 'shell':
                 return this._handle_shell_reply(msg);
-                break;
             case 'iopub':
                 return this._handle_iopub_message(msg);
-                break;
             case 'stdin':
                 return this._handle_input_request(msg);
-                break;
             default:
                 console.error("unrecognized message channel", msg.channel, msg);
         }
@@ -919,7 +918,7 @@ define([
         this._finish_shell(parent_id);
         
         if (shell_callbacks.reply !== undefined) {
-            promise = promise.then(function() {return shell_callbacks.reply(reply)});
+            promise = promise.then(function() {return shell_callbacks.reply(reply);});
         }
         if (content.payload && shell_callbacks.payload) {
             promise = promise.then(function() {

--- a/notebook/static/tree/js/newnotebook.js
+++ b/notebook/static/tree/js/newnotebook.js
@@ -32,7 +32,7 @@ define([
     
     NewNotebookWidget.prototype.request_kernelspecs = function () {
         /** request and then load kernel specs */
-        var url = utils.url_join_encode(this.base_url, 'api/kernelspecs');
+        var url = utils.url_path_join(this.base_url, 'api/kernelspecs');
         utils.promising_ajax(url).then($.proxy(this._load_kernelspecs, this));
     };
     
@@ -78,8 +78,9 @@ define([
         var w = window.open(undefined, IPython._target);
         this.contents.new_untitled(that.notebook_path, {type: "notebook"}).then(
             function (data) {
-                var url = utils.url_join_encode(
-                    that.base_url, 'notebooks', data.path
+                var url = utils.url_path_join(
+                    that.base_url, 'notebooks',
+                    utils.encode_uri_components(data.path)
                 );
                 if (kernel_name) {
                     url += "?kernel_name=" + kernel_name;

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -75,8 +75,9 @@ define([
             $('#new-file').click(function(e) {
                 var w = window.open('', IPython._target);
                 that.contents.new_untitled(that.notebook_path || '', {type: 'file', ext: '.txt'}).then(function(data) {
-                    var url = utils.url_join_encode(
-                        that.base_url, 'edit', data.path
+                    var url = utils.url_path_join(
+                        that.base_url, 'edit',
+                        utils.encode_uri_components(data.path)
                     );
                     w.location = url;
                 }).catch(function (e) {
@@ -298,7 +299,7 @@ define([
             try {
                 this.add_link(model, item);
             } catch(err) {
-                console.log('Error adding link: ' + err)
+                console.log('Error adding link: ' + err);
             }
         }
         // Trigger an event when we've finished drawing the notebook list.
@@ -550,10 +551,10 @@ define([
         item.find(".item_icon").addClass(icon).addClass('icon-fixed-width');
         var link = item.find("a.item_link")
             .attr('href',
-                utils.url_join_encode(
+                utils.url_path_join(
                     this.base_url,
                     uri_prefix,
-                    path
+                    utils.encode_uri_components(path)
                 )
             );
 
@@ -613,10 +614,10 @@ define([
 
         var session = this.sessions[path];
         if (session) {
-            var url = utils.url_join_encode(
+            var url = utils.url_path_join(
                 this.base_url,
                 'api/sessions',
-                session
+                encodeURIComponent(session)
             );
             $.ajax(url, settings);
         }

--- a/notebook/static/tree/js/sessionlist.js
+++ b/notebook/static/tree/js/sessionlist.js
@@ -62,7 +62,7 @@ define([
             success : $.proxy(that.sessions_loaded, this),
             error : utils.log_ajax_error,
         };
-        var url = utils.url_join_encode(this.base_url, 'api/sessions');
+        var url = utils.url_path_join(this.base_url, 'api/sessions');
         $.ajax(url, settings);
     };
 

--- a/notebook/static/tree/js/terminallist.js
+++ b/notebook/static/tree/js/terminallist.js
@@ -49,14 +49,15 @@ define([
             dataType: "json",
             success : function (data, status, xhr) {
                 var name = data.name;
-                w.location = utils.url_join_encode(base_url, 'terminals', name);
+                w.location = utils.url_path_join(base_url, 'terminals', 
+                    utils.encode_uri_components(name));
             },
             error : function(jqXHR, status, error){
                 w.close();
                 utils.log_ajax_error(jqXHR, status, error);
             },
         };
-        var url = utils.url_join_encode(
+        var url = utils.url_path_join(
             this.base_url,
             'api/terminals'
         );
@@ -64,7 +65,7 @@ define([
     };
     
     TerminalList.prototype.load_terminals = function() {
-        var url = utils.url_join_encode(this.base_url, 'api/terminals');
+        var url = utils.url_path_join(this.base_url, 'api/terminals');
         $.ajax(url, {
             type: "GET",
             cache: false,
@@ -92,7 +93,8 @@ define([
         item.find(".item_name").text("terminals/" + name);
         item.find(".item_icon").addClass("fa fa-terminal");
         var link = item.find("a.item_link")
-            .attr('href', utils.url_join_encode(this.base_url, "terminals", name));
+            .attr('href', utils.url_path_join(this.base_url, "terminals",
+                utils.encode_uri_components(name)));
         link.attr('target', IPython._target||'_blank');
         this.add_shutdown_button(name, item);
     };
@@ -110,7 +112,8 @@ define([
                     },
                     error : utils.log_ajax_error,
                 };
-                var url = utils.url_join_encode(that.base_url, 'api/terminals', name);
+                var url = utils.url_path_join(that.base_url, 'api/terminals',
+                    utils.encode_uri_components(name));
                 $.ajax(url, settings);
                 return false;
             });

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -26,11 +26,10 @@ window.mathjax_url = "{{mathjax_url}}";
 {% block params %}
 
 {{super()}}
-data-project="{{project}}"
-data-base-url="{{base_url}}"
-data-ws-url="{{ws_url}}"
-data-notebook-name="{{notebook_name}}"
-data-notebook-path="{{notebook_path}}"
+data-base-url="{{base_url | urlencode}}"
+data-ws-url="{{ws_url | urlencode}}"
+data-notebook-name="{{notebook_name | urlencode}}"
+data-notebook-path="{{notebook_path | urlencode}}"
 
 {% endblock %}
 

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -5,8 +5,8 @@
 
 {% block params %}
 {{super()}}
-data-base-url="{{base_url}}"
-data-notebook-path="{{notebook_path}}"
+data-base-url="{{base_url | urlencode}}"
+data-notebook-path="{{notebook_path | urlencode}}"
 data-terminals-available="{{terminals_available}}"
 
 {% endblock %}

--- a/notebook/tests/base/keyboard.js
+++ b/notebook/tests/base/keyboard.js
@@ -84,8 +84,8 @@ casper.notebook_test(function () {
             longer_first = longer_first||(that.msgs[m].match(/you are overriting/)!= null);
             longer_last = longer_last  ||(that.msgs[m].match(/will be shadowed/) != null);
         }
-        this.test.assert(longer_first, 'no warnign if registering shorter shortut');
-        this.test.assert(longer_last , 'no warnign if registering longer shortut');
+        this.test.assert(longer_first, 'no warning if registering shorter shortut');
+        this.test.assert(longer_last , 'no warning if registering longer shortut');
     })
 
 });

--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -39,11 +39,12 @@ class NotebookTestBase(TestCase):
 
     port = 12341
     config = None
+    url_prefix = '/a%40b/'
 
     @classmethod
     def wait_until_alive(cls):
         """Wait for the server to be alive"""
-        url = 'http://localhost:%i/api/contents' % cls.port
+        url = cls.base_url() + 'api/contents'
         for _ in range(int(MAX_WAITTIME/POLL_INTERVAL)):
             try:
                 requests.get(url)
@@ -86,6 +87,7 @@ class NotebookTestBase(TestCase):
             data_dir=cls.data_dir.name,
             runtime_dir=cls.runtime_dir.name,
             notebook_dir=cls.notebook_dir.name,
+            base_url=cls.url_prefix,
             config=cls.config,
         )
         
@@ -123,7 +125,7 @@ class NotebookTestBase(TestCase):
 
     @classmethod
     def base_url(cls):
-        return 'http://localhost:%i/' % cls.port
+        return 'http://localhost:%i%s' % (cls.port, cls.url_prefix)
 
 
 @contextmanager

--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -39,6 +39,8 @@ class NotebookTestBase(TestCase):
 
     port = 12341
     config = None
+    # run with a base URL that would be escaped,
+    # to test that we don't double-escape URLs
     url_prefix = '/a%40b/'
 
     @classmethod

--- a/notebook/tests/services/kernel.js
+++ b/notebook/tests/services/kernel.js
@@ -126,14 +126,17 @@ casper.notebook_test(function () {
     });
 
     // test start
-    var url;
+    var url, base_url;
     this.then(function () {
+        base_url = this.evaluate(function () {
+            return IPython.notebook.base_url;
+        });
         url = this.evaluate(function () {
             return IPython.notebook.kernel.start();
         });
     });
     this.then(function () {
-        this.test.assertEquals(url, "/api/kernels", "start url is correct");
+        this.test.assertEquals(url, base_url + "api/kernels", "start url is correct");
     });
     this.wait_for_kernel_ready();
     this.then(function () {
@@ -151,7 +154,7 @@ casper.notebook_test(function () {
         });
     });
     this.then(function () {
-        this.test.assertEquals(url, "/api/kernels?foo=bar", "start url with params is correct");
+        this.test.assertEquals(url, base_url + "api/kernels?foo=bar", "start url with params is correct");
     });
     this.wait_for_kernel_ready();
     this.then(function () {

--- a/notebook/tests/util.js
+++ b/notebook/tests/util.js
@@ -79,7 +79,7 @@ casper.open_new_notebook = function () {
 };
 
 casper.page_loaded = function() {
-    // Return whether or not the kernel is running.
+    // Return whether or not the page has been loaded.
     return this.evaluate(function() {
         return typeof IPython !== "undefined" &&
             IPython.page !== undefined;

--- a/notebook/tree/handlers.py
+++ b/notebook/tree/handlers.py
@@ -12,13 +12,14 @@ class TreeHandler(IPythonHandler):
     """Render the tree view, listing notebooks, etc."""
 
     def generate_breadcrumbs(self, path):
-        breadcrumbs = [(url_escape(url_path_join(self.base_url, 'tree')), '')]
-        comps = path.split('/')
-        ncomps = len(comps)
-        for i in range(ncomps):
-            if comps[i]:
-                link = url_escape(url_path_join(self.base_url, 'tree', *comps[0:i+1]))
-                breadcrumbs.append((link, comps[i]))
+        breadcrumbs = [(url_path_join(self.base_url, 'tree'), '')]
+        parts = path.split('/')
+        for i in range(len(parts)):
+            if parts[i]:
+                link = url_path_join(self.base_url, 'tree',
+                    url_escape(url_path_join(*parts[:i+1])),
+                )
+                breadcrumbs.append((link, parts[i]))
         return breadcrumbs
 
     def generate_page_title(self, path):
@@ -53,9 +54,9 @@ class TreeHandler(IPythonHandler):
             model = cm.get(path, content=False)
             # redirect to /api/notebooks if it's a notebook, otherwise /api/files
             service = 'notebooks' if model['type'] == 'notebook' else 'files'
-            url = url_escape(url_path_join(
-                self.base_url, service, path,
-            ))
+            url = url_path_join(
+                self.base_url, service, url_escape(path),
+            )
             self.log.debug("Redirecting %s to %s", self.request.path, url)
             self.redirect(url)
         else:


### PR DESCRIPTION
base_url should already be url-encoded (on both sides), so it shouldn't ever be passed through to urlencode.

Both the javascript and server-side tests now run with a base URL that would be dealt with incorrectly if it were encoded.

closes #295