### PR TITLE
Docker image change and README update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,16 @@ RUN apt-get update -qq \
  && rm get-pip.py \
  \
  && pip2 --no-cache-dir install ipykernel \
- && pip3 --no-cache-dir install ipykernel
+ && pip3 --no-cache-dir install ipykernel \
+ \
+ && python2 -m ipykernel.kernelspec \
+ && python3 -m ipykernel.kernelspec \
+ \
+ && pip2 install --no-cache-dir mock nose requests testpath \
+ && pip3 install --no-cache-dir nose requests testpath \
+ && iptest2 && iptest3 \
+ && pip2 uninstall -y funcsigs mock nose pbr requests six testpath \
+ && pip3 uninstall -y nose requests testpath
 
 ADD . /usr/src/jupyter-notebook
 
@@ -55,16 +64,7 @@ RUN ln -s /usr/src/jupyter-notebook/scripts/lxc-launcher.sh /launch.sh \
  \
  && apt-get purge -y --auto-remove \
        -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $BUILD_DEPS \
- && rm -rf /var/lib/apt/lists/* \
- \
- && python2 -m ipykernel.kernelspec \
- && python3 -m ipykernel.kernelspec \
- \
- && pip2 install --no-cache-dir mock nose requests testpath \
- && pip3 install --no-cache-dir nose requests testpath \
- && iptest2 && iptest3 \
- && pip2 uninstall -y funcsigs mock nose pbr requests six testpath \
- && pip3 uninstall -y nose requests testpath
+ && rm -rf /var/lib/apt/lists/*
 
 VOLUME /notebooks
 WORKDIR /notebooks

--- a/README.md
+++ b/README.md
@@ -6,7 +6,34 @@
 
 The Jupyter HTML notebook is a web-based notebook environment for interactive computing.
 
-Dev quickstart:
+## Usage
+
+### Local installation
+
+Launch with:
+
+    $ jupyter notebook
+
+### In a Docker container
+
+If you have a [Docker daemon running](https://docs.docker.com/installation/), e.g. reachable on `localhost`, start a container with:
+
+    $ docker run -d -p "8888:8888" --name="myproject" jupyter/notebook
+
+In your browser open the URL `http://localhost:8888/`.
+
+The image defines a [volume](https://docs.docker.com/userguide/dockervolumes/) for notebook files at `/notebooks`.
+You can override it to mount a host path, e.g. the current working directory:
+
+    $ docker run -d -p "8888:8888" -v "$(pwd):/notebooks" --name="myproject" jupyter/notebook
+
+## Installation
+
+For a local installation, make sure you have [pip installed](https://pip.readthedocs.org/en/stable/installing/) and run:
+
+    $ pip install notebook
+
+### Dev quickstart
 
 * ensure that you have node/npm installed (e.g. `brew install node` on OS X)
 * Clone this repo and cd into it
@@ -15,11 +42,7 @@ Dev quickstart:
 _NOTE_: For Debian/Ubuntu systems, if you're installing the system node you need
 to use the 'nodejs-legacy' package and not the 'node' package.
 
-Launch with:
-
-    jupyter notebook
-
-Example installation (tested on Ubuntu Trusty):
+### Ubuntu Trusty
 
 ```
 sudo apt-get install nodejs-legacy npm python-virtualenv python-dev
@@ -31,7 +54,8 @@ pip install --pre -e .
 jupyter notebook
 ```
 
-For FreeBSD:
+### FreeBSD
+
 ```
 cd /usr/ports/www/npm
 sudo make install    # (Be sure to select the "NODE" option)


### PR DESCRIPTION
this includes a change that makes local builds of a docker image faster if there are no changes to the prequisites.

i added instructions for using the Docker image and placed them rather on the top as it should be seen [at the image description](https://hub.docker.com/r/jupyter/notebook/).

i would also suggest that the docker registry repo is bound to another source repo as it is expected there to provide only stable releases or at least a stable release as default. atm only a reflection of the master's tip is available.
it would also allow to design the `Dockerfile` here for development purposes and to add image variants (i could make use of an onbuild-variant to include packages).
disclaimer: if this didn't change recently, the docker registry repo must be deleted and be created again to link it to another source repo. as a sideeffect all repo statistics go to void.


regarding `scripts/lxc-launcher.sh`, this still seems to need some work.

while a kill invoked with `docker kill` doesn't reach the timeout, it stops immediately w/o shutting down the kernels.
the wrapped process returns an exit code 137.

if this is tolerable, the script should transform that 137 to a 0 for the docker host.

furthermore i noticed that when it's running in a docker-compose setup and one is attached to their stdout, the container again exceeds the timeout when invoking a shutdown with <ctrl + c> (this sends a TERM to all containers).
