### PR TITLE
give defined ordering to keyboard shortcuts with the same help_index

### DIFF
--- a/notebook/static/base/js/keyboard.js
+++ b/notebook/static/base/js/keyboard.js
@@ -255,7 +255,13 @@ define([
         }
         help.sort(function (a, b) {
             if (a.help_index === b.help_index) {
-                return 0;
+                if (a.shortcut === b.shortcut) {
+                    return 0;
+                }
+                if (a.shortcut > b.shortcut) {
+                    return 1;
+                }
+                return -1;
             }
             if (a.help_index === undefined || a.help_index > b.help_index){
                 return 1;


### PR DESCRIPTION
fixes #776
Since two shortcuts in a set should not be the same, this should give defined ordering for any set.