### PR TITLE
Toggle scroll, collapse and clear cell now apply on selection.

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -307,22 +307,33 @@ define(function(require){
             }
         },
         'toggle-cell-output-collapsed' : {
-            help    : 'toggle output',
+            help    : 'toggle output of selected cells',
             help_index : 'gb',
             handler : function (env) {
-                env.notebook.toggle_output();
+                var indices = env.notebook.get_selected_cells_indices();
+                console.log(indices)
+                for(var i =0; i< indices.length; i++){
+                    env.notebook.toggle_output(indices[i]);
+                }
             }
         },
         'toggle-cell-output-scrolled' : {
-            help    : 'toggle output scrolling',
+            help    : 'toggle output scrolling of selected cells',
             help_index : 'gc',
             handler : function (env) {
-                env.notebook.toggle_output_scroll();
+                var indices = env.notebook.get_selected_cells_indices();
+                for(var i =0; i< indices.length; i++){
+                    env.notebook.toggle_output_scroll(indices[i]);
+                }
             }
         },
         'clear-cell-output' : {
+            help    : 'clear output of selected cells',
             handler : function (env) {
-                env.notebook.clear_output();
+                var indices = env.notebook.get_selected_cells_indices();
+                for(var i =0; i< indices.length; i++){
+                    env.notebook.clear_output(indices[i]);
+                }
             }
         },
         'move-cell-down' : {


### PR DESCRIPTION
Still need tests.

And as discussed a long time ago, the concept of toggling scrolling and
Collapsed is **not** the right one, it leads to inconsistencies.

The cell output has 3 states:
 - expanded
 - scrolled
 - collapsed

And the menu action should decide which one of the 3 user want.

Otherwise you get into inconsistencies like what is the difference
between collapsed & scrolled /vs/ collapsed & not scrolled.

Partially addresses #800 and #801 (I think)