### PR TITLE
[WIP] Added ConfigSection object to MarkdownCell.config

### DIFF
--- a/notebook/static/notebook/js/textcell.js
+++ b/notebook/static/notebook/js/textcell.js
@@ -227,7 +227,8 @@ define([
          *          notebook: Notebook instance
          */
         options = options || {};
-        var config = utils.mergeopt(MarkdownCell, {});
+        var config = new configmod.ConfigSection('markdown',
+                utils.mergeopt(MarkdownCell, options.config, {}));
         this.class_config = new configmod.ConfigWithDefaults(options.config,
                                             {}, 'MarkdownCell');
         TextCell.apply(this, [$.extend({}, options, {config: config})]);

--- a/notebook/static/notebook/js/textcell.js
+++ b/notebook/static/notebook/js/textcell.js
@@ -227,8 +227,7 @@ define([
          *          notebook: Notebook instance
          */
         options = options || {};
-        var config = new configmod.ConfigSection('markdown',
-                utils.mergeopt(MarkdownCell, options.config, {}));
+        var config = new configmod.ConfigSection('markdown');
         this.class_config = new configmod.ConfigWithDefaults(options.config,
                                             {}, 'MarkdownCell');
         TextCell.apply(this, [$.extend({}, options, {config: config})]);


### PR DESCRIPTION
Should close #454.

I'm opening this @Carreau because I've got a couple of questions. Can you explain to me the purpose of `mergeopt` in this? I understand that in this particular case, it is just returning the `default_options` associated with the `Markdown` class, but why is this done?

Otherwise, I would just do:

```
var config = options.config;
this.class_config = new configmod.ConfigWithDefaults(options.config, {}, 'MarkdownCell');
```

As is done in the other Cell classes.

Thanks!
