### PR TITLE
Fixing backspace on multiple selection bug

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -50,7 +50,14 @@ define([
      */
     CodeMirror.commands.delSpaceToPrevTabStop = function(cm){
         var from = cm.getCursor(true), to = cm.getCursor(false), sel = !posEq(from, to);
-        if (!posEq(from, to)) { cm.replaceRange("", from, to); return; }
+         if (sel) { 
+            var ranges = cm.listSelections();
+            for (var i = ranges.length - 1; i >= 0; i--) {
+              var cur = ranges[i].head;
+              cm.replaceRange("", Pos(cur.line, cur.ch - 1), Pos(cur.line, cur.ch + 1));
+            }
+            return;
+        }
         var cur = cm.getCursor(), line = cm.getLine(cur.line);
         var tabsize = cm.getOption('tabSize');
         var chToPrevTabStop = cur.ch-(Math.ceil(cur.ch/tabsize)-1)*tabsize;


### PR DESCRIPTION
The bug could be reproduced in two ways:

**1) Block selection**
a) Alt + select a block containing more than one line, and more than one character per line.
b) Hit backspace

Expected result: all the selected content is deleted
Actual result: only the first line of the selection is deleted

**2) Multiple selection**
a) Select any portion of text
b) Ctrl + select any other portion of text
c) Hit backspace

Expected result: all the selections' contents are deleted
Actual result: only the first selection is deleted

The fix
-------------
The portion of code that took care of selection deletion did not take into account multiple selections. The proposed fix simply gets the list of selections and removes them all from last to first.

closes #766
