### PR TITLE
Update for additional build information from Read The Docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
+jupyter
+sphinx_rtd_theme
 jinja2
 tornado
 -e git+https://github.com/ipython/ipython_genutils.git#egg=ipython_genutils

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,12 +20,30 @@ import shlex
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('.'))
-sys.path.insert(0, os.path.abspath('../..'))
+
+# DEBUG for RTD
+print("DEBUG:: sys.path")
+print("================")
+for item in sys.path:
+    print(item)
+
+print("os.path.abspath('..')")
+print("=====================")
+print(os.path.abspath('..'))
+
+# Insert absolute path into system path
+sys.path.insert(0, os.path.abspath('..'))
+
+# DEBUG for post insert on RTD
+print("DEBUG:: Post insert to sys.path")
+print("===============================")
+for item in sys.path:
+    print(item)
 
 # Check if docs are being built by ReadTheDocs
 # If so, generate a config.rst file and populate it with documentation about
 # configuration options
+
 if os.environ.get('READTHEDOCS', ''):
 
     # Readthedocs doesn't run our Makefile, so we do this to force it to generate


### PR DESCRIPTION
Follow up on #488.

I've updated the `docs/requirements.txt` to install jupyter for docs builds on RTD and hopefully avoid RTD build from trying to drop back and run `setup.py` and `setup_base.py` which is causing build errors on RTD related to bower, npm, css/js. (Note: I'm hoping to avoid having to change either setup file.)

I've also updated `conf.py` with some debug code that should provide more info if RTD build fails.

cc/@minrk, @carreau