### PR TITLE
Don't run git unless it looks like we are in a repo.

### DIFF
--- a/notebook/_sysinfo.py
+++ b/notebook/_sysinfo.py
@@ -38,14 +38,25 @@ def pkg_commit_hash(pkg_path):
     hash_str : str
        short form of hash
     """
-    # maybe we are in a repository
-    proc = subprocess.Popen('git rev-parse --short HEAD',
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                            cwd=pkg_path, shell=True)
-    repo_commit, _ = proc.communicate()
-    if repo_commit:
-        return 'repository', repo_commit.strip().decode('ascii')
+
+    # maybe we are in a repository, check for a .git folder
+    p = os.path
+    cur_path = None
+    par_path = pkg_path
+    while cur_path != par_path:
+        cur_path = par_path
+        if p.exists(p.join(cur_path, '.git')):
+            proc = subprocess.Popen('git rev-parse --short HEAD',
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                cwd=pkg_path, shell=True)
+            repo_commit, _ = proc.communicate()
+            if repo_commit:
+                return 'repository', repo_commit.strip().decode('ascii')
+            else:
+                return u'', u''
+        par_path = p.dirname(par_path)
+                
     return u'', u''
 
 


### PR DESCRIPTION
On recent versions of OSX there is a git executable installed by default that isn't actually git.  Instead it opens a dialog prompting the user to install the developer tools, like this:

![screenshot1](https://github-cloud.s3.amazonaws.com/assets%2F808502%2F10956653%2F2a14fc16-8312-11e5-83cf-ca430b502ccb.png)

To have this pop up when starting when running the jupyter notebook can be annoying for users.

This PR changes the notebook to look for a .git folder before running git.
