### PR TITLE
Remove explicit Python 3.3 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,6 @@ for more information.
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
     ],
 )
 


### PR DESCRIPTION
If we're going to explicitly list 3.3, we should also be listing 3.4 and 3.5. But really we're compatible with any fairly recent Python 3 version, and will probably be compatible with future versions, so I think it's best to just use the overall Python 3 classifier.