### PR TITLE
Escape: Close pager if open otherwise unmark all

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -437,7 +437,18 @@ define(function(require){
                 $('.header-bar').toggle();
                 events.trigger('resize-header.Page');
             }
-        }
+        },
+        'escape': {
+            help : 'close the pager or unmark all cells',
+            handler : function(env) {
+                // Collapse the page if it is open, otherwise unmark all.
+                if (env.pager && env.pager.expanded) {
+                    env.pager.collapse();
+                } else {
+                    env.notebook.unmark_all_cells();
+                }
+            }
+        },
     };
 
     /**

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -438,7 +438,7 @@ define(function(require){
                 events.trigger('resize-header.Page');
             }
         },
-        'escape': {
+        'close-pager-or-unmark-all-cells': {
             help : 'close the pager or unmark all cells',
             handler : function(env) {
                 // Collapse the page if it is open, otherwise unmark all.

--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -96,7 +96,7 @@ define([
             'i,i' : 'jupyter-notebook:interrupt-kernel',
             '0,0' : 'jupyter-notebook:confirm-restart-kernel',
             'd,d' : 'jupyter-notebook:delete-cell',
-            'esc': 'jupyter-notebook:escape',
+            'esc': 'jupyter-notebook:close-pager-or-unmark-all-cells',
             'up' : 'jupyter-notebook:select-previous-cell',
             'k' : 'jupyter-notebook:select-previous-cell',
             'j' : 'jupyter-notebook:select-next-cell',

--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -96,7 +96,7 @@ define([
             'i,i' : 'jupyter-notebook:interrupt-kernel',
             '0,0' : 'jupyter-notebook:confirm-restart-kernel',
             'd,d' : 'jupyter-notebook:delete-cell',
-            'esc': 'jupyter-notebook:close-pager',
+            'esc': 'jupyter-notebook:escape',
             'up' : 'jupyter-notebook:select-previous-cell',
             'k' : 'jupyter-notebook:select-previous-cell',
             'j' : 'jupyter-notebook:select-next-cell',


### PR DESCRIPTION
A kludge, because our design doesn't allow shortcut->multiple actions.
closes #656
makes #655 better