### PR TITLE
Run marked cells

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -107,10 +107,10 @@ define(function(require){
             }
         },
         'run-cell':{
-            help    : 'run cell',
+            help    : 'run marked cells',
             help_index : 'bb',
             handler : function (env) {
-                env.notebook.execute_cell();
+                env.notebook.execute_marked_cells();
             }
         },
         'run-cell-and-insert-below':{

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1992,10 +1992,11 @@ define(function (require) {
 
         var cell;
         for (var i = 0; i < indices.length; i++) {
-            this.select(indices[i]);
             cell = this.get_cell(indices[i]);
             cell.execute();
         }
+
+        this.select(indices[indices.length - 1]);
     };
 
     /**

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -2006,6 +2006,17 @@ define(function (require) {
     };
 
     /**
+     * Alias for execute_marked_cells, for backwards compatibility --
+     * previously, doing "Run Cell" would only ever run a single cell (hence
+     * `execute_cell`), but now it runs all marked cells, so that's the
+     * preferable function to use. But it is good to keep this function to avoid
+     * breaking existing extensions, etc.
+     */
+    Notebook.prototype.execute_cell = function () {
+        this.execute_marked_cells();
+    };
+
+    /**
      * Execute or render cell outputs and insert a new cell below.
      */
     Notebook.prototype.execute_cell_and_insert_below = function () {

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1987,9 +1987,6 @@ define(function (require) {
             return;
         }
 
-        this.command_mode();
-        this.set_dirty(true);
-
         var cell;
         for (var i = 0; i < indices.length; i++) {
             cell = this.get_cell(indices[i]);
@@ -1997,6 +1994,8 @@ define(function (require) {
         }
 
         this.select(indices[indices.length - 1]);
+        this.command_mode();
+        this.set_dirty(true);
     };
 
     /**
@@ -2112,6 +2111,7 @@ define(function (require) {
      * @param {integer} end - index of the last cell to execute (exclusive)
      */
     Notebook.prototype.execute_cell_range = function (start, end) {
+        this.command_mode();
         var indices = [];
         for (var i=start; i<end; i++) {
             indices.push(i);

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -2001,7 +2001,7 @@ define(function (require) {
     /**
      * Execute or render cell outputs and go into command mode.
      */
-    Notebook.prototype.execute_cell = function () {
+    Notebook.prototype.execute_marked_cells = function () {
         this.execute_cells(this.get_marked_indices());
     };
 

--- a/notebook/tests/notebook/execute_marked_cells.js
+++ b/notebook/tests/notebook/execute_marked_cells.js
@@ -1,0 +1,155 @@
+//
+// Test that the correct cells are executed when there are marked cells.
+//
+casper.notebook_test(function () {
+    var that = this;
+    var assert_outputs = function (expected) {
+        var msg, i;
+        for (i = 0; i < that.get_cells_length(); i++) {
+            if (expected[i] === undefined) {
+                msg = 'cell ' + i + ' not executed';
+                that.test.assertFalse(that.cell_has_outputs(i), msg);
+
+            } else {
+                msg = 'cell ' + i + ' executed';
+                that.test.assertEquals(that.get_output_cell(i).text, expected[i], msg);
+            }
+        }
+    };
+
+    this.then(function () {
+        this.set_cell_text(0, 'print("a")');
+        this.append_cell('print("b")');
+        this.append_cell('print("c")');
+        this.append_cell('print("d")');
+        this.test.assertEquals(this.get_cells_length(), 4, "correct number of cells");
+
+        this.evaluate(function () {
+            IPython.notebook.unmark_all_cells();
+            IPython.notebook.set_marked_indices([1, 2]);
+        });
+    });
+
+    this.then(function () {
+        this.evaluate(function () {
+            IPython.notebook.clear_all_output();
+        });
+
+        this.select_cell(1);
+        this.validate_notebook_state('before execute', 'command', 1);
+        this.trigger_keydown('ctrl-enter');
+    });
+
+    this.wait_for_output(1);
+    this.wait_for_output(2);
+
+    this.then(function () {
+        assert_outputs([undefined, 'b\n', 'c\n', undefined]);
+        this.validate_notebook_state('run marked cells', 'command', 2);
+    });
+
+    // execute cells in place when there are marked cells
+    this.then(function () {
+        this.evaluate(function () {
+            IPython.notebook.clear_all_output();
+        });
+
+        this.select_cell(1);
+        this.validate_notebook_state('before execute', 'command', 1);
+        this.trigger_keydown('shift-enter');
+    });
+
+    this.wait_for_output(1);
+    this.wait_for_output(2);
+
+    this.then(function () {
+        assert_outputs([undefined, 'b\n', 'c\n', undefined]);
+        this.validate_notebook_state('run marked cells', 'command', 2);
+    });
+
+    // execute and insert below when there are marked cells
+    this.then(function () {
+        this.evaluate(function () {
+            IPython.notebook.clear_all_output();
+        });
+
+        this.select_cell(1);
+        this.validate_notebook_state('before execute', 'command', 1);
+        this.evaluate(function () {
+            $("#run_cell_insert_below").click();
+        });
+    });
+
+    this.wait_for_output(1);
+    this.wait_for_output(2);
+
+    this.then(function () {
+        assert_outputs([undefined, 'b\n', 'c\n', undefined]);
+        this.validate_notebook_state('run marked cells', 'command', 2);
+    });
+
+    // check that it doesn't affect run all above
+    this.then(function () {
+        this.evaluate(function () {
+            IPython.notebook.clear_all_output();
+        });
+
+        this.select_cell(1);
+        this.validate_notebook_state('before execute', 'command', 1);
+        this.evaluate(function () {
+            $("#run_all_cells_above").click();
+        });
+    });
+
+    this.wait_for_output(0);
+
+    this.then(function () {
+        assert_outputs(['a\n', undefined, undefined, undefined]);
+        this.validate_notebook_state('run cells above', 'command', 0);
+    });
+
+    // check that it doesn't affect run all below
+    this.then(function () {
+        this.evaluate(function () {
+            IPython.notebook.clear_all_output();
+        });
+
+        this.select_cell(1);
+        this.validate_notebook_state('before execute', 'command', 1);
+        this.evaluate(function () {
+            $("#run_all_cells_below").click();
+        });
+    });
+
+    this.wait_for_output(1);
+    this.wait_for_output(2);
+    this.wait_for_output(3);
+
+    this.then(function () {
+        assert_outputs([undefined, 'b\n', 'c\n', 'd\n']);
+        this.validate_notebook_state('run cells below', 'command', 3);
+    });
+
+    // check that it doesn't affect run all
+    this.then(function () {
+        this.evaluate(function () {
+            IPython.notebook.clear_all_output();
+        });
+
+        this.select_cell(1);
+        this.validate_notebook_state('before execute', 'command', 1);
+        this.evaluate(function () {
+            $("#run_all_cells").click();
+        });
+    });
+
+    this.wait_for_output(0);
+    this.wait_for_output(1);
+    this.wait_for_output(2);
+    this.wait_for_output(3);
+
+    this.then(function () {
+        assert_outputs(['a\n', 'b\n', 'c\n', 'd\n']);
+        this.validate_notebook_state('run all cells', 'command', 3);
+    });
+});

--- a/notebook/tests/util.js
+++ b/notebook/tests/util.js
@@ -216,6 +216,15 @@ casper.wait_for_widget = function (widget_info) {
     });
 };
 
+casper.cell_has_outputs = function (cell_num) {
+    var result = casper.evaluate(function (c) {
+        var cell = IPython.notebook.get_cell(c);
+        return cell.output_area.outputs.length;
+    },
+    {c : cell_num});
+    return result > 0;
+};
+
 casper.get_output_cell = function (cell_num, out_num) {
     // return an output of a given cell
     out_num = out_num || 0;


### PR DESCRIPTION
Fixes #677 and adds tests. They will fail though until #676 is merged as this PR relies on the assumption that `get_marked_indices` will return all marked cells including the currently selected cell, and this assumption is only introduced in #676.