### PR TITLE
Fix closing ansi handling.

### DIFF
--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -308,12 +308,12 @@ define([
         }
     }
 
-    function ansispan(str) {
+    function _ansispan(str) {
         // ansispan function adapted from github.com/mmalecki/ansispan (MIT License)
         // regular ansi escapes (using the table above)
         var is_open = false;
         return str.replace(/\033\[(0?[01]|22|39)?([;\d]+)?m/g, function(match, prefix, pattern) {
-            if (!pattern) {
+            if (!pattern || prefix === '39') {
                 // [(01|22|39|)m close spans
                 if (is_open) {
                     is_open = false;
@@ -352,7 +352,7 @@ define([
         txt = txt.replace(ignored_re, "");
         
         // color ansi codes
-        txt = ansispan(txt);
+        txt = _ansispan(txt);
         return txt;
     }
 
@@ -864,6 +864,7 @@ define([
         reject: reject,
         typeset: typeset,
         time: time,
+        _ansispan:_ansispan
     };
 
     return utils;

--- a/notebook/tests/base/utils.js
+++ b/notebook/tests/base/utils.js
@@ -7,6 +7,7 @@ casper.notebook_test(function () {
         "\033[0m[\033[31merror\033[0m] \033[0m\033[0m",
         "\033[0m[\033[31merror\033[0m] \033[0m\teven more text\033[0m",
         "\u001b[?25hBuilding wheels for collected packages: scipy",
+        "\x1b[38;5;28;01mtry\x1b[39;00m",
         "\033[0m[\033[31merror\033[0m] \033[0m\t\tand more more text\033[0m"].join("\n");
 
     var output = [
@@ -16,6 +17,7 @@ casper.notebook_test(function () {
         "[<span  class=\"ansired\">error</span>] ",
         "[<span  class=\"ansired\">error</span>] \teven more text",
         "Building wheels for collected packages: scipy",
+        '<span  style="color: rgb(0,102,0);" class="ansibold">try</span>',
         "[<span  class=\"ansired\">error</span>] \t\tand more more text"].join("\n");
 
     var result = this.evaluate(function (input) {


### PR DESCRIPTION
The following was wrong:

    IPython.utils.ansispan("\x1b[38;5;28;01mtry\x1b[39;00m")
    "<span  style="color: rgb(0,102,0);" class="ansibold">try< span>"


---- 
Opening to remember to write a test,  well it's default foreground color but it's used a lot to mean reset right ? 49 is background and should likely be handled. 

It comes up in pygments that use `[39;00m` for reset, which screw up tracebacks.