### PR TITLE
fixed bug in javascript for shutting down notebook

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -618,7 +618,7 @@ define([
             var url = utils.url_path_join(
                 this.base_url,
                 'api/sessions',
-                encodeURIComponent(session)
+                encodeURIComponent(session.id)
             );
             $.ajax(url, settings);
         }


### PR DESCRIPTION
javascript object included `id` and `kernel` keys, breaking the ability to shut down a notebook

closes #563