### PR TITLE
Add tests for multiselect toggles

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -307,22 +307,33 @@ define(function(require){
             }
         },
         'toggle-cell-output-collapsed' : {
-            help    : 'toggle output',
+            help    : 'toggle output of selected cells',
             help_index : 'gb',
             handler : function (env) {
-                env.notebook.toggle_output();
+                var indices = env.notebook.get_selected_cells_indices();
+                console.log(indices)
+                for(var i =0; i< indices.length; i++){
+                    env.notebook.toggle_output(indices[i]);
+                }
             }
         },
         'toggle-cell-output-scrolled' : {
-            help    : 'toggle output scrolling',
+            help    : 'toggle output scrolling of selected cells',
             help_index : 'gc',
             handler : function (env) {
-                env.notebook.toggle_output_scroll();
+                var indices = env.notebook.get_selected_cells_indices();
+                for(var i =0; i< indices.length; i++){
+                    env.notebook.toggle_output_scroll(indices[i]);
+                }
             }
         },
         'clear-cell-output' : {
+            help    : 'clear output of selected cells',
             handler : function (env) {
-                env.notebook.clear_output();
+                var indices = env.notebook.get_selected_cells_indices();
+                for(var i =0; i< indices.length; i++){
+                    env.notebook.clear_output(indices[i]);
+                }
             }
         },
         'move-cell-down' : {

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -310,30 +310,20 @@ define(function(require){
             help    : 'toggle output of selected cells',
             help_index : 'gb',
             handler : function (env) {
-                var indices = env.notebook.get_selected_cells_indices();
-                console.log(indices)
-                for(var i =0; i< indices.length; i++){
-                    env.notebook.toggle_output(indices[i]);
-                }
+                env.notebook.toggle_cells_outputs();
             }
         },
         'toggle-cell-output-scrolled' : {
             help    : 'toggle output scrolling of selected cells',
             help_index : 'gc',
             handler : function (env) {
-                var indices = env.notebook.get_selected_cells_indices();
-                for(var i =0; i< indices.length; i++){
-                    env.notebook.toggle_output_scroll(indices[i]);
-                }
+                env.notebook.toggle_cells_outputs_scroll();
             }
         },
         'clear-cell-output' : {
             help    : 'clear output of selected cells',
             handler : function (env) {
-                var indices = env.notebook.get_selected_cells_indices();
-                for(var i =0; i< indices.length; i++){
-                    env.notebook.clear_output(indices[i]);
-                }
+                env.notebook.clear_cells_outputs();
             }
         },
         'move-cell-down' : {

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1601,6 +1601,20 @@ define(function (require) {
     };
 
     /**
+     * Clear multiple selected CodeCells' output areas.
+     *
+     */
+    Notebook.prototype.clear_cells_outputs = function(indices) {
+        if (!indices) {
+           var indices = this.get_selected_cells_indices();
+        }
+
+        for (var i = 0; i < indices.length; i++){
+            this.clear_output(indices[i]);
+        }
+    }
+
+    /**
      * Clear each code cell's output area.
      */
     Notebook.prototype.clear_all_output = function () {
@@ -1654,6 +1668,21 @@ define(function (require) {
     };
 
     /**
+     * Toggle whether all selected cells' outputs are collapsed or expanded.
+     *
+     * @param {integer} indices - the indices of the cells to toggle
+     */
+    Notebook.prototype.toggle_cells_outputs = function(indices) {
+        if (!indices) {
+           var indices = this.get_selected_cells_indices();
+        }
+
+        for (var i = 0; i < indices.length; i++){
+            this.toggle_output(indices[i]);
+        }
+    }
+
+    /**
      * Toggle the output of all cells.
      */
     Notebook.prototype.toggle_all_output = function () {
@@ -1679,6 +1708,21 @@ define(function (require) {
             this.set_dirty(true);
         }
     };
+
+    /**
+     * Toggle a scrollbar for selected long cells' outputs.
+     *
+     * @param {integer} indices - the indices of the cells to toggle
+     */
+    Notebook.prototype.toggle_cells_outputs_scroll = function(indices) {
+        if (!indices) {
+            var indices = this.get_selected_cells_indices();
+        }
+
+        for (var i = 0; i < indices.length; i++){
+            this.toggle_output_scroll(indices[i]);
+        }
+    }
 
     /**
      * Toggle the scrolling of long output on all cells.

--- a/notebook/tests/notebook/multiselect_toggle.js
+++ b/notebook/tests/notebook/multiselect_toggle.js
@@ -1,0 +1,70 @@
+// Test
+casper.notebook_test(function () {
+    var that = this;
+    
+    var a = 'print("a")';
+    var index = this.append_cell(a);
+
+    var b = 'print("b")';
+    index = this.append_cell(b);
+
+    var c = 'print("c")';
+    index = this.append_cell(c);
+
+    this.then(function () {   
+        /**
+         * Test that cells, which start off not collapsed, are collapsed after
+         * calling the multiselected cell toggle.
+         */     
+        var cell_output_states = this.evaluate(function() {
+            Jupyter.notebook.select(0);
+            Jupyter.notebook.extend_selection_by(2);
+            var indices = Jupyter.notebook.get_selected_cells_indices();
+            Jupyter.notebook.toggle_cells_outputs();
+            return indices.map(function(index) {
+                return Jupyter.notebook.get_cell(index).collapsed;
+            });
+        });
+
+        this.test.assert(cell_output_states.every(function(cell_output_state) {
+            return cell_output_state == false;
+        }), "ensure that all cells are not collapsed");
+        
+        /**
+         * Test that cells, which start off not scrolled are scrolled after
+         * calling the multiselected scroll toggle.
+         */
+        var cell_scrolled_states = this.evaluate(function() {
+            Jupyter.notebook.select(0);
+            Jupyter.notebook.extend_selection_by(2);
+            var indices = Jupyter.notebook.get_selected_cells_indices();
+            Jupyter.notebook.toggle_cells_outputs_scroll();
+            return indices.map(function(index) {
+                return Jupyter.notebook.get_cell(index).output_area.scroll_state;
+            });
+        });
+
+        this.test.assert(cell_scrolled_states.every(function(cell_scroll_state) {
+            return cell_scroll_state;
+        }), "ensure that all have scrolling enabled");
+
+        /**
+         * Test that cells, which start off not cleared are cleared after
+         * calling the multiselected scroll toggle.
+         */
+        var cell_outputs_cleared = this.evaluate(function() {
+            Jupyter.notebook.select(0);
+            Jupyter.notebook.extend_selection_by(2);
+            var indices = Jupyter.notebook.get_selected_cells_indices();
+            Jupyter.notebook.clear_cells_outputs();
+            return indices.map(function(index) {
+                return Jupyter.notebook.get_cell(index).output_area.element.html();
+            });
+        });
+
+        this.test.assert(cell_outputs_cleared.every(function(cell_output_state) {
+            return cell_output_state == "";
+        }), "ensure that all cells are cleared");
+
+    });
+});


### PR DESCRIPTION
Addresses @Carreau's request for tests for functionality added in #809.

Also refactors the code he added to use the neat function separation that @parleur used.

Not sure if we want all the multiselect tests in one file but I can probably refactor and make that happen.