### PR TITLE
setup.py fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,13 +67,13 @@ setup_args = dict(
     name            = name,
     description     = "A web-based notebook environment for interactive computing",
     long_description = """
-        The Jupyter Notebook is a web application that allows you to create and
-        share documents that contain live code, equations, visualizations, and
-        explanatory text. The Notebook has support for multiple programming
-        languages, sharing, and interactive widgets.
+The Jupyter Notebook is a web application that allows you to create and
+share documents that contain live code, equations, visualizations, and
+explanatory text. The Notebook has support for multiple programming
+languages, sharing, and interactive widgets.
 
-        Read `the documentation<https://jupyter-notebook.readthedocs.org>`_
-        for more information.
+Read `the documentation <https://jupyter-notebook.readthedocs.org>`_
+for more information.
     """,
     version         = version,
     scripts         = glob(pjoin('scripts', '*')),

--- a/setup.py
+++ b/setup.py
@@ -130,14 +130,7 @@ setup_args['cmdclass'] = {
 # Handle scripts, dependencies, and setuptools specific things
 #---------------------------------------------------------------------------
 
-# For some commands, use setuptools.  Note that we do NOT list install here!
-# If you want a setuptools-enhanced install, just run 'setupegg.py install'
-needs_setuptools = set(('develop', 'release', 'bdist_egg', 'bdist_rpm',
-           'bdist', 'bdist_dumb', 'bdist_wininst', 'bdist_wheel',
-           'egg_info', 'easy_install', 'upload', 'install_egg_info',
-            ))
-
-if len(needs_setuptools.intersection(sys.argv)) > 0:
+if any(arg.startswith('bdist') for arg in sys.argv):
     import setuptools
 
 # This dict is used for passing extra arguments that are setuptools


### PR DESCRIPTION
- use more conservative rule to pull in setuptools (same as we use on all the other packages now),
  fixes #339 which was caused by pulling in setuptools on `sdist upload`
- fix rst formatting for long_description