### PR TITLE
Fix ConfigWithDefaults "this" context

### DIFF
--- a/notebook/static/services/config.js
+++ b/notebook/static/services/config.js
@@ -93,7 +93,7 @@ function($, utils) {
     ConfigWithDefaults.prototype.get = function(key) {
         var that = this;
         return this.section.loaded.then(function() {
-            return this._class_data()[key] || this.defaults[key]
+            return that._class_data()[key] || that.defaults[key]
         });
     };
     


### PR DESCRIPTION
Within the promise callback, refer to the ConfigWithDefaults instance, not the Promise