### PR TITLE
Provide a hook to include extra JavaScript snippets in pages.

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -117,6 +117,10 @@ class IPythonHandler(AuthenticatedHandler):
     
     Mostly property shortcuts to IPython-specific settings.
     """
+    _extra_scripts = []
+
+    def initialize(self, extra_scripts=None):
+        self._extra_scripts = extra_scripts or []
 
 
     @property
@@ -312,6 +316,7 @@ class IPythonHandler(AuthenticatedHandler):
             contents_js_source=self.contents_js_source,
             version_hash=self.version_hash,
             ignore_minified_js=self.ignore_minified_js,
+            extra_scripts=self._extra_scripts,
             **self.jinja_template_vars
         )
     

--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -129,6 +129,9 @@
 {% endblock %}
 
 {% block script %}
+{% for script in extra_scripts %}
+  <script src="{{script}}" type="text/javascript" charset="utf-8"></script>
+{% endfor %}
 {% endblock %}
 
 </body>


### PR DESCRIPTION
We add a generic mechanism in IPythonHandler for the handler definition to list paths of extra JS scripts that should be loaded at the bottom of every page.

This provides a mechanism by which Notebook Server extensions can inject extra JavaScript into semi-arbitrary pages. This is the best mechanism I can devise that will allow multiple extensions to extend the same page:

 - I see no appealing way to allow multiple extensions to chain overrides
   of the Jinja template files.
 - Ditto with custom.js code.

With the approach taken here, extensions can call for extra JavaScript to be loaded with code like:

```python
    from notebook.tree.handlers import TreeHandler

    def load_jupyter_server_extension (nbapp):
        for host_regex, urlspecs in npabb.web_app.handlers:
            for urlspec in urlspecs:
                if issubclass (urlspec.handler_class, TreeHandler):
                    scripts = urlspec.kwargs.setdefault ('extra_scripts', [])
                    scripts.append ('/path/to/my/tree/extension/script')
```

This isn't super appealing, but Tornado does not provide a good mechanism for extending handlers in a chainable way. In particular, you can't subclass the handler class, because that's not a chainable technique (well, barring extremely painful gymnastics).