### PR TITLE
Minor changes to marking behavior

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -656,7 +656,7 @@ define(function (require) {
      */
     Notebook.prototype.get_marked_cells = function(cells) {
         cells = cells || this.get_cells();
-        return cells.filter(function(cell) { return cell.marked; });
+        return cells.filter(function(cell) { return (cell.marked || cell.selected); });
     };
     
     /**
@@ -959,10 +959,6 @@ define(function (require) {
     Notebook.prototype.delete_cells = function(indices) {
         if (indices === undefined) {
             indices = this.get_marked_indices();
-            
-            if (indices.length === 0) {
-                indices = [this.get_selected_index()];
-            }
         }
 
         this.undelete_backup = [];

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1534,6 +1534,7 @@ define(function (require) {
         this.delete_cells(indices);
 
         this.select(this.find_cell_index(target));
+        this.unmark_all_cells();
     };
 
     /**

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -719,16 +719,13 @@ define(function (require) {
      * @param {number} offset
      */
     Notebook.prototype.extend_marked = function(offset) {
-                
         // Mark currently selected cell
         this.get_selected_cell().marked = true;
-        
+
         // Select the cell in the offset direction.  Bound index between 0 and
         // the number of cells -1.
         var selectedIndex = Math.min(Math.max(this.get_selected_index() + offset, 0), this.ncells()-1);
         this.select(selectedIndex);
-        this.get_selected_cell().marked = true;
-
         this.ensure_focused();
     };
 

--- a/notebook/tests/notebook/marks.js
+++ b/notebook/tests/notebook/marks.js
@@ -13,10 +13,19 @@ casper.notebook_test(function () {
     index = this.append_cell(c);
 
     this.then(function () {
+        var selectedIndex = this.evaluate(function () {
+            Jupyter.notebook.select(0);
+            return Jupyter.notebook.get_selected_index();
+        });
+
         this.test.assertEquals(this.evaluate(function() { 
             return Jupyter.notebook.get_marked_cells().length; 
-        }), 0, 'no cells are marked programmatically');
-        
+        }), 1, 'only one cell is marked programmatically');
+
+        this.test.assertEquals(this.evaluate(function() {
+            return Jupyter.notebook.get_marked_indices()[0];
+        }), selectedIndex, 'marked cell is selected cell');
+
         this.test.assertEquals(this.evaluate(function() { 
             return $('.cell.marked').length; 
         }), 0, 'no cells are marked visibily');
@@ -43,14 +52,22 @@ casper.notebook_test(function () {
         
         this.test.assertEquals(this.evaluate(function() { 
             return Jupyter.notebook.get_marked_cells().length; 
-        }), 0, 'unmark_all');
-        
+        }), 1, 'unmark_all');
+
+        this.test.assertEquals(this.evaluate(function() {
+            return Jupyter.notebook.get_marked_indices()[0];
+        }), selectedIndex, 'marked cell is selected cell');
+
         this.evaluate(function() {
             Jupyter.notebook.set_marked_indices([1]);
         });
-        
-        this.test.assertEquals(this.evaluate(function() { 
-            return Jupyter.notebook.get_marked_indices()[0];
-        }), 1, 'get/set_marked_indices');
+
+        this.test.assertEquals(this.evaluate(function() {
+            return Jupyter.notebook.get_marked_cells().length;
+        }), 2, 'two cells are marked');
+
+        this.test.assertEquals(this.evaluate(function() {
+            return Jupyter.notebook.get_marked_indices();
+        }), [selectedIndex, 1], 'get/set_marked_indices');
     });
 });


### PR DESCRIPTION
This goes in hand with #675 (or something like it). Specifically, this modifies the behavior of marked cells so that:

* The selected cell is always counted as a marked cell.
* When extending the marked region, the currently selected cell is marked and then the above or below cell is selected. Previously, that above/below cell would also get an explicit mark, but this PR changes it so that it doesn't (since it already gets an implicit mark).
* All cells are unmarked after ~~splits and~~ merges.

Fixes part of #665. Shouldn't be merged until after #675, as it actually branches off from that PR.

@jdfreder @ellisonbg @Carreau 