### PR TITLE
Making style of restart kernel confirm buttons consistent

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1908,7 +1908,7 @@ define(function (require) {
             ),
             buttons : {
                 "Restart" : {
-                    "class" : "btn-warning",
+                    "class" : "btn-danger",
                     "click" : function () {},
                 },
             }


### PR DESCRIPTION
Right now, 2 of the 3 ways of restarting the kernel have a "danger" (red) style and one has a "warning" (orange) style. In my mind, the red/danger here refers conceptually to the destructive action of restarting the kernel. Because of this all, three should have the danger/red style. This PR implements that.

Should go into 4.1