### PR TITLE
limit merging of stream output

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -181,10 +181,12 @@ define([
         cell.append(input).append(output);
         this.element = cell;
         this.output_area = new outputarea.OutputArea({
-            selector: output, 
-            prompt_area: true, 
-            events: this.events, 
-            keyboard_manager: this.keyboard_manager});
+            config: this.config,
+            selector: output,
+            prompt_area: true,
+            events: this.events,
+            keyboard_manager: this.keyboard_manager,
+        });
         this.completer = new completer.Completer(this, this.events);
     };
 


### PR DESCRIPTION
Two changes:

- <del>Throttle websocket messages server-side (not kernel-side) to 60 Hz.
  This limits the ability for a flurry of messages to grind the CPU on the browser-side during message processing.</del>
- Limit 'append-to-previous' output behavior of consecutive stream messages
  to 8k chunks.

All the knobs are configurable.

This *does not* do any truncation or limiting of output in absolute terms, nor does it take the size of messages into account.

The most common source of killing your browser with messages is many consecutive stream outputs because of how we merge consecutive stream outputs, which is very expensive. By limiting the size of the chunk that we consider during this process, this limits the cost of those outputs. The one downside is that when there are two consecutive non-merged outputs, there is a small gap due to padding between output chunks. I'll spend a short time seeing if I can figure out the CSS to address that, but not long.

I think this closes ipython/ipython#6516 enough for 4.x.

cc @jhamrick, @ssanderson, @Carreau, @dsblank