### PR TITLE
Avoid trying to upload large files

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -184,8 +184,8 @@ define([
             // skip files over 15MB with a warning
             if (f.size > 15728640) {
                 dialog.modal({
-                    title : 'Failed to upload file',
-                    body : "Failed to upload file (>15MB) '" + f.name + "'",
+                    title : 'Cannot upload file',
+                    body : "Cannot upload file (>15MB) '" + f.name + "'",
                     buttons : {'OK' : { 'class' : 'btn-primary' }}
                 });
                 continue;

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -181,6 +181,16 @@ define([
             var name_and_ext = utils.splitext(f.name);
             var file_ext = name_and_ext[1];
 
+            // skip files over 15MB with a warning
+            if (f.size > 15728640) {
+                dialog.modal({
+                    title : 'Failed to upload file',
+                    body : "Failed to upload file (>15MB) '" + f.name + "'",
+                    buttons : {'OK' : { 'class' : 'btn-primary' }}
+                });
+                continue;
+            }
+
             var reader = new FileReader();
             if (file_ext === '.ipynb') {
                 reader.readAsText(f);


### PR DESCRIPTION
Workaround for #96, I verified that I could upload files of size 15Mb in Firefox and Chrome in OSX.

<img width="696" alt="screen shot 2015-10-19 at 7 45 46 pm" src="https://cloud.githubusercontent.com/assets/2096628/10595118/0a9837ce-769a-11e5-828d-cad495ac0879.png">


ping @ellisonbg @Carreau 