### PR TITLE
Unbind ctrl-space for now

### DIFF
--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -104,7 +104,6 @@ define([
             'shift-j': 'jupyter-notebook:extend-marked-cells-below',
             'shift-up': 'jupyter-notebook:extend-marked-cells-above',
             'shift-down': 'jupyter-notebook:extend-marked-cells-below',
-            'ctrl-space': 'jupyter-notebook:toggle-cell-marked',
             'x' : 'jupyter-notebook:cut-cell',
             'c' : 'jupyter-notebook:copy-cell',
             'v' : 'jupyter-notebook:paste-cell-below',


### PR DESCRIPTION
The shortcut is not agreed upon form 4.1, and is useful only for non-contiguous selection, or deselection only part of a selection, thus I propose to just remove it from 4.1 and add it for 4.2 if requested. 

It is also relatively easy to activate with `custom.js`