### PR TITLE
Don't re-use APIHandler name for serving yaml spec

### DIFF
--- a/notebook/services/api/handlers.py
+++ b/notebook/services/api/handlers.py
@@ -7,17 +7,17 @@ from tornado import web
 from ...base.handlers import IPythonHandler
 import os
 
-class APIHandler(web.StaticFileHandler, IPythonHandler):
+class APISpecHandler(web.StaticFileHandler, IPythonHandler):
 
     def initialize(self):
         web.StaticFileHandler.initialize(self, path=os.path.dirname(__file__))
 
     @web.authenticated
     def get(self):
-        self.log.debug("Serving api")
+        self.log.warn("Serving api spec (experimental, incomplete)")
         self.set_header('Content-Type', 'text/x-yaml')
         return web.StaticFileHandler.get(self, 'api.yaml')
 
 default_handlers = [
-    (r"/api/spec.yaml", APIHandler)
+    (r"/api/spec.yaml", APISpecHandler)
 ]


### PR DESCRIPTION
the re-used name causes unnecessary confusion