### PR TITLE
Support multiple cell selections in markdown, raw, and code conversions

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -254,7 +254,7 @@ define(function(require){
             help    : 'to markdown',
             help_index : 'cb',
             handler : function (env) {
-                env.notebook.to_markdown();
+                env.notebook.cells_to_markdown();
             }
         },
         'change-cell-to-raw' : {

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -261,7 +261,7 @@ define(function(require){
             help    : 'to raw',
             help_index : 'cc',
             handler : function (env) {
-                env.notebook.to_raw();
+                env.notebook.cells_to_raw();
             }
         },
         'change-cell-to-heading-1' : {

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -243,11 +243,11 @@ define(function(require){
                 env.notebook.focus_cell();
             }
         },
-        'change-cell-to-code' : {
+        'change-cell(s)-to-code' : {
             help    : 'to code',
             help_index : 'ca',
             handler : function (env) {
-                env.notebook.to_code();
+                env.notebook.cells_to_code();
             }
         },
         'change-cell-to-markdown' : {

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -243,7 +243,7 @@ define(function(require){
                 env.notebook.focus_cell();
             }
         },
-        'change-cell(s)-to-code' : {
+        'change-cell-to-code' : {
             help    : 'to code',
             help_index : 'ca',
             handler : function (env) {

--- a/notebook/static/notebook/js/maintoolbar.js
+++ b/notebook/static/notebook/js/maintoolbar.js
@@ -114,7 +114,7 @@ define([
                 that.notebook.to_markdown();
                 break;
             case 'raw':
-                that.notebook.to_raw();
+                that.notebook.cells_to_raw();
                 break;
             case 'heading':
                 that.notebook._warn_heading();

--- a/notebook/static/notebook/js/maintoolbar.js
+++ b/notebook/static/notebook/js/maintoolbar.js
@@ -111,7 +111,7 @@ define([
                 that.notebook.cells_to_code();
                 break;
             case 'markdown':
-                that.notebook.to_markdown();
+                that.notebook.cells_to_markdown();
                 break;
             case 'raw':
                 that.notebook.cells_to_raw();

--- a/notebook/static/notebook/js/maintoolbar.js
+++ b/notebook/static/notebook/js/maintoolbar.js
@@ -108,7 +108,7 @@ define([
             var cell_type = $(this).val();
             switch (cell_type) {
             case 'code':
-                that.notebook.to_code();
+                that.notebook.cells_to_code();
                 break;
             case 'markdown':
                 that.notebook.to_markdown();

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1185,9 +1185,9 @@ define(function (require) {
         this.untocode_backup =[];
         
         for (var i=0; i <indices.length; i++){
-            this.to_code(indices[i])
+            this.to_code(indices[i]);
         }
-    }
+    };
     /**
      * Turn a cell into a code cell.
      * 

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1260,6 +1260,21 @@ define(function (require) {
     };
 
     /**
+     * Turn one or more cells into a raw text cell.
+     *
+     * @param {Array} indices - cell indices to convert
+     */
+     Notebook.prototype.cells_to_raw = function (indices) {
+        if (indices === undefined) {
+            indices = this.get_selected_cells_indices();
+        }
+
+        for(var i=0; i < indices.length; i++) {
+            this.to_raw(indices[i]);
+        }
+     };
+
+    /**
      * Turn a cell into a raw text cell.
      * 
      * @param {integer} [index] - cell index

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1182,7 +1182,6 @@ define(function (require) {
         if (indices === undefined){
             indices = this.get_selected_cells_indices();
         }
-        this.untocode_backup =[];
         
         for (var i=0; i <indices.length; i++){
             this.to_code(indices[i]);

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1191,6 +1191,7 @@ define(function (require) {
             this.to_code(indices[i]);
         }
     };
+
     /**
      * Turn a cell into a code cell.
      * 
@@ -1221,6 +1222,21 @@ define(function (require) {
             }
         }
     };
+
+    /**
+     * Turn one or more cells into Markdown.
+     *
+     * @param {Array} indices - cell indices to convert
+     */
+     Notebook.prototype.cells_to_markdown = function (indices) {
+        if (indices === undefined) {
+            indices = this.get_selected_cells_indices();
+        }
+
+        for(var i=0; i < indices.length; i++) {
+            this.to_markdown(indices[i]);
+        }
+     };
 
     /**
      * Turn a cell into a Markdown cell.

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1177,7 +1177,11 @@ define(function (require) {
         return this.insert_cell_below(type,len-1);
     };
     
-    
+    /**
+     * Turn one or more cells into code.
+     *
+     * @param {Array} indices - cell indices to convert
+     */
     Notebook.prototype.cells_to_code = function (indices) {
         if (indices === undefined){
             indices = this.get_selected_cells_indices();

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1176,7 +1176,18 @@ define(function (require) {
         var len = this.ncells();
         return this.insert_cell_below(type,len-1);
     };
-
+    
+    
+    Notebook.prototype.cells_to_code = function (indices) {
+        if (indices === undefined){
+            indices = this.get_selected_cells_indices();
+        }
+        this.untocode_backup =[];
+        
+        for (var i=0; i <indices.length; i++){
+            this.to_code(indices[i])
+        }
+    }
     /**
      * Turn a cell into a code cell.
      * 

--- a/notebook/tests/notebook/multiselect.js
+++ b/notebook/tests/notebook/multiselect.js
@@ -26,8 +26,6 @@ casper.notebook_test(function () {
             return $('.cell.jupyter-soft-selected').length; 
         }), 1, 'one cell is selected');
         
-                
-        
         this.test.assertEquals(this.evaluate(function() { 
             Jupyter.notebook.extend_selection_by(1);
             return Jupyter.notebook.get_selected_cells().length; 
@@ -45,5 +43,58 @@ casper.notebook_test(function () {
             return Jupyter.notebook.get_selected_cells().length; 
         }), 2, 'extend selection by one up');
 
+        // Test multiple markdown conversions.
+        var cell_types = this.evaluate(function() {
+            Jupyter.notebook.select(0);
+            Jupyter.notebook.extend_selection_by(2);
+            var indices = Jupyter.notebook.get_selected_cells_indices();
+            Jupyter.notebook.cells_to_markdown();
+            return indices.map(function(i) {
+                return Jupyter.notebook.get_cell(i).cell_type;
+            });
+        });
+        this.test.assert(cell_types.every(function(cell_type) {
+            return cell_type === 'markdown';
+        }), 'selected cells converted to markdown');
+
+        this.test.assertEquals(this.evaluate(function() {
+            return Jupyter.notebook.get_selected_cells_indices();
+        }).length, 1, 'one cell selected after convert');
+
+        // Test multiple raw conversions.
+        cell_types = this.evaluate(function() {
+            Jupyter.notebook.select(0);
+            Jupyter.notebook.extend_selection_by(2);
+            var indices = Jupyter.notebook.get_selected_cells_indices();
+            Jupyter.notebook.cells_to_raw();
+            return indices.map(function(i) {
+                return Jupyter.notebook.get_cell(i).cell_type;
+            });
+        });
+        this.test.assert(cell_types.every(function(cell_type) {
+            return cell_type === 'raw';
+        }), 'selected cells converted to raw');
+
+        this.test.assertEquals(this.evaluate(function() {
+            return Jupyter.notebook.get_selected_cells_indices();
+        }).length, 1, 'one cell selected after convert');
+
+        // Test multiple code conversions.
+        cell_types = this.evaluate(function() {
+            Jupyter.notebook.select(0);
+            Jupyter.notebook.extend_selection_by(2);
+            var indices = Jupyter.notebook.get_selected_cells_indices();
+            Jupyter.notebook.cells_to_code();
+            return indices.map(function(i) {
+                return Jupyter.notebook.get_cell(i).cell_type;
+            });
+        });
+        this.test.assert(cell_types.every(function(cell_type) {
+            return cell_type === 'code';
+        }), 'selected cells converted to code');
+
+        this.test.assertEquals(this.evaluate(function() {
+            return Jupyter.notebook.get_selected_cells_indices();
+        }).length, 1, 'one cell selected after convert');
     });
 });


### PR DESCRIPTION
Builds atop PR #790 for issue #802. Addresses the missing function comment. Also handles multiselect in the to_markdown and to_raw functions to fix #803 and #804.

Manually vetted. I can look into adding some tests.

/cc @parleur @Carreau @captainsafia 