### PR TITLE
Ensure focus is kept when extending the marked region

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -728,6 +728,8 @@ define(function (require) {
         var selectedIndex = Math.min(Math.max(this.get_selected_index() + offset, 0), this.ncells()-1);
         this.select(selectedIndex);
         this.get_selected_cell().marked = true;
+
+        this.ensure_focused();
     };
 
     // Cell selection.


### PR DESCRIPTION
Currently, if you use `shift-j` and `shift-k` to expand the marked region, focus does not follow the selected cell. This PR ensures that the focus is kept on the selected cell after expanding the marked region.