### PR TITLE
Reverting Firefox Windows bug fix ipython/ipython#8853

### DIFF
--- a/notebook/static/notebook/js/pager.js
+++ b/notebook/static/notebook/js/pager.js
@@ -78,11 +78,6 @@ define([
                 // This allows the pager-contents div to use percentage sizing.
                 that.pager_element.height(that.pager_element.height());
                 that._resize();
-                
-                // Fixes: ipython/ipython#8853
-                // Horrible hack that forces firefox to recalculate the content 
-                // size so the scrollbars get rendered.
-                that.pager_element.html(that.pager_element.html());
             });
         });
 


### PR DESCRIPTION
The fix that @jdfreder did for ipython/ipython#8853 broke all click and resize events for the pager as it effectively cloned all of the pager DOM nodes and removed all of their events. This broke the pager closing and resizing.

I have just reverted for now until we can investigate a better fix.