### PR TITLE
Avoid duplicate edit shortcuts in quick-help

### DIFF
--- a/notebook/static/notebook/js/quickhelp.js
+++ b/notebook/static/notebook/js/quickhelp.js
@@ -257,8 +257,8 @@ define([
     
     QuickHelp.prototype.build_edit_help = function (cm_shortcuts) {
         var edit_shortcuts = this.keyboard_manager.edit_shortcuts.help();
-        jQuery.merge(cm_shortcuts, edit_shortcuts);
-        return build_div('<h4>Edit Mode (press <kbd>Enter</kbd> to enable)</h4>', cm_shortcuts);
+        edit_shortcuts = jQuery.merge(jQuery.merge([], cm_shortcuts), edit_shortcuts);
+        return build_div('<h4>Edit Mode (press <kbd>Enter</kbd> to enable)</h4>', edit_shortcuts);
     };
 
     var build_one = function (s) {


### PR DESCRIPTION
fix bug in `notebook/js/quickhelp` whereby edit-mode shortcuts were duplicated on every rebuild

closes #772