### PR TITLE
Improve navigation to 'Jupyter' Installation docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -326,5 +326,6 @@ texinfo_documents = [
 intersphinx_mapping = {
     'ipython': ('http://ipython.org/ipython-doc/dev/', None),
     'nbconvert': ('http://nbconvert.readthedocs.org/en/latest/', None),
-    'nbformat': ('http://nbformat.readthedocs.org/en/latest/', None)
+    'nbformat': ('http://nbformat.readthedocs.org/en/latest/', None),
+    'jupyter': ('http://jupyter.readthedocs.org/en/latest/', None),
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,10 +3,13 @@ The Jupyter notebook
 ====================
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: User Documentation
 
    notebook
+   Installation <https://jupyter.readthedocs.org/en/latest/install.html>
+   Running the Notebook <https://jupyter.readthedocs.org/en/latest/running.html>
+   Migrating from IPython <https://jupyter.readthedocs.org/en/latest/migrating.html>
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/notebook.rst
+++ b/docs/source/notebook.rst
@@ -22,8 +22,7 @@ text, mathematics, images, and rich media representations of objects.
 
 .. seealso::
 
-    See the :ref:`installation documentation <installnotebook>` for directions
-    on how to install the notebook and its dependencies.
+    See the :ref:`installation guide <jupyter:install>` on how to install the notebook and its dependencies.
 
 
 Main features of the web application


### PR DESCRIPTION
Addresses #501 

Screen captures at #501 and additional detail on the current user experience and proposed changes.

* Add Jupyter to intersphinx in `conf.py` so jupyter docs can be easily referenced.
* Add URLs to 'Jupyter' RTD sections on Installation, Running the Notebook, and Migrating from IPython (note: unfortunately, Sphinx does not support using intersphinx references in the toctree)
* Update link in see also box to refer to Jupyter docs