### PR TITLE
Fix handling of upload add_link

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -815,7 +815,7 @@ define([
                     filedata = btoa(bytes);
                     format = 'base64';
                 }
-                var model = {};
+                var model = { name: filename, path: path };
 
                 var name_and_ext = utils.splitext(filename);
                 var file_ext = name_and_ext[1];


### PR DESCRIPTION
Avoids this error when uploading a file in the tree view in the latest master, run as `jupyter notebook --NotebookApp.ignore_minified_js=True`

<img width="537" alt="screen shot 2015-10-09 at 4 05 11 pm" src="https://cloud.githubusercontent.com/assets/2096628/10405616/a54e48d8-6e9f-11e5-8952-f88c0ed65958.png">
