### PR TITLE
Expose the default port of 8888

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,3 +56,5 @@ RUN pip3 install --pre -e .
 # install kernels
 RUN python2 -m ipykernel.kernelspec
 RUN python3 -m ipykernel.kernelspec
+
+EXPOSE 8888


### PR DESCRIPTION
Seems like a reasonable default. We probably held back from doing this to not give people an unopinionated form of the original `ipython/ipython` image, but this is the raw notebook. With an `EXPOSE`d port, tmpnb can reason about it directly.

For Mr. @zischwartz 