### PR TITLE
Fix secondary error that occurs during handling of HTTP 500 status

### DIFF
--- a/notebook/log.py
+++ b/notebook/log.py
@@ -43,6 +43,7 @@ def log_request(handler):
         msg = msg + ' referer={referer}'
     if status >= 500 and status != 502:
         # log all headers if it caused an error
-        log_method(json.dumps(request.headers, indent=2))
+        headers = { k: request.headers[k] for k in request.headers }
+        log_method(json.dumps(headers, indent=2))
     log_method(msg.format(**ns))
 

--- a/notebook/log.py
+++ b/notebook/log.py
@@ -43,7 +43,6 @@ def log_request(handler):
         msg = msg + ' referer={referer}'
     if status >= 500 and status != 502:
         # log all headers if it caused an error
-        headers = { k: request.headers[k] for k in request.headers }
-        log_method(json.dumps(headers, indent=2))
+        log_method(json.dumps(dict(request.headers), indent=2))
     log_method(msg.format(**ns))
 


### PR DESCRIPTION
In log.py, we're attempting to log the request headers when a
500-series error occurs, but tornado.httputil.HTTPHeaders isn't a dict -
it inherits from collections.MutableMapping. So it fails during
JSON serialization. The fix is to convert it to a dict first.

Unfortunately, the HTTPHeaders class doesn't expose any methods
to access the underlying dictionary (`request.headers._dict`) directly,
so we recreate it using the public API.

[This is my first Jupyter PR... feedback is welcome]