### PR TITLE
Fix #581 to prevent focusing on a code cell with double click.

### DIFF
--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -201,8 +201,9 @@ define([
             if (that.selected === false) {
                 this.events.trigger('select.Cell', {'cell':that});
             }
+
             var cont = that.unrender();
-            if (cont) {
+            if (cont && that.cell_type !== 'code') {
                 that.focus_editor();
             }
         });


### PR DESCRIPTION
The default behavior of a cell is to focus to the editor after a double click. This fix adds a simple check to disable the behavior for code cell.

Would it be better to move the focus behavior explicitly into text_cell instead?