### PR TITLE
fix subcommand quoting on Windows in setup.py

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -24,6 +24,11 @@ from glob import glob
 from multiprocessing.pool import ThreadPool
 from subprocess import check_call
 
+if sys.platform == 'win32':
+    from subprocess import list2cmdline
+else:
+    def list2cmdline(cmd_list):
+        return ' '.join(map(pipes.quote, cmd_list))
 
 #-------------------------------------------------------------------------------
 # Useful globals and utility functions
@@ -296,10 +301,8 @@ def mtime(path):
 
 def run(cmd, *args, **kwargs):
     """Echo a command before running it"""
-    if isinstance(cmd, list):
-        cmd = ' '.join(map(pipes.quote, cmd))
-    log.info('> ' + cmd)
-    kwargs['shell'] = True
+    log.info('> ' + list2cmdline(cmd))
+    kwargs['shell'] = (sys.platform == 'win32')
     return check_call(cmd, *args, **kwargs)
 
 


### PR DESCRIPTION
Windows accepts command lists when shell=True. With this, build completes successfully on Windows.

closes #540