### PR TITLE
Specify ip via config file instead of command-line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,10 +92,14 @@ RUN pip2 install --no-cache-dir mock nose requests testpath && \
     pip2 uninstall -y funcsigs mock nose pbr requests six testpath && \
     pip3 uninstall -y nose requests testpath
 
+# Add a notebook profile.
+RUN mkdir -p -m 700 /root/.jupyter/ && \
+    echo "c.NotebookApp.ip = '*'" >> /root/.jupyter/jupyter_notebook_config.py
+
 VOLUME /notebooks
 WORKDIR /notebooks
 
 EXPOSE 8888
 
 ENTRYPOINT ["tini", "--"]
-CMD ["jupyter", "notebook", "--ip=*"]
+CMD ["jupyter", "notebook"]


### PR DESCRIPTION
Ensures the `jupyter` notebook profile has the `ip` argument as `*` and drops it from the arguments in `CMD`. 