### PR TITLE
Docker purge unneeded files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,7 @@ RUN BUILD_DEPS="nodejs-legacy npm" && \
     \
     npm cache clean && \
     apt-get clean && \
+    rm -rf /root/.npm && \
     rm -rf /root/.cache && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get purge -y --auto-remove \

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ RUN BUILD_DEPS="nodejs-legacy npm" && \
     \
     pip3 install --no-cache-dir --pre -e /usr/src/jupyter-notebook && \
     \
+    npm cache clean && \
     apt-get clean && \
     rm -rf /root/.cache && \
     rm -rf /var/lib/apt/lists/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,7 @@ RUN BUILD_DEPS="nodejs-legacy npm" && \
     rm -rf /root/.cache && \
     rm -rf /root/.config && \
     rm -rf /root/.local && \
+    rm -rf /root/tmp && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get purge -y --auto-remove \
         -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $BUILD_DEPS

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ RUN BUILD_DEPS="nodejs-legacy npm" && \
     apt-get clean && \
     rm -rf /root/.npm && \
     rm -rf /root/.cache && \
+    rm -rf /root/.config && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get purge -y --auto-remove \
         -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $BUILD_DEPS

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,14 +59,17 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \
     rm get-pip.py && \
     pip2 --no-cache-dir install requests[security] && \
-    pip3 --no-cache-dir install requests[security]
+    pip3 --no-cache-dir install requests[security] && \
+    rm get-pip.py && \
+    rm -rf /root/.cache
 
 # Install some dependencies.
 RUN pip2 --no-cache-dir install ipykernel && \
     pip3 --no-cache-dir install ipykernel && \
     \
     python2 -m ipykernel.kernelspec && \
-    python3 -m ipykernel.kernelspec
+    python3 -m ipykernel.kernelspec && \
+    rm -rf /root/.cache
 
 # Move notebook contents into place.
 ADD . /usr/src/jupyter-notebook
@@ -79,6 +82,7 @@ RUN BUILD_DEPS="nodejs-legacy npm" && \
     pip3 install --no-cache-dir --pre -e /usr/src/jupyter-notebook && \
     \
     apt-get clean && \
+    rm -rf /root/.cache && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get purge -y --auto-remove \
         -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $BUILD_DEPS
@@ -90,7 +94,8 @@ RUN pip2 install --no-cache-dir mock nose requests testpath && \
     iptest2 && iptest3 && \
     \
     pip2 uninstall -y funcsigs mock nose pbr requests six testpath && \
-    pip3 uninstall -y nose requests testpath
+    pip3 uninstall -y nose requests testpath && \
+    rm -rf /root/.cache
 
 # Add a notebook profile.
 RUN mkdir -p -m 700 /root/.jupyter/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,7 @@ RUN BUILD_DEPS="nodejs-legacy npm" && \
     rm -rf /root/.npm && \
     rm -rf /root/.cache && \
     rm -rf /root/.config && \
+    rm -rf /root/.local && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get purge -y --auto-remove \
         -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $BUILD_DEPS


### PR DESCRIPTION
* Clears the `~/.cache` directory at every build step as `pip` and `npm` are filling it with junk. ( ~100MB )
* Clears the `~/.npm` directory (just used for cache). ( ~36.7MB )
* Clears the `~/.config` directory after building the notebook (only has `bower` stuff and `bower` is removed).
* Clears the `~/.local` directory after building the notebook (only has `bower` stuff and `bower` is removed).
* Clears the `~/tmp` directory after building the notebook (is already empty).