### PR TITLE
Docker: Drop port argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,4 +95,4 @@ WORKDIR /notebooks
 EXPOSE 8888
 
 ENTRYPOINT ["tini", "--"]
-CMD ["jupyter", "notebook", "--port", "8888", "--ip=*"]
+CMD ["jupyter", "notebook", "--ip=*"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,15 @@ ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 ENV PYTHONIOENCODING UTF-8
 
+# Remove preinstalled copy of python that blocks are ability to install development python.
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -yq \
+        python3-minimal \
+        python3.4 \
+        python3.4-minimal \
+        libpython3-stdlib \
+        libpython3.4-stdlib \
+        libpython3.4-minimal
+
 # Python binary and source dependencies
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \


### PR DESCRIPTION
Drops the port argument as it is the default argument anyways. Tested build and running to make sure it still performed correctly.

Currently, had to base off of this PR ( https://github.com/jupyter/notebook/pull/572 ) to get it to build through.