### PR TITLE
Fixes the build on Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,15 @@ ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 ENV PYTHONIOENCODING UTF-8
 
+# Remove preinstalled copy of python that blocks are ability to install development python.
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -yq \
+        python3-minimal \
+        python3.4 \
+        python3.4-minimal \
+        libpython3-stdlib \
+        libpython3.4-stdlib \
+        libpython3.4-minimal
+
 # Python binary and source dependencies
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \


### PR DESCRIPTION
Broken out from my work here ( https://github.com/jupyter/notebook/pull/547 ). I found this was necessary to get building on the new `ubuntu` images given this issue ( https://github.com/docker-library/official-images/issues/1110 ). There appears to be a broken `python` install present, which blocks our first `apt-get` step and consequently every other step. This will simply remove it before proceeding.