### PR TITLE
get kernelspec info from kernelspecs

### DIFF
--- a/notebook/services/kernels/kernelmanager.py
+++ b/notebook/services/kernels/kernelmanager.py
@@ -103,10 +103,8 @@ class MappingKernelManager(MultiKernelManager):
         """Return a dictionary of kernel information described in the
         JSON standard model."""
         self._check_kernel_id(kernel_id)
-        kernel_spec = self._kernels[kernel_id].kernel_spec
         model = {"id":kernel_id,
-                 "name": self._kernels[kernel_id].kernel_name,
-                 "display_name": kernel_spec.display_name}
+                 "name": self._kernels[kernel_id].kernel_name}
         return model
 
     def list_kernels(self):

--- a/notebook/static/tree/js/kernellist.js
+++ b/notebook/static/tree/js/kernellist.js
@@ -23,6 +23,8 @@ define([
         notebooklist.NotebookList.call(this, selector, $.extend({
             element_name: 'running'},
             options));
+        this.kernelspecs = this.sessions = null;
+        this.events.on('kernelspecs_loaded.KernelSpec', $.proxy(this._kernelspecs_loaded, this));
     };
 
     KernelList.prototype = Object.create(notebooklist.NotebookList.prototype);
@@ -33,8 +35,19 @@ define([
          */
     };
     
+    KernelList.prototype._kernelspecs_loaded = function (event, kernelspecs) {
+        this.kernelspecs = kernelspecs;
+        if (this.sessions) {
+            // trigger delayed session load, since kernelspecs arrived later
+            this.sessions_loaded(this.sessions);
+        }
+    };
+    
     KernelList.prototype.sessions_loaded = function (d) {
         this.sessions = d;
+        if (!this.kernelspecs) {
+            return; // wait for kernelspecs before first load
+        }
         this.clear_list();
         var item, path, session;
         for (path in d) {
@@ -48,14 +61,14 @@ define([
                 name: path,
                 path: path,
                 type: 'notebook',
-                kernel_display_name: session.kernel.display_name
+                kernel_display_name: this.kernelspecs[session.kernel.name].spec.display_name
             }, item);
         }
         $('#running_list_placeholder').toggle($.isEmptyObject(d));
     };
 
     KernelList.prototype.add_link = function (model, item) {
-        notebooklist.NotebookList.prototype.add_link.apply(this, [model, item])
+        notebooklist.NotebookList.prototype.add_link.apply(this, [model, item]);
 
         var running_indicator = item.find(".item_buttons")
             .text('');

--- a/notebook/static/tree/js/main.js
+++ b/notebook/static/tree/js/main.js
@@ -60,10 +60,10 @@ require([
     });
     var notebook_list = new notebooklist.NotebookList('#notebook_list', $.extend({
         contents: contents,
-        session_list:  session_list}, 
+        session_list:  session_list},
         common_options));
     var kernel_list = new kernellist.KernelList('#running_list',  $.extend({
-        session_list:  session_list}, 
+        session_list:  session_list},
         common_options));
     
     var terminal_list;
@@ -75,7 +75,7 @@ require([
 
     var new_buttons = new newnotebook.NewNotebookWidget("#new-buttons",
         $.extend(
-            {contents: contents},
+            {contents: contents, events: events},
             common_options
         )
     );

--- a/notebook/static/tree/js/newnotebook.js
+++ b/notebook/static/tree/js/newnotebook.js
@@ -14,6 +14,7 @@ define([
         this.base_url = options.base_url;
         this.notebook_path = options.notebook_path;
         this.contents = options.contents;
+        this.events = options.events;
         this.default_kernel = null;
         this.kernelspecs = {};
         if (this.selector !== undefined) {
@@ -69,6 +70,7 @@ define([
                 );
             menu.after(li);
         }
+        this.events.trigger('kernelspecs_loaded.KernelSpec', data.kernelspecs);
     };
     
     NewNotebookWidget.prototype.new_notebook = function (kernel_name) {

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -27,6 +27,7 @@ define([
          */
         var that = this;
         this.session_list = options.session_list;
+        this.events = this.session_list.events;
         // allow code re-use by just changing element_name in kernellist.js
         this.element_name = options.element_name || 'notebook';
         this.selector = selector;

--- a/notebook/static/tree/js/sessionlist.js
+++ b/notebook/static/tree/js/sessionlist.js
@@ -75,7 +75,7 @@ define([
             this.sessions[nb_path] = {
                 id: data[i].id,
                 kernel: {
-                  display_name: data[i].kernel.display_name
+                  name: data[i].kernel.name
                 }
             };
         }


### PR DESCRIPTION
client-side, instead of modifying the sessions model to include display_name

This fixes recently-introduced test failures in master (my fault) from #503