### PR TITLE
Fix #581 by moving the double-click selection focus into MarkdownCell.

### DIFF
--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -199,10 +199,6 @@ define([
             if (that.selected === false) {
                 this.events.trigger('select.Cell', {'cell':that});
             }
-            var cont = that.unrender();
-            if (cont) {
-                that.focus_editor();
-            }
         });
     };
     

--- a/notebook/static/notebook/js/textcell.js
+++ b/notebook/static/notebook/js/textcell.js
@@ -298,6 +298,18 @@ define([
         return cont;
     };
 
+    /** @method bind_events **/
+    MarkdownCell.prototype.bind_events = function () {
+        TextCell.prototype.bind_events.apply(this);
+        var that = this;
+
+        this.element.dblclick(function () {
+            var cont = that.unrender();
+            if (cont) {
+                that.focus_editor();
+            }
+        });
+    };
 
     var RawCell = function (options) {
         /**


### PR DESCRIPTION
This fix explicitly moved the dblclick behavior of focusing on the editor into MarkdownCell.