### PR TITLE
Allow all Cross-Origin Methods

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -386,6 +386,13 @@ class APIHandler(IPythonHandler):
         self.set_header('Content-Type', 'application/json')
         return super(APIHandler, self).finish(*args, **kwargs)
 
+    @web.authenticated
+    def options(self, *args, **kwargs):
+        self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
+        self.set_header('Access-Control-Allow-Methods',
+                        'GET, PUT, PATCH, DELETE, OPTIONS')
+        self.finish()
+
 
 class Template404(IPythonHandler):
     """Render our 404 template"""

--- a/notebook/services/api/handlers.py
+++ b/notebook/services/api/handlers.py
@@ -18,6 +18,13 @@ class APIHandler(web.StaticFileHandler, IPythonHandler):
         self.set_header('Content-Type', 'text/x-yaml')
         return web.StaticFileHandler.get(self, 'api.yaml')
 
+    @web.authenticated
+    def options(self, section_name):
+        self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
+        self.set_header('Access-Control-Allow-Methods',
+                        'GET, PUT, POST, PATCH, DELETE, OPTIONS')
+        self.finish()
+
 default_handlers = [
     (r"/api/spec.yaml", APIHandler)
 ]

--- a/notebook/services/api/handlers.py
+++ b/notebook/services/api/handlers.py
@@ -19,7 +19,7 @@ class APIHandler(web.StaticFileHandler, IPythonHandler):
         return web.StaticFileHandler.get(self, 'api.yaml')
 
     @web.authenticated
-    def options(self, section_name):
+    def options(self, *args, **kwargs):
         self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
         self.set_header('Access-Control-Allow-Methods',
                         'GET, PUT, POST, PATCH, DELETE, OPTIONS')

--- a/notebook/services/api/handlers.py
+++ b/notebook/services/api/handlers.py
@@ -18,13 +18,6 @@ class APIHandler(web.StaticFileHandler, IPythonHandler):
         self.set_header('Content-Type', 'text/x-yaml')
         return web.StaticFileHandler.get(self, 'api.yaml')
 
-    @web.authenticated
-    def options(self, *args, **kwargs):
-        self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
-        self.set_header('Access-Control-Allow-Methods',
-                        'GET, PUT, POST, PATCH, DELETE, OPTIONS')
-        self.finish()
-
 default_handlers = [
     (r"/api/spec.yaml", APIHandler)
 ]

--- a/notebook/services/config/handlers.py
+++ b/notebook/services/config/handlers.py
@@ -12,7 +12,7 @@ from ipython_genutils.py3compat import PY3
 from ...base.handlers import APIHandler, json_errors
 
 class ConfigHandler(APIHandler):
-    SUPPORTED_METHODS = ('GET', 'PUT', 'PATCH')
+    SUPPORTED_METHODS = ('GET', 'PUT', 'PATCH', 'OPTIONS')
 
     @web.authenticated
     @json_errors
@@ -33,6 +33,13 @@ class ConfigHandler(APIHandler):
         new_data = self.get_json_body()
         section = self.config_manager.update(section_name, new_data)
         self.finish(json.dumps(section))
+
+    @web.authenticated
+    @json_errors
+    def options(self, section_name):
+        self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
+        self.set_header('Access-Control-Allow-Methods', 'GET, PUT, PATCH')
+        self.finish()
 
 
 # URL to handler mappings

--- a/notebook/services/config/handlers.py
+++ b/notebook/services/config/handlers.py
@@ -12,7 +12,6 @@ from ipython_genutils.py3compat import PY3
 from ...base.handlers import APIHandler, json_errors
 
 class ConfigHandler(APIHandler):
-    SUPPORTED_METHODS = ('GET', 'PUT', 'PATCH', 'OPTIONS')
 
     @web.authenticated
     @json_errors
@@ -33,13 +32,6 @@ class ConfigHandler(APIHandler):
         new_data = self.get_json_body()
         section = self.config_manager.update(section_name, new_data)
         self.finish(json.dumps(section))
-
-    @web.authenticated
-    @json_errors
-    def options(self, section_name):
-        self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
-        self.set_header('Access-Control-Allow-Methods', 'GET, PUT, PATCH')
-        self.finish()
 
 
 # URL to handler mappings

--- a/notebook/services/contents/handlers.py
+++ b/notebook/services/contents/handlers.py
@@ -77,8 +77,6 @@ def validate_model(model, expect_content):
 
 class ContentsHandler(APIHandler):
 
-    SUPPORTED_METHODS = (u'GET', u'PUT', u'PATCH', u'POST', u'DELETE')
-
     def location_url(self, path):
         """Return the full URL location of a file.
 
@@ -259,8 +257,6 @@ class ContentsHandler(APIHandler):
 
 class CheckpointsHandler(APIHandler):
 
-    SUPPORTED_METHODS = ('GET', 'POST')
-
     @web.authenticated
     @json_errors
     @gen.coroutine
@@ -287,8 +283,6 @@ class CheckpointsHandler(APIHandler):
 
 
 class ModifyCheckpointsHandler(APIHandler):
-
-    SUPPORTED_METHODS = ('POST', 'DELETE')
 
     @web.authenticated
     @json_errors

--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -51,8 +51,6 @@ class MainKernelHandler(APIHandler):
 
 class KernelHandler(APIHandler):
 
-    SUPPORTED_METHODS = ('DELETE', 'GET', 'OPTIONS')
-
     @web.authenticated
     @json_errors
     def get(self, kernel_id):
@@ -67,12 +65,6 @@ class KernelHandler(APIHandler):
         km = self.kernel_manager
         km.shutdown_kernel(kernel_id)
         self.set_status(204)
-        self.finish()
-
-    @web.authenticated
-    @json_errors
-    def options(self, kernel_id):
-        self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
         self.finish()
 
 
@@ -90,12 +82,6 @@ class KernelActionHandler(APIHandler):
             model = km.kernel_model(kernel_id)
             self.set_header('Location', '{0}api/kernels/{1}'.format(self.base_url, kernel_id))
             self.write(json.dumps(model))
-        self.finish()
-
-    @web.authenticated
-    @json_errors
-    def options(self, kernel_id, action):
-        self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
         self.finish()
 
 

--- a/notebook/services/kernelspecs/handlers.py
+++ b/notebook/services/kernelspecs/handlers.py
@@ -44,7 +44,6 @@ def kernelspec_model(handler, name):
     return d
 
 class MainKernelSpecHandler(APIHandler):
-    SUPPORTED_METHODS = ('GET', 'OPTIONS')
 
     @web.authenticated
     @json_errors
@@ -64,14 +63,8 @@ class MainKernelSpecHandler(APIHandler):
         self.set_header("Content-Type", 'application/json')
         self.finish(json.dumps(model))
 
-    @web.authenticated
-    @json_errors
-    def options(self):
-        self.finish()
-
 
 class KernelSpecHandler(APIHandler):
-    SUPPORTED_METHODS = ('GET',)
 
     @web.authenticated
     @json_errors

--- a/notebook/services/nbconvert/handlers.py
+++ b/notebook/services/nbconvert/handlers.py
@@ -5,7 +5,6 @@ from tornado import web
 from ...base.handlers import APIHandler, json_errors
 
 class NbconvertRootHandler(APIHandler):
-    SUPPORTED_METHODS = ('GET',)
 
     @web.authenticated
     @json_errors

--- a/notebook/services/sessions/handlers.py
+++ b/notebook/services/sessions/handlers.py
@@ -68,15 +68,8 @@ class SessionRootHandler(APIHandler):
         self.set_status(201)
         self.finish(json.dumps(model, default=date_default))
 
-    @web.authenticated
-    @json_errors
-    def options(self):
-        self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
-        self.finish()
 
 class SessionHandler(APIHandler):
-
-    SUPPORTED_METHODS = ('GET', 'PATCH', 'DELETE')
 
     @web.authenticated
     @json_errors


### PR DESCRIPTION
Allows all REST API methods to be cross-origin, if explicitly requested with `--NotebookApp.allow_origin="*"`
