### PR TITLE
Bump upload size to 25MB

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -46,6 +46,7 @@ define([
                 function(e, d) { that.sessions_loaded(d); });
         }
         this.selected = [];
+        this._max_upload_size_mb = 25;
     };
 
     NotebookList.prototype.style = function () {
@@ -181,11 +182,11 @@ define([
             var name_and_ext = utils.splitext(f.name);
             var file_ext = name_and_ext[1];
 
-            // skip files over 25MB with a warning (same as Gmail)
-            if (f.size > 26214400) {
+            // skip large files with a warning
+            if (f.size > this._max_upload_size_mb * 1024 * 1024) {
                 dialog.modal({
                     title : 'Cannot upload file',
-                    body : "Cannot upload file (>25MB) '" + f.name + "'",
+                    body : "Cannot upload file (>" + this._max_upload_size_mb + " MB) '" + f.name + "'",
                     buttons : {'OK' : { 'class' : 'btn-primary' }}
                 });
                 continue;

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -181,11 +181,11 @@ define([
             var name_and_ext = utils.splitext(f.name);
             var file_ext = name_and_ext[1];
 
-            // skip files over 15MB with a warning
-            if (f.size > 15728640) {
+            // skip files over 25MB with a warning (same as Gmail)
+            if (f.size > 26214400) {
                 dialog.modal({
                     title : 'Cannot upload file',
-                    body : "Cannot upload file (>15MB) '" + f.name + "'",
+                    body : "Cannot upload file (>25MB) '" + f.name + "'",
                     buttons : {'OK' : { 'class' : 'btn-primary' }}
                 });
                 continue;


### PR DESCRIPTION
Tested with a 24MB file in Firefox and Chrome on OSX.

<img width="698" alt="screen shot 2015-10-21 at 9 12 00 am" src="https://cloud.githubusercontent.com/assets/2096628/10639211/a3fdcf88-77d4-11e5-808c-372b751d06d5.png">
