### PR TITLE
Fix the selectbox celltype behavior when multiselected 

### DIFF
--- a/notebook/static/notebook/js/maintoolbar.js
+++ b/notebook/static/notebook/js/maintoolbar.js
@@ -95,7 +95,8 @@ define([
             .append($('<option/>').attr('value','code').text('Code'))
             .append($('<option/>').attr('value','markdown').text('Markdown'))
             .append($('<option/>').attr('value','raw').text('Raw NBConvert'))
-            .append($('<option/>').attr('value','heading').text('Heading'));
+            .append($('<option/>').attr('value','heading').text('Heading'))
+            .append($('<option/>').attr('value','multiselect').text('-'));
         this.notebook.keyboard_manager.register_events(sel);
         this.events.on('selected_cell_type_changed.Notebook', function (event, data) {
             if (data.cell_type === 'heading') {
@@ -120,6 +121,8 @@ define([
                 that.notebook._warn_heading();
                 that.notebook.to_heading();
                 sel.val('markdown');
+                break;
+            case 'multiselect':
                 break;
             default:
                 console.log("unrecognized cell type:", cell_type);

--- a/notebook/static/notebook/js/maintoolbar.js
+++ b/notebook/static/notebook/js/maintoolbar.js
@@ -90,6 +90,7 @@ define([
     MainToolBar.prototype._pseudo_actions.add_celltype_list = function () {
         var that = this;
         var multiselect = $('<option/>').attr('value','multiselect').attr('disabled','').text('-');
+        multiselect.hide();
         var sel = $('<select/>')
             .attr('id','cell_type')
             .addClass('form-control select-xs')
@@ -101,9 +102,7 @@ define([
         this.notebook.keyboard_manager.register_events(sel);
         this.events.on('selected_cell_type_changed.Notebook', function (event, data) {
             if ( that.notebook.get_selected_cells_indices().length > 1) {
-                multiselect.show();
                 sel.val('multiselect');
-                multiselect.hide();
             } else {
                 if (data.cell_type === 'heading') {
                     sel.val('Markdown');

--- a/notebook/static/notebook/js/maintoolbar.js
+++ b/notebook/static/notebook/js/maintoolbar.js
@@ -89,6 +89,7 @@ define([
     // encountered when building a toolbar.
     MainToolBar.prototype._pseudo_actions.add_celltype_list = function () {
         var that = this;
+        var multiselect = $('<option/>').attr('value','multiselect').attr('disabled','').text('-');
         var sel = $('<select/>')
             .attr('id','cell_type')
             .addClass('form-control select-xs')
@@ -96,13 +97,19 @@ define([
             .append($('<option/>').attr('value','markdown').text('Markdown'))
             .append($('<option/>').attr('value','raw').text('Raw NBConvert'))
             .append($('<option/>').attr('value','heading').text('Heading'))
-            .append($('<option/>').attr('value','multiselect').text('-'));
+            .append(multiselect);
         this.notebook.keyboard_manager.register_events(sel);
         this.events.on('selected_cell_type_changed.Notebook', function (event, data) {
-            if (data.cell_type === 'heading') {
-                sel.val('Markdown');
+            if ( that.notebook.get_selected_cells_indices().length > 1) {
+                multiselect.show();
+                sel.val('multiselect');
+                multiselect.hide();
             } else {
-                sel.val(data.cell_type);
+                if (data.cell_type === 'heading') {
+                    sel.val('Markdown');
+                } else {
+                    sel.val(data.cell_type);
+                }
             }
         });
         sel.change(function () {

--- a/notebook/static/notebook/js/maintoolbar.js
+++ b/notebook/static/notebook/js/maintoolbar.js
@@ -90,7 +90,6 @@ define([
     MainToolBar.prototype._pseudo_actions.add_celltype_list = function () {
         var that = this;
         var multiselect = $('<option/>').attr('value','multiselect').attr('disabled','').text('-');
-        multiselect.hide();
         var sel = $('<select/>')
             .attr('id','cell_type')
             .addClass('form-control select-xs')
@@ -102,8 +101,10 @@ define([
         this.notebook.keyboard_manager.register_events(sel);
         this.events.on('selected_cell_type_changed.Notebook', function (event, data) {
             if ( that.notebook.get_selected_cells_indices().length > 1) {
+                multiselect.show();
                 sel.val('multiselect');
             } else {
+                multiselect.hide()
                 if (data.cell_type === 'heading') {
                     sel.val('Markdown');
                 } else {

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -709,6 +709,7 @@ define(function (require) {
             }
             var cell = this.get_cell(index);
             cell.select(moveanchor);
+            this.update_soft_selection();
             if (cell.cell_type === 'heading') {
                 this.events.trigger('selected_cell_type_changed.Notebook',
                     {'cell_type':cell.cell_type,level:cell.level}
@@ -719,7 +720,6 @@ define(function (require) {
                 );
             }
         }
-        this.update_soft_selection();
         return this;
     };
 


### PR DESCRIPTION
PR on top of @parente 's #809 (ping @Carreau, @jdfreder )
Basically when several cells are selected, the selectbox enter in a state '-' hidden otherwise. It allows to select any other cell type and flip all cell in selection to it. 

Thanks to @carreau for help on it.