### PR TITLE
Resolve some `InsecurePlatformWarning` when installing with `pip`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update -qq && \
         git \
         language-pack-en \
         libcurl4-openssl-dev \
+        libffi-dev \
         libsqlite3-dev \
         libzmq3-dev \
         pandoc \
@@ -56,7 +57,9 @@ RUN curl -L https://github.com/krallin/tini/releases/download/v0.6.0/tini > tini
 RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     python2 get-pip.py && \
     python3 get-pip.py && \
-    rm get-pip.py
+    rm get-pip.py && \
+    pip2 --no-cache-dir install requests[security] && \
+    pip3 --no-cache-dir install requests[security]
 
 # Install some dependencies.
 RUN pip2 --no-cache-dir install ipykernel && \


### PR DESCRIPTION
Installs `requests[security]` to silence some `InsecurePlatformWarning`s. This won't work when installing `pip` via `get-pip.py` as that is due to a different issue ( https://github.com/pypa/pip/issues/2681 ).