### PR TITLE
Reminder of where the celltoolbar menu is

### DIFF
--- a/notebook/static/notebook/js/maintoolbar.js
+++ b/notebook/static/notebook/js/maintoolbar.js
@@ -55,10 +55,34 @@ define([
             ],
             'run_int'],
          ['<add_celltype_list>'],
-         [['jupyter-notebook:show-command-palette']]
+         [['jupyter-notebook:show-command-palette']],
+         ['<add_celltoolbar_reminder>']
         ];
         this.construct(grps);
     };
+   
+    MainToolBar.prototype._pseudo_actions = {};
+
+
+    // reminder of where the celltoolbar new menu is, remove for 5.0
+    MainToolBar.prototype._pseudo_actions.add_celltoolbar_reminder = function () {
+        var _b = $('<button/>').attr('title','show new celltoolbar selector location').addClass('btn btn-default').text('CellToolbar')
+        var btn = $('<div/>').addClass('btn-group').append(_b)
+
+        _b.on('click', function(){
+            setTimeout(function(){$('#view_menu').parent().addClass('pulse')},0) 
+            setTimeout(function(){$('#view_menu').parent().addClass('open')},1000) 
+            setTimeout(function(){$('#menu-cell-toolbar').children('a').addClass('pulse')},2000)
+            setTimeout(function(){$('#menu-cell-toolbar').children('ul').css('display','block')},3000)
+            setTimeout(function(){$('#menu-cell-toolbar').children('ul').css('display','')},5400)
+            setTimeout(function(){$('#menu-cell-toolbar').children('a').removeClass('pulse')},5600)
+            setTimeout(function(){$('#view_menu').parent().removeClass('open')},5800)
+            setTimeout(function(){$('#view_menu').parent().removeClass('pulse')},6000)
+        })
+
+        return btn;
+    };
+
     
     // add a cell type drop down to the maintoolbar.
     // triggered when the pseudo action `<add_celltype_list>` is

--- a/notebook/static/notebook/less/toolbar.less
+++ b/notebook/static/notebook/less/toolbar.less
@@ -50,3 +50,10 @@
 .select-xs {
   height: @btn_small_height;
 }
+
+
+// highlight the new menu where celltoolbar is
+.pulse, .dropdown-menu > li > a.pulse,  li.pulse > a.dropdown-toggle, li.pulse.open > a.dropdown-toggle {
+    background-color: #F37626;
+    color: white;
+}


### PR DESCRIPTION
The UI has changed since 4.0 so 4.1 need to tell that to users.

Ping @ellisonbg , @jdfreder 

![ct](https://cloud.githubusercontent.com/assets/335567/10711889/59665a5a-7a3e-11e5-970f-86b89592880c.gif)