### PR TITLE
Trigger notification when marked cells are offscreen

### DIFF
--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -298,6 +298,7 @@ define([
                 } else {
                     this.element.removeClass('marked');
                 }
+                this.events.trigger('marked_changed.Cell', {cell: this, value: value});
             }
         }
     });

--- a/notebook/static/notebook/js/notificationarea.js
+++ b/notebook/static/notebook/js/notificationarea.js
@@ -25,6 +25,7 @@ define([
     NotebookNotificationArea.prototype.init_notification_widgets = function () {
         this.init_kernel_notification_widget();
         this.init_notebook_notification_widget();
+        this.init_marked_cells_notification_widget();
     };
 
     /**
@@ -336,6 +337,23 @@ define([
         });
         this.events.on('autosave_enabled.Notebook', function (evt, interval) {
             nnw.set_message("Saving every " + interval / 1000 + "s", 1000);
+        });
+    };
+
+    /**
+     * Initialize the notification widget for marked cells.
+     *
+     * @method init_marked_cells_notification_widget
+     */
+    NotebookNotificationArea.prototype.init_marked_cells_notification_widget = function () {
+        var mcnw = this.new_notification_widget('marked_cells');
+
+        this.events.on('marked_offscreen.Cell', function (evt, num) {
+            if (num === 0) {
+                mcnw.hide();
+            } else {
+                mcnw.set_message(num + " marked cells offscreen");
+            }
         });
     };
 

--- a/notebook/static/notebook/js/notificationarea.js
+++ b/notebook/static/notebook/js/notificationarea.js
@@ -352,7 +352,7 @@ define([
             if (num === 0) {
                 mcnw.hide();
             } else {
-                mcnw.set_message(num + " marked cells offscreen");
+                mcnw.info(num + " marked cells offscreen");
             }
         });
     };

--- a/notebook/static/notebook/js/scrollmanager.js
+++ b/notebook/static/notebook/js/scrollmanager.js
@@ -73,6 +73,12 @@ define(['jquery'], function($){
         return Math.min(i + 1, cell_count - 1);
     };
 
+    ScrollManager.prototype.is_cell_visible = function (cell) {
+        var cell_rect = cell.element[0].getBoundingClientRect();
+        var scroll_rect = this.element[0].getBoundingClientRect();
+        return ((cell_rect.top <= scroll_rect.bottom) && (cell_rect.bottom >= scroll_rect.top));
+    };
+
 
     var TargetScrollManager = function(notebook, options) {
         /**


### PR DESCRIPTION
This prototype creates a new notification widget that alerts users if they have marked cells offscreen. Here's what it looks like:

![](http://i.imgur.com/RpAMvby.gif)

Fixes #680 

Note that this builds on #675 and #676 and shouldn't be merged util those are.

@ellisonbg @Carreau @willingc @jdfreder 