### PR TITLE
Doc: update headings info in example notebook

### DIFF
--- a/docs/source/examples/Notebook/Working With Markdown Cells.ipynb
+++ b/docs/source/examples/Notebook/Working With Markdown Cells.ipynb
@@ -159,8 +159,7 @@
     "Courtesy of MathJax, you can include mathematical expressions both inline: \n",
     "$e^{i\\pi} + 1 = 0$  and displayed:\n",
     "\n",
-    "$$e^x=\\sum_{i=0}^\\infty \\frac{1}{i!}x^i$$",
-    "\n",
+    "$$e^x=\\sum_{i=0}^\\infty \\frac{1}{i!}x^i$$\n",
     "Inline expressions can be added by surrounding the latex code with `$`:\n",
     "```\n",
     "$e^{i\\pi} + 1 = 0$\n",
@@ -315,7 +314,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.0"
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,

--- a/docs/source/examples/Notebook/Working With Markdown Cells.ipynb
+++ b/docs/source/examples/Notebook/Working With Markdown Cells.ipynb
@@ -112,19 +112,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you want, you can add headings using Markdown's syntax:\n",
+    "You can add headings by starting a line with one (or multiple) `#` followed by a space, as in the following example:\n",
     "\n",
     "# Heading 1\n",
     "# Heading 2\n",
     "## Heading 2.1\n",
     "## Heading 2.2"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**BUT most of the time you should use the Notebook's Heading Cells to organize your Notebook content**, as they provide meaningful structure that can be interpreted by other tools, not just large bold fonts."
    ]
   },
   {


### PR DESCRIPTION
This PR updates the example notebook "Working with Markdown" by removing outdated suggestion to use the cell type for headings.

While saving the notebook I had a few spurious modifications to the metadata that I put in a second commit.