### PR TITLE
Add the ability to mark cells.

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -423,12 +423,12 @@ define(function(require){
                 env.notebook.show_command_palette();
             }
         },
-        'toggle-marks': {
+        'toggle-cell-marked': {
             help_index : 'cj',
             help: 'toggle marks',
             icon: 'fa-check',
             handler : function(env){
-                env.notebook.toggle_marks(env.notebook.get_selected_cells());
+                env.notebook.toggle_cells_marked(env.notebook.get_selected_cells());
             }
         },
     };

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -423,6 +423,14 @@ define(function(require){
                 env.notebook.show_command_palette();
             }
         },
+        'toggle-marks': {
+            help_index : 'cj',
+            help: 'toggle marks',
+            icon: 'fa-check',
+            handler : function(env){
+                env.notebook.toggle_marks(env.notebook.get_selected_cells());
+            }
+        },
     };
 
     /**

--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -288,28 +288,6 @@ define([
     };
     
     /**
-     * Marks the cell
-     * @return {Cell} this
-     */
-    Cell.prototype.mark = function() {
-        if (!this.marked) {
-            this.element.addClass('marked');
-        }
-        return this;
-    };
-    
-    /**
-     * Unmarks the cell
-     * @return {Cell} this
-     */
-    Cell.prototype.unmark = function() {
-        if (this.marked) {
-            this.element.removeClass('marked');
-        }
-        return this;
-    };
-    
-    /**
      * Whether or not the cell is marked.
      * @return {boolean}
      */
@@ -318,10 +296,13 @@ define([
             return this.element.hasClass('marked');
         },
         set: function(value) {
-            if (value) {
-                this.mark();
-            } else {
-                this.unmark();
+            var isMarked = this.element.hasClass('marked');
+            if (isMarked !== value) {
+                if (value) {
+                    this.element.addClass('marked');
+                } else {
+                    this.element.removeClass('marked');
+                }
             }
         }
     });

--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -169,6 +169,11 @@ define([
             if (!that.selected) {
                 that.events.trigger('select.Cell', {'cell':that});
             }
+                
+            // Ctrl-click should mark the c ell.
+            if (event.ctrlKey) {
+                that.marked = !that.marked;
+            }
         });
         that.element.focusin(function (event) {
             if (!that.selected) {
@@ -280,6 +285,45 @@ define([
         }
         return was_selected_cell;
     };
+    
+    /**
+     * Marks the cell
+     * @return {Cell} this
+     */
+    Cell.prototype.mark = function() {
+        if (!this.marked) {
+            this.element.addClass('marked');
+        }
+        return this;
+    };
+    
+    /**
+     * Unmarks the cell
+     * @return {Cell} this
+     */
+    Cell.prototype.unmark = function() {
+        if (this.marked) {
+            this.element.removeClass('marked');
+        }
+        return this;
+    };
+    
+    /**
+     * Whether or not the cell is marked.
+     * @return {boolean}
+     */
+    Object.defineProperty(Cell.prototype, 'marked', {
+        get: function() {
+            return this.element.hasClass('marked');
+        },
+        set: function(value) {
+            if (value) {
+                this.mark();
+            } else {
+                this.unmark();
+            }
+        }
+    });
 
     /**
      * should be overritten by subclass

--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -169,9 +169,10 @@ define([
             if (!that.selected) {
                 that.events.trigger('select.Cell', {'cell':that});
             }
-                
-            // Ctrl-click should mark the c ell.
-            if (event.ctrlKey) {
+            
+            // Cmdtrl-click should mark the cell.
+            var isMac = navigator.platform.slice(0, 3).toLowerCase() === 'mac';
+            if ((!isMac && event.ctrlKey) || (isMac && event.metaKey)) {
                 that.marked = !that.marked;
             }
         });

--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -93,7 +93,7 @@ define([
             'enter' : 'ipython.enter-edit-mode',
             'space' : 'ipython.scroll-down',
             'down' : 'ipython.select-next-cell',
-            'cmdtrl-space' : 'ipython.toggle-marks',
+            'ctrl-space' : 'ipython.toggle-marks',
             'i,i' : 'ipython.interrupt-kernel',
             '0,0' : 'ipython.restart-kernel',
             'd,d' : 'ipython.delete-cell',

--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -93,7 +93,7 @@ define([
             'enter' : 'ipython.enter-edit-mode',
             'space' : 'ipython.scroll-down',
             'down' : 'ipython.select-next-cell',
-            'ctrl-space' : 'ipython.toggle-marks',
+            'ctrl-space' : 'ipython.toggle-cell-marked',
             'i,i' : 'ipython.interrupt-kernel',
             '0,0' : 'ipython.restart-kernel',
             'd,d' : 'ipython.delete-cell',

--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -93,6 +93,7 @@ define([
             'enter' : 'ipython.enter-edit-mode',
             'space' : 'ipython.scroll-down',
             'down' : 'ipython.select-next-cell',
+            'cmdtrl-space' : 'ipython.toggle-marks',
             'i,i' : 'ipython.interrupt-kernel',
             '0,0' : 'ipython.restart-kernel',
             'd,d' : 'ipython.delete-cell',

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -628,6 +628,73 @@ define(function (require) {
         });
         return result;
     };
+    
+    /**
+     * Toggles the marks on the cells
+     * @param  {Cell[]} [cells] - optionally specify what cells should be toggled
+     */
+    Notebook.prototype.toggle_marks = function(cells) {
+        cells = cells || this.get_cells();
+        cells.forEach(function(cell) { cell.marked = !cell.marked; });
+    };
+    
+    /**
+     * Mark all of the cells
+     * @param  {Cell[]} [cells] - optionally specify what cells should be marked
+     */
+    Notebook.prototype.mark_all = function(cells) {
+        cells = cells || this.get_cells();
+        cells.forEach(function(cell) { cell.mark(); });
+    };
+    
+    /**
+     * Unmark all of the cells
+     * @param  {Cell[]} [cells] - optionally specify what cells should be unmarked
+     */
+    Notebook.prototype.unmark_all = function(cells) {
+        this.get_marked_cells(cells).forEach(function(cell) { cell.unmark(); });
+    };
+    
+    /**
+     * Set the cells that should be marked, exclusively
+     * @param  {Cell[]} cells
+     */
+    Notebook.prototype.set_marked_cells = function(cells) {
+        this.unmark_all();
+        this.mark_all(cells);
+    };
+    
+    /**
+     * Gets the cells that are marked
+     * @param  {Cell[]} [cells] - optionally provide the cells to search through
+     * @return {Cell[]} marked cells
+     */
+    Notebook.prototype.get_marked_cells = function(cells) {
+        cells = cells || this.get_cells();
+        return cells.filter(function(cell) { return cell.marked; });
+    };
+    
+    /**
+     * Sets the cells that are marked by indices
+     * @param  {number[]} indices
+     * @param  {Cell[]} [cells] - optionally provide the cells to search through
+     */
+    Notebook.prototype.set_marked_indices = function(indices, cells) {
+        cells = cells || this.get_cells();
+        this.unmark_all(cells);
+        this.mark_all(cells.filter(function(cell, index) { return indices.indexOf(index) !== -1; }));
+    };
+    
+    /**
+     * Gets the indices of the cells that are marked
+     * @param  {Cell[]} [cells] - optionally provide the cells to search through
+     * @return {number[]} marked cell indices
+     */
+    Notebook.prototype.get_marked_indices = function(cells) {
+        cells = cells || this.get_cells();
+        var markedCells = this.get_marked_cells(cells);
+        return markedCells.map(function(cell) { return cells.indexOf(cell); });
+    };
 
     /**
      * Get an array of the cells in the currently selected range

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -644,7 +644,7 @@ define(function (require) {
      */
     Notebook.prototype.mark_all_cells = function(cells) {
         cells = cells || this.get_cells();
-        cells.forEach(function(cell) { cell.mark(); });
+        cells.forEach(function(cell) { cell.marked = true; });
     };
     
     /**
@@ -652,7 +652,7 @@ define(function (require) {
      * @param  {Cell[]} [cells] - optionally specify what cells should be unmarked
      */
     Notebook.prototype.unmark_all_cells = function(cells) {
-        this.get_marked_cells(cells).forEach(function(cell) { cell.unmark(); });
+        this.get_marked_cells(cells).forEach(function(cell) { cell.marked = false; });
     };
     
     /**
@@ -701,7 +701,7 @@ define(function (require) {
      * @param  {Cell[]} [cells] - optionally provide the cells to search through
      * @return {boolean}
      */
-    Notebook.prototype.are_marks_contiguous = function(cells) {
+    Notebook.prototype.are_marked_cells_contiguous = function(cells) {
         // Get a numerically sorted list of the marked indices.
         var markedIndices = this.get_marked_indices(cells).sort(
             function(a,b) { return a-b; });
@@ -713,6 +713,19 @@ define(function (require) {
             }
         }
         return true;
+    };
+    
+    /**
+     * Checks if the marked cells specified by their indices are contiguous
+     * @param  {number[]} indices - the cell indices to search through
+     * @param  {Cell[]} [cells] - the cells to search through
+     * @return {boolean}
+     */
+    Notebook.prototype.are_marked_indices_contiguous = function(indices, cells) {
+        cells = cells || this.get_cells();
+        return this.are_marked_cells_contiguous(cells.filter(function(cell, index) {
+            return indices.indexOf(index) !== -1;
+        }));
     };
 
     /**

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -401,7 +401,7 @@ define(function (require) {
         var st = sme.scrollTop();
         var t = sme.offset().top;
         var ct = cells[index].element.offset().top;
-        var scroll_value =  st + ct - (t + .01 * percent * h);
+        var scroll_value =  st + ct - (t + 0.01 * percent * h);
         this.scroll_manager.element.animate({scrollTop:scroll_value}, time);
         return scroll_value;
     };
@@ -633,7 +633,7 @@ define(function (require) {
      * Toggles the marks on the cells
      * @param  {Cell[]} [cells] - optionally specify what cells should be toggled
      */
-    Notebook.prototype.toggle_marks = function(cells) {
+    Notebook.prototype.toggle_cells_marked = function(cells) {
         cells = cells || this.get_cells();
         cells.forEach(function(cell) { cell.marked = !cell.marked; });
     };
@@ -642,7 +642,7 @@ define(function (require) {
      * Mark all of the cells
      * @param  {Cell[]} [cells] - optionally specify what cells should be marked
      */
-    Notebook.prototype.mark_all = function(cells) {
+    Notebook.prototype.mark_all_cells = function(cells) {
         cells = cells || this.get_cells();
         cells.forEach(function(cell) { cell.mark(); });
     };
@@ -651,7 +651,7 @@ define(function (require) {
      * Unmark all of the cells
      * @param  {Cell[]} [cells] - optionally specify what cells should be unmarked
      */
-    Notebook.prototype.unmark_all = function(cells) {
+    Notebook.prototype.unmark_all_cells = function(cells) {
         this.get_marked_cells(cells).forEach(function(cell) { cell.unmark(); });
     };
     
@@ -660,8 +660,8 @@ define(function (require) {
      * @param  {Cell[]} cells
      */
     Notebook.prototype.set_marked_cells = function(cells) {
-        this.unmark_all();
-        this.mark_all(cells);
+        this.unmark_all_cells();
+        this.mark_all_cells(cells);
     };
     
     /**
@@ -681,8 +681,8 @@ define(function (require) {
      */
     Notebook.prototype.set_marked_indices = function(indices, cells) {
         cells = cells || this.get_cells();
-        this.unmark_all(cells);
-        this.mark_all(cells.filter(function(cell, index) { return indices.indexOf(index) !== -1; }));
+        this.unmark_all_cells(cells);
+        this.mark_all_cells(cells.filter(function(cell, index) { return indices.indexOf(index) !== -1; }));
     };
     
     /**
@@ -694,6 +694,25 @@ define(function (require) {
         cells = cells || this.get_cells();
         var markedCells = this.get_marked_cells(cells);
         return markedCells.map(function(cell) { return cells.indexOf(cell); });
+    };
+    
+    /**
+     * Checks if the marked cells are contiguous
+     * @param  {Cell[]} [cells] - optionally provide the cells to search through
+     * @return {boolean}
+     */
+    Notebook.prototype.are_marks_contiguous = function(cells) {
+        // Get a numerically sorted list of the marked indices.
+        var markedIndices = this.get_marked_indices(cells).sort(
+            function(a,b) { return a-b; });
+
+        // Check for contiguousness
+        for (var i = 0; i < markedIndices.length - 1; i++) {
+            if (markedIndices[i+1] - markedIndices[i] !== 1) {
+                return false;
+            }
+        }
+        return true;
     };
 
     /**

--- a/notebook/static/notebook/less/cell.less
+++ b/notebook/static/notebook/less/cell.less
@@ -16,6 +16,7 @@ div.cell {
 
     .edit_mode &.selected {
         border-color: green;
+
         /* Don't border the cells when printing */
         @media print {
             border-color: transparent;

--- a/notebook/static/notebook/less/cell.less
+++ b/notebook/static/notebook/less/cell.less
@@ -25,6 +25,7 @@ div.cell {
     &.marked {
         border-left-color: blue;
         border-left-width: 3px;
+        margin-left: -2px;
     }
 
     width: 100%;

--- a/notebook/static/notebook/less/cell.less
+++ b/notebook/static/notebook/less/cell.less
@@ -21,6 +21,11 @@ div.cell {
             border-color: transparent;
         }
     }
+    
+    &.marked {
+        border-left-color: blue;
+        border-left-width: 3px;
+    }
 
     width: 100%;
     padding: 5px;

--- a/notebook/static/notebook/less/cell.less
+++ b/notebook/static/notebook/less/cell.less
@@ -23,9 +23,11 @@ div.cell {
     }
     
     &.marked {
-        border-left-color: blue;
+        border-left-color: #009AF5;
         border-left-width: 3px;
         margin-left: -2px;
+        border-bottom-left-radius: 0px;
+        border-top-left-radius: 0px;
     }
 
     width: 100%;

--- a/notebook/static/notebook/less/variables.less
+++ b/notebook/static/notebook/less/variables.less
@@ -11,7 +11,7 @@
 @code_line_height:              1.21429em;  // changed from 1.231 to get 17px even
 @code_padding:                  0.4em;  // 5.6 px
 @rendered_html_border_color:    black;
-@input_prompt_color:            navy;
+@input_prompt_color:            #2F97C1;
 @output_prompt_color:           darkred;
 @output_pre_color:              black;
 @notification_widget_bg:        rgba(240, 240, 240, 0.5);

--- a/notebook/tests/notebook/marks.js
+++ b/notebook/tests/notebook/marks.js
@@ -1,0 +1,56 @@
+
+// Test
+casper.notebook_test(function () {
+    var that = this;
+    
+    var a = 'print("a")';
+    var index = this.append_cell(a);
+
+    var b = 'print("b")';
+    index = this.append_cell(b);
+
+    var c = 'print("c")';
+    index = this.append_cell(c);
+
+    this.then(function () {
+        this.test.assertEquals(this.evaluate(function() { 
+            return Jupyter.notebook.get_marked_cells().length; 
+        }), 0, 'no cells are marked programmatically');
+        
+        this.test.assertEquals(this.evaluate(function() { 
+            return $('.cell.marked').length; 
+        }), 0, 'no cells are marked visibily');
+        
+        this.evaluate(function() {
+            Jupyter.notebook.mark_all();
+        });
+        
+        var cellCount = this.evaluate(function() { 
+            return Jupyter.notebook.ncells(); 
+        });
+        
+        this.test.assertEquals(this.evaluate(function() { 
+            return Jupyter.notebook.get_marked_cells().length; 
+        }), cellCount, 'mark_all');
+        
+        this.test.assertEquals(this.evaluate(function() { 
+            return $('.cell.marked').length; 
+        }), cellCount, 'marked cells are marked visibily');
+        
+        this.evaluate(function() {
+            Jupyter.notebook.unmark_all();
+        });
+        
+        this.test.assertEquals(this.evaluate(function() { 
+            return Jupyter.notebook.get_marked_cells().length; 
+        }), 0, 'unmark_all');
+        
+        this.evaluate(function() {
+            Jupyter.notebook.set_marked_indices([1]);
+        });
+        
+        this.test.assertEquals(this.evaluate(function() { 
+            return Jupyter.notebook.get_marked_indices()[0];
+        }), 1, 'get/set_marked_indices');
+    });
+});

--- a/notebook/tests/notebook/marks.js
+++ b/notebook/tests/notebook/marks.js
@@ -22,7 +22,7 @@ casper.notebook_test(function () {
         }), 0, 'no cells are marked visibily');
         
         this.evaluate(function() {
-            Jupyter.notebook.mark_all();
+            Jupyter.notebook.mark_all_cells();
         });
         
         var cellCount = this.evaluate(function() { 
@@ -38,7 +38,7 @@ casper.notebook_test(function () {
         }), cellCount, 'marked cells are marked visibily');
         
         this.evaluate(function() {
-            Jupyter.notebook.unmark_all();
+            Jupyter.notebook.unmark_all_cells();
         });
         
         this.test.assertEquals(this.evaluate(function() { 


### PR DESCRIPTION
@ellisonbg convinced me that it would be a good idea to decouple the multi-select from single selection.  Right now the focus and selection of cells are tightly coupled, which leads to a confused implementation of multiple cell selection.  This PR introduces a new concept of "marked" cells, similar to how GMail works.

Cell marks can be toggle by `cmdtrl-space` or by holding control and left clicking on the cells.

related to #580 and #565 

If accepted, in a following PR I'll start converting the multiselection functionality that exists now to use marks.

ping @captainsafia 

Action shot:
![demo](https://cloud.githubusercontent.com/assets/3292874/10436535/e4f2e69a-70db-11e5-9f89-655f09a3ca14.gif)

closes #577