### PR TITLE
Fixing way in which selection ranges are deleted

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -53,8 +53,9 @@ define([
          if (sel) { 
             var ranges = cm.listSelections();
             for (var i = ranges.length - 1; i >= 0; i--) {
-              var cur = ranges[i].head;
-              cm.replaceRange("", Pos(cur.line, cur.ch - 1), Pos(cur.line, cur.ch + 1));
+              var head = ranges[i].head;
+              var anchor = ranges[i].anchor;
+              cm.replaceRange("", Pos(head.line, head.ch), CodeMirror.Pos(anchor.line, anchor.ch));
             }
             return;
         }


### PR DESCRIPTION
I had made this fix: https://github.com/jupyter/notebook/pull/765

Which does work, but not exactly how it should -- It raised an exception which would make the control behave normally (which would delete the selections).

I've noticed this now, and made this fix, which tested it a lot, and now it works properly. Hope it's not too late for 4.1.