### PR TITLE
Try to clean up the Dockerfile a bit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ MAINTAINER Project Jupyter <jupyter@googlegroups.com>
 ENV LANGUAGE en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
+ENV PYTHONIOENCODING UTF-8
 
 # Python binary and source dependencies
 RUN apt-get update -qq \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,16 @@ RUN apt-get update -qq \
  && rm get-pip.py \
  \
  && pip2 --no-cache-dir install ipykernel \
- && pip3 --no-cache-dir install ipykernel
+ && pip3 --no-cache-dir install ipykernel \
+ \
+ && python2 -m ipykernel.kernelspec \
+ && python3 -m ipykernel.kernelspec \
+ \
+ && pip2 install --no-cache-dir mock nose requests testpath \
+ && pip3 install --no-cache-dir nose requests testpath \
+ && iptest2 && iptest3 \
+ && pip2 uninstall -y funcsigs mock nose pbr requests six testpath \
+ && pip3 uninstall -y nose requests testpath
 
 ADD . /usr/src/jupyter-notebook
 
@@ -55,16 +64,7 @@ RUN ln -s /usr/src/jupyter-notebook/scripts/lxc-launcher.sh /launch.sh \
  \
  && apt-get purge -y --auto-remove \
        -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $BUILD_DEPS \
- && rm -rf /var/lib/apt/lists/* \
- \
- && python2 -m ipykernel.kernelspec \
- && python3 -m ipykernel.kernelspec \
- \
- && pip2 install --no-cache-dir mock nose requests testpath \
- && pip3 install --no-cache-dir nose requests testpath \
- && iptest2 && iptest3 \
- && pip2 uninstall -y funcsigs mock nose pbr requests six testpath \
- && pip3 uninstall -y nose requests testpath
+ && rm -rf /var/lib/apt/lists/*
 
 VOLUME /notebooks
 WORKDIR /notebooks

--- a/README.md
+++ b/README.md
@@ -18,14 +18,10 @@ Launch with:
 
 If you have a [Docker daemon running](https://docs.docker.com/installation/), e.g. reachable on `localhost`, start a container with:
 
-    $ docker run -d -p "8888:8888" --name="myproject" jupyter/notebook
+    $ docker run --rm -itP -v "$(pwd):/notebooks" jupyter/notebook
 
 In your browser open the URL `http://localhost:8888/`.
-
-The image defines a [volume](https://docs.docker.com/userguide/dockervolumes/) for notebook files at `/notebooks`.
-You can override it to mount a host path, e.g. the current working directory:
-
-    $ docker run -d -p "8888:8888" -v "$(pwd):/notebooks" --name="myproject" jupyter/notebook
+All notebooks from your session will be saved in the current directory.
 
 On other platforms without `docker`, this can be started using `docker-machine`
 by replacing `localhost` with an IP from [`docker-machine ip <MACHINE>`](https://docs.docker.com/machine/reference/ip/).

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ You can override it to mount a host path, e.g. the current working directory:
 
     $ docker run -d -p "8888:8888" -v "$(pwd):/notebooks" --name="myproject" jupyter/notebook
 
+On other platforms without `docker`, this can be started using `docker-machine`
+by replacing `localhost` with an IP from [`docker-machine ip <MACHINE>`](https://docs.docker.com/machine/reference/ip/).
+With the deprecated `boot2docker`, this IP will be `boot2docker ip`.
+
 ## Installation
 
 For a local installation, make sure you have [pip installed](https://pip.readthedocs.org/en/stable/installing/) and run:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,34 @@
 
 The Jupyter HTML notebook is a web-based notebook environment for interactive computing.
 
-Dev quickstart:
+## Usage
+
+### Local installation
+
+Launch with:
+
+    $ jupyter notebook
+
+### In a Docker container
+
+If you have a [Docker daemon running](https://docs.docker.com/installation/), e.g. reachable on `localhost`, start a container with:
+
+    $ docker run -d -p "8888:8888" --name="myproject" jupyter/notebook
+
+In your browser open the URL `http://localhost:8888/`.
+
+The image defines a [volume](https://docs.docker.com/userguide/dockervolumes/) for notebook files at `/notebooks`.
+You can override it to mount a host path, e.g. the current working directory:
+
+    $ docker run -d -p "8888:8888" -v "$(pwd):/notebooks" --name="myproject" jupyter/notebook
+
+## Installation
+
+For a local installation, make sure you have [pip installed](https://pip.readthedocs.org/en/stable/installing/) and run:
+
+    $ pip install notebook
+
+### Dev quickstart
 
 * ensure that you have node/npm installed (e.g. `brew install node` on OS X)
 * Clone this repo and cd into it
@@ -15,11 +42,7 @@ Dev quickstart:
 _NOTE_: For Debian/Ubuntu systems, if you're installing the system node you need
 to use the 'nodejs-legacy' package and not the 'node' package.
 
-Launch with:
-
-    jupyter notebook
-
-Example installation (tested on Ubuntu Trusty):
+### Ubuntu Trusty
 
 ```
 sudo apt-get install nodejs-legacy npm python-virtualenv python-dev
@@ -31,7 +54,8 @@ pip install --pre -e .
 jupyter notebook
 ```
 
-For FreeBSD:
+### FreeBSD
+
 ```
 cd /usr/ports/www/npm
 sudo make install    # (Be sure to select the "NODE" option)


### PR DESCRIPTION
* Includes ( https://github.com/jupyter/notebook/pull/537 ).
* Put `&&` at the end of the previous line to avoid being too distracting.
* Clean up after the first use of `apt-get update` to, hopefully, cut down layer size.
* Break out installation of `pip` into a separate layer.
* Install some dependencies before adding the repo. (should help avoid cache invalidation until later)
* Breaks up installation and testing layers.
* Sum total layer size is not noticeably changed.
* Layers are better organized by steps.
* Appears to make a small speedup in build time (~30s).
* Maintains the same underlying behavior without adding any new features.
* Show how to start notebook with `docker` the same way one would without `docker`.
* Fixes an encoding issue that occurs with Python2 when there is no terminal connected to `sys.stdout` (e.g. building the image).