### PR TITLE
More info on front-end extensions

### DIFF
--- a/docs/source/extending/frontend_extensions.rst
+++ b/docs/source/extending/frontend_extensions.rst
@@ -14,8 +14,9 @@ The structure of a front-end extension
     to a lot of changes. Any extension written for the current notebook is
     almost guaranteed to break in the next release.
 
-A front-end extension is a JavaScript file that defines an
-[AMD module](https://en.wikipedia.org/wiki/Asynchronous_module_definition)
+.. _AMD module: https://en.wikipedia.org/wiki/Asynchronous_module_definition
+
+A front-end extension is a JavaScript file that defines an `AMD module`_
 which exposes at least a function called ``load_ipython_extension``, which
 takes no arguments. We will not get into the details of what each of these
 terms consists of yet, but here is the minimal code needed for a working

--- a/docs/source/extending/frontend_extensions.rst
+++ b/docs/source/extending/frontend_extensions.rst
@@ -5,19 +5,20 @@ This describes the basic steps to write a JavaScript extension for the Jupyter
 notebook front-end. This allows you to customize the behaviour of the various
 pages like the dashboard, the notebook, or the text editor.
 
-The structure of an extension
------------------------------
+The structure of a front-end extension
+--------------------------------------
 
 .. note::
 
-    The notebook frontend and Javascript API are not stable, and are subject to
-    a lot of changes. Any extension written for the current notebook is almost
-    guaranteed to break in the next release.
+    The notebook front-end and Javascript API are not stable, and are subject
+    to a lot of changes. Any extension written for the current notebook is
+    almost guaranteed to break in the next release.
 
-A front-end extension is a JavaScript file that defines an AMD module
-exposing at least a function called `load_ipython_extension`, which takes no
-arguments. We will not get into the details of what each of these terms are,
-but here is the minimal code needed for a working extension:
+A front-end extension is a JavaScript file that defines an
+[AMD module](https://en.wikipedia.org/wiki/Asynchronous_module_definition)
+which exposes at least a function called `load_ipython_extension`, which takes
+no arguments. We will not get into the details of what each of these terms
+consists of yet, but here is the minimal code needed for a working extension:
 
 .. code:: javascript
 
@@ -34,19 +35,23 @@ but here is the minimal code needed for a working extension:
 
 .. note::
     
-    For historical reasons, the function is called `load_ipython_extension`,
-    but it does apply to the Jupyter notebook as well, and will work
-    regardless of the kernel you use. 
+    Although for historical reasons the function is called
+    `load_ipython_extension`, it does apply to the Jupyter notebook in general,
+    and will work regardless of the kernel in use.
 
 If you are familiar with JavaScript, you can use this template to require any
-Jupyter module and modify its configuration. Your extension will be loaded
-at the right time during the notebook page initialisation for you to set up a
-listener for the various events that the page can trigger.
+Jupyter module and modify its configuration, or do anything else in client-side
+Javascript. Your extension will be loaded at the right time during the notebook
+page initialisation for you to set up a listener for the various events that
+the page can trigger.
 
-You might want to access to the current instances of the various component on
-the page, these are exposed by a module named `base/js/namespace`. If you plan
-on accessing instances on the page, you should require this module rather than
-accessing the global variable `Jupyter`. Here is how to do that:
+You might want access to the current instances of the various Jupyter notebook
+components on the page, as opposed to the classes defined in the modules.
+The current instances are exposed by a module named `base/js/namespace`.
+If you plan
+on accessing instances on the page, you should ``require`` this module rather
+than accessing the global variable `Jupyter`, which will be removed in future.
+The following example demonstrates how to access the current notebook instance:
 
 .. code:: javascript
 
@@ -66,12 +71,14 @@ accessing the global variable `Jupyter`. Here is how to do that:
 Modifying key bindings
 ----------------------
 
-Extensions have the ability to modify key bindings. Once again, this API
-is not guaranteed to be stable, but changing key bindings is a common request.
-This is how to do it in the current version of the notebook.
+One of the abilities of extensions is to modify key bindings, although once
+again this is an API which is not guaranteed to be stable. However, custom key
+bindings are frequently requested, and are helpful to increase accessibility,
+so in the following we show how to access them.
 
-Here is an example of extension that will unbind `0,0` in command mode, which
-normally restarts the kernel, and bind `0,0,0` in it's place.
+Here is an example of an extension that will unbind the shortcut `0,0` in
+command mode, which normally restarts the kernel, and bind `0,0,0` in its
+place:
 
 .. code:: javascript
 
@@ -89,30 +96,31 @@ normally restarts the kernel, and bind `0,0,0` in it's place.
 
 .. note::
     
-    Keybindings might not work correctly on non-US keyboards.
-    Unfortunately, this is a limitation of browser implementations and the status of
-    keyboard event handling on the web. We appreciate your feedback if you have
-    issues binding keys, or ideas to help improve the situation.
+    The standard keybindings might not work correctly on non-US keyboards.
+    Unfortunately, this is a limitation of browser implementations and the
+    status of keyboard event handling on the web in general. We appreciate your
+    feedback if you have issues binding keys, or have any ideas to help improve
+    the situation.
 
-You can see that I have used the **command name**
+You can see that I have used the **action name**
 `jupyter-notebook:restart-kernel` to bind the new shortcut. There is no API yet
-to access the list of all available *commands*, though the following in the
+to access the list of all available *actions*, though the following in the
 JavaScript console of your browser on a notebook page should give you an idea
-of what of available:
+of what is available:
 
 .. code:: javascript
 
     Object.keys(IPython.actions._actions)
 
-In this example, we changed keyboard shortcuts in **command mode**; you can also
-customise keyboard shortcuts in edit mode.
+In this example, we changed the keyboard shortcut in the **command mode**; you
+can also customize keyboard shortcuts in **edit mode**.
 However, most of the keyboard shortcuts in edit mode are handled by CodeMirror,
 which supports custom key bindings via a completely different API.
 
-You can also define and register your own action to be used, but the
-documentation for this has not been written yet. If you need to do it,
-please ask us, we can give you the necessary information, and we would appreciate
-if you could format them in a detailed way in place of this paragraph.
+You can also define and register your own **actions** to be used, but the
+documentation for this has not been written yet. If you need to do it, please
+ask us, we can give you the necessary information, and we would appreciate if
+you could format them in a detailed way in place of this paragraph.
 
 Installing and enabling extensions
 ----------------------------------
@@ -135,4 +143,4 @@ notebook interface to load it. You can do that with another command:
 
 The argument refers to the Javascript module containing your ``load_ipython_extension``
 function, which is ``myext/main.js`` in this example. There is a corresponding
-``disable`` command to stop using an extension without installing it.
+``disable`` command to stop using an extension without uninstalling it.

--- a/docs/source/extending/frontend_extensions.rst
+++ b/docs/source/extending/frontend_extensions.rst
@@ -129,7 +129,7 @@ of what is available:
 
     Object.keys(require('base/js/namespace').actions._actions);
 
-In this example, we changed the keyboard shortcut in the **command mode**; you
+In this example, we changed a keyboard shortcut in **command mode**; you
 can also customize keyboard shortcuts in **edit mode**.
 However, most of the keyboard shortcuts in edit mode are handled by CodeMirror,
 which supports custom key bindings via a completely different API.

--- a/docs/source/extending/frontend_extensions.rst
+++ b/docs/source/extending/frontend_extensions.rst
@@ -22,16 +22,18 @@ consists of yet, but here is the minimal code needed for a working extension:
 
 .. code:: javascript
 
-    //file myext/main.js
+    // file my_extension/main.js
 
     define(function(){
 
         function load_ipython_extension(){
-            console.info('this is my first extension')
+            console.info('this is my first extension');
         }
 
-        return {load_ipython_extension: load_ipython_extension };
-    })
+        return {
+            load_ipython_extension: load_ipython_extension
+        };
+    });
 
 .. note::
     
@@ -55,17 +57,24 @@ The following example demonstrates how to access the current notebook instance:
 
 .. code:: javascript
 
-    //file myext/main.js
+    // file my_extension/main.js
 
-    define(['base/js/namespace'],function(Jupyter){
-
-        function load_ipython_extension(){
-            console.log('This is the current notebook application instance', Jupyter.notebook);
+    define([
+        'base/js/namespace'
+    ], function(
+        Jupyter
+    ) {
+        function load_ipython_extension() {
+            console.log(
+                'This is the current notebook application instance:',
+                Jupyter.notebook
+            );
         }
 
-        return {load_ipython_extension: load_ipython_extension };
-    })
-
+        return {
+            load_ipython_extension: load_ipython_extension
+        };
+    });
 
 
 Modifying key bindings
@@ -82,17 +91,23 @@ place:
 
 .. code:: javascript
 
-    //file myext/main.js
+    // file my_extension/main.js
 
-    define(['base/js/namespace'],function(Jupyter){
+    define([
+        'base/js/namespace'
+    ], function(
+        Jupyter
+    ) {
 
-        function load_ipython_extension(){
-            Jupyter.keyboard_manager.command_shortcuts.remove_shortcut('0,0')
-            Jupyter.keyboard_manager.command_shortcuts.add_shortcut('0,0,0', 'jupyter-notebook:restart-kernel')
+        function load_ipython_extension() {
+            Jupyter.keyboard_manager.command_shortcuts.remove_shortcut('0,0');
+            Jupyter.keyboard_manager.command_shortcuts.add_shortcut('0,0,0', 'jupyter-notebook:restart-kernel');
         }
 
-        return {load_ipython_extension: load_ipython_extension };
-    })
+        return {
+            load_ipython_extension: load_ipython_extension
+        };
+    });
 
 .. note::
     
@@ -110,7 +125,7 @@ of what is available:
 
 .. code:: javascript
 
-    Object.keys(IPython.actions._actions)
+    Object.keys(require('base/js/namespace').actions._actions);
 
 In this example, we changed the keyboard shortcut in the **command mode**; you
 can also customize keyboard shortcuts in **edit mode**.
@@ -127,11 +142,11 @@ Installing and enabling extensions
 
 You can install your nbextension with the command:
 
-    jupyter nbextension install path/to/myext/
+    jupyter nbextension install path/to/my_extension/
 
-Where myext is the directory containing the Javascript files. This will copy
-it to a Jupyter data directory (the exact location is platform dependent - see
-:ref:`jupyter_path`).
+Where my_extension is the directory containing the Javascript files.
+This will copy it to a Jupyter data directory (the exact location is platform
+dependent - see :ref:`jupyter_path`).
 
 For development, you can use the ``--symlink`` flag to symlink your extension
 rather than copying it, so there's no need to reinstall after changes.
@@ -139,8 +154,9 @@ rather than copying it, so there's no need to reinstall after changes.
 To use your extension, you'll also need to **enable** it, which tells the
 notebook interface to load it. You can do that with another command:
 
-    jupyter nbextension enable myext/main
+    jupyter nbextension enable my_extension/main
 
-The argument refers to the Javascript module containing your ``load_ipython_extension``
-function, which is ``myext/main.js`` in this example. There is a corresponding
-``disable`` command to stop using an extension without uninstalling it.
+The argument refers to the Javascript module containing your
+``load_ipython_extension`` function, which is ``my_extension/main.js`` in this
+example. There is a corresponding ``disable`` command to stop using an
+extension without uninstalling it.

--- a/docs/source/extending/frontend_extensions.rst
+++ b/docs/source/extending/frontend_extensions.rst
@@ -16,9 +16,10 @@ The structure of a front-end extension
 
 A front-end extension is a JavaScript file that defines an
 [AMD module](https://en.wikipedia.org/wiki/Asynchronous_module_definition)
-which exposes at least a function called `load_ipython_extension`, which takes
-no arguments. We will not get into the details of what each of these terms
-consists of yet, but here is the minimal code needed for a working extension:
+which exposes at least a function called ``load_ipython_extension``, which
+takes no arguments. We will not get into the details of what each of these
+terms consists of yet, but here is the minimal code needed for a working
+extension:
 
 .. code:: javascript
 
@@ -38,8 +39,8 @@ consists of yet, but here is the minimal code needed for a working extension:
 .. note::
     
     Although for historical reasons the function is called
-    `load_ipython_extension`, it does apply to the Jupyter notebook in general,
-    and will work regardless of the kernel in use.
+    ``load_ipython_extension``, it does apply to the Jupyter notebook in
+    general, and will work regardless of the kernel in use.
 
 If you are familiar with JavaScript, you can use this template to require any
 Jupyter module and modify its configuration, or do anything else in client-side
@@ -48,12 +49,12 @@ page initialisation for you to set up a listener for the various events that
 the page can trigger.
 
 You might want access to the current instances of the various Jupyter notebook
-components on the page, as opposed to the classes defined in the modules.
-The current instances are exposed by a module named `base/js/namespace`.
-If you plan
-on accessing instances on the page, you should ``require`` this module rather
-than accessing the global variable `Jupyter`, which will be removed in future.
-The following example demonstrates how to access the current notebook instance:
+components on the page, as opposed to the classes defined in the modules. The
+current instances are exposed by a module named ``base/js/namespace``. If you
+plan on accessing instances on the page, you should ``require`` this module
+rather than accessing the global variable ``Jupyter``, which will be removed in
+future. The following example demonstrates how to access the current notebook
+instance:
 
 .. code:: javascript
 
@@ -85,8 +86,8 @@ again this is an API which is not guaranteed to be stable. However, custom key
 bindings are frequently requested, and are helpful to increase accessibility,
 so in the following we show how to access them.
 
-Here is an example of an extension that will unbind the shortcut `0,0` in
-command mode, which normally restarts the kernel, and bind `0,0,0` in its
+Here is an example of an extension that will unbind the shortcut ``0,0`` in
+command mode, which normally restarts the kernel, and bind ``0,0,0`` in its
 place:
 
 .. code:: javascript
@@ -118,8 +119,8 @@ place:
     the situation.
 
 You can see that I have used the **action name**
-`jupyter-notebook:restart-kernel` to bind the new shortcut. There is no API yet
-to access the list of all available *actions*, though the following in the
+``jupyter-notebook:restart-kernel`` to bind the new shortcut. There is no API
+yet to access the list of all available *actions*, though the following in the
 JavaScript console of your browser on a notebook page should give you an idea
 of what is available:
 

--- a/docs/source/extending/frontend_extensions.rst
+++ b/docs/source/extending/frontend_extensions.rst
@@ -134,10 +134,70 @@ can also customize keyboard shortcuts in **edit mode**.
 However, most of the keyboard shortcuts in edit mode are handled by CodeMirror,
 which supports custom key bindings via a completely different API.
 
-You can also define and register your own **actions** to be used, but the
-documentation for this has not been written yet. If you need to do it, please
-ask us, we can give you the necessary information, and we would appreciate if
-you could format them in a detailed way in place of this paragraph.
+
+Defining and registering your own actions
+-----------------------------------------
+
+As part of your front-end extension, you may wish to define actions, which can
+be attached to toolbar buttons, or called from the command palette. Here is an
+example of an extension that defines a (not very useful!) action to show an
+alert, and adds a toolabr button using the full action name:
+
+.. code:: javascript
+
+    // file my_extension/main.js
+
+    define([
+        'base/js/namespace'
+    ], function(
+        Jupyter
+    ) {
+        function load_ipython_extension() {
+
+            var handler = function () {
+                alert('this is an alert from my_extension!');
+            };
+
+            var action = {
+                icon: 'fa-comment-o', // a font-awesome class used on buttons, etc
+                help    : 'Show an alert',
+                help_index : 'zz',
+                handler : handler
+            };
+            var prefix = 'my_extension';
+            var action_name = 'show-alert';
+
+            var full_action_name = Jupyter.actions.register(action, name, prefix); // returns 'my_extension:show-alert'
+            Jupyter.toolbar.add_buttons_group([full_action_name]);
+        }
+
+        return {
+            load_ipython_extension: load_ipython_extension
+        };
+    });
+
+Every action needs a name, which, when joined with its prefix to make the full
+action name, should be unique. Built-in actions, like the
+``jupyter-notebook:restart-kernel`` we bound in the earlier
+`Modifying key bindings`_ example, use the prefix ``jupyter-notebook``. For
+actions defined in an extension, it makes sense to use the extension name as
+the prefix. For the action name, the following guidelines should be considered:
+
+.. adapted from notebook/static/notebook/js/actions.js
+* First pick a noun and a verb for the action. For example, if the action is
+  "restart kernel," the verb is "restart" and the noun is "kernel".
+* Omit terms like "selected" and "active" by default, so "delete-cell", rather
+  than "delete-selected-cell". Only provide a scope like "-all-" if it is other
+  than the default "selected" or "active" scope.
+* If an action has a secondary action, separate the secondary action with
+  "-and-", so "restart-kernel-and-clear-output".
+* Use above/below or previous/next to indicate spatial and sequential
+  relationships.
+* Don't ever use before/after as they have a temporal connotation that is
+  confusing when used in a spatial context.
+* For dialogs, use a verb that indicates what the dialog will accomplish, such
+  as "confirm-restart-kernel".
+
 
 Installing and enabling extensions
 ----------------------------------


### PR DESCRIPTION
in docs/extending/frontend_extensions:
* Add some description of actions
* beautify javascript examples
* fix inline literals, which in RST start and end with ``, not just `
* fix some typos & misspellings, some improvements to phrasing