### PR TITLE
Adds kernel name to running notebooks list

### DIFF
--- a/notebook/services/kernels/kernelmanager.py
+++ b/notebook/services/kernels/kernelmanager.py
@@ -103,8 +103,10 @@ class MappingKernelManager(MultiKernelManager):
         """Return a dictionary of kernel information described in the
         JSON standard model."""
         self._check_kernel_id(kernel_id)
+        kernel_spec = self._kernels[kernel_id].kernel_spec
         model = {"id":kernel_id,
-                 "name": self._kernels[kernel_id].kernel_name}
+                 "name": self._kernels[kernel_id].kernel_name,
+                 "display_name": kernel_spec.display_name}
         return model
 
     def list_kernels(self):

--- a/notebook/static/tree/js/kernellist.js
+++ b/notebook/static/tree/js/kernellist.js
@@ -48,7 +48,7 @@ define([
                 name: path,
                 path: path,
                 type: 'notebook',
-                kernel_name: session.kernel_name
+                kernel_display_name: session.kernel.display_name
             }, item);
         }
         $('#running_list_placeholder').toggle($.isEmptyObject(d));
@@ -63,7 +63,7 @@ define([
         var that = this;
         var kernel_name = $('<div/>')
             .addClass('kernel-name')
-            .text(model.kernel_name)
+            .text(model.kernel_display_name)
             .appendTo(running_indicator);
 
         var shutdown_button = $('<button/>')

--- a/notebook/static/tree/js/kernellist.js
+++ b/notebook/static/tree/js/kernellist.js
@@ -36,17 +36,19 @@ define([
     KernelList.prototype.sessions_loaded = function (d) {
         this.sessions = d;
         this.clear_list();
-        var item, path;
+        var item, path, session;
         for (path in d) {
             if (!d.hasOwnProperty(path)) {
                 // nothing is safe in javascript
                 continue;
             }
+            session = d[path];
             item = this.new_item(-1);
             this.add_link({
                 name: path,
                 path: path,
                 type: 'notebook',
+                kernel_name: session.kernel_name
             }, item);
         }
         $('#running_list_placeholder').toggle($.isEmptyObject(d));
@@ -59,6 +61,11 @@ define([
             .text('');
 
         var that = this;
+        var kernel_name = $('<div/>')
+            .addClass('kernel-name')
+            .text(model.kernel_name)
+            .appendTo(running_indicator);
+
         var shutdown_button = $('<button/>')
             .addClass('btn btn-warning btn-xs')
             .text('Shutdown')

--- a/notebook/static/tree/js/sessionlist.js
+++ b/notebook/static/tree/js/sessionlist.js
@@ -74,7 +74,9 @@ define([
             nb_path = data[i].notebook.path;
             this.sessions[nb_path] = {
                 id: data[i].id,
-                kernel_name: data[i].kernel.name
+                kernel: {
+                  display_name: data[i].kernel.display_name
+                }
             };
         }
         this.events.trigger('sessions_loaded.Dashboard', this.sessions);

--- a/notebook/static/tree/js/sessionlist.js
+++ b/notebook/static/tree/js/sessionlist.js
@@ -72,7 +72,10 @@ define([
         var nb_path;
         for (var i=0; i<len; i++) {
             nb_path = data[i].notebook.path;
-            this.sessions[nb_path] = data[i].id;
+            this.sessions[nb_path] = {
+                id: data[i].id,
+                kernel_name: data[i].kernel.name
+            };
         }
         this.events.trigger('sessions_loaded.Dashboard', this.sessions);
     };

--- a/notebook/static/tree/less/tree.less
+++ b/notebook/static/tree/less/tree.less
@@ -149,6 +149,12 @@ ul.breadcrumb {
         padding-top: @dashboard_tb_pad;
         color: @brand-success;
     }
+    .kernel-name {
+        padding-top: @dashboard_tb_pad;
+        color: @brand-info;
+        margin-right: @dashboard_lr_pad;
+        float: left;
+    }
 }
 
 .toolbar_info {


### PR DESCRIPTION
This adds the kernel name to the running notebooks list, as requested in #395 .

I had to change the parameters passed to the `sessions_loaded.Dashboard` event to turn it from just the id to an object so it can store the id + kernel name (and maybe other things in the future). It *seems* like this does not break things, but if someone familiar with the js side can review this, that would be great.

![jupyter_kernel_name](https://cloud.githubusercontent.com/assets/506602/10134824/25802a90-65e9-11e5-9596-702b048a8ce2.png)