### PR TITLE
point bower at CodeMirror hash until a new version is released

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "backbone": "components/backbone#~1.2",
     "bootstrap": "components/bootstrap#~3.3",
     "bootstrap-tour": "0.9.0",
-    "codemirror": "~5.5",
+    "codemirror": "git://github.com/codemirror/CodeMirror.git#5fafcf837480430b614085d62d884098ccd53297",
     "es6-promise": "~1.0",
     "font-awesome": "components/font-awesome#~4.2.0",
     "google-caja": "5669",


### PR DESCRIPTION
This fixes #513 by pointing bower at the commit hash for the fix in CodeMirror. This can be updated once the next version of CodeMirror is released.