### PR TITLE
Force pager to draw scrollbars on FireFox

### DIFF
--- a/notebook/static/notebook/js/pager.js
+++ b/notebook/static/notebook/js/pager.js
@@ -78,6 +78,13 @@ define([
                 // This allows the pager-contents div to use percentage sizing.
                 that.pager_element.height(that.pager_element.height());
                 that._resize();
+                
+                // HACK: Less horrible, but still horrible hack to force the
+                // pager to show it's scrollbars on FireFox. ipython/ipython/#8853
+                that.pager_element.css('position', 'relative');
+                window.requestAnimationFrame(function() { /* Wait one frame */                    
+                    that.pager_element.css('position', '');
+                });
             });
         });
 


### PR DESCRIPTION
Here's a less horrible hack, that looks uglier, which fixes the pager scrollbar issue in FireFox.

closes ipython/ipython#8853

@ellisonbg