### PR TITLE
Fix move selection up/down

### DIFF
--- a/notebook/tests/notebook/move_multiselection.js
+++ b/notebook/tests/notebook/move_multiselection.js
@@ -16,15 +16,12 @@ casper.notebook_test(function () {
                     pre_message+': Verify that cell `' + i +  '` has for content: `'+ expected_state[i] + '` found : ' + that.get_cell_text(i)
             );
         }
-
-
-
     }
 
 
 
     this.then(function () {
-         // Copy/paste/cut
+        // select 3 first cells
         this.select_cell(0);
         this.select_cell(2, false);
 
@@ -32,8 +29,10 @@ casper.notebook_test(function () {
             Jupyter.notebook.move_selection_up();
         });
 
+        // should not move up at top
         assert_order(this, 'move up at top', ['', '1', '2', '3', '4', '5','6'])
-        
+
+        // we do not need to reselect, move/up down should keep the selection. 
         this.evaluate(function () {
             Jupyter.notebook.move_selection_down();
             Jupyter.notebook.move_selection_down();
@@ -41,12 +40,14 @@ casper.notebook_test(function () {
             Jupyter.notebook.move_selection_down();
         });
 
+        // 4 times down should move to the 3 cells to the bottom
         assert_order(this, 'move down to bottom', [ '3', '4', '5','6', '', '1', '2'])
         
         this.evaluate(function () {
             Jupyter.notebook.move_selection_down();
         });
 
+        // they can't go any further (test it)
         assert_order(this, 'move at to top', [ '3', '4', '5','6', '', '1', '2'])
         
         this.evaluate(function () {
@@ -55,7 +56,8 @@ casper.notebook_test(function () {
             Jupyter.notebook.move_selection_up();
             Jupyter.notebook.move_selection_up();
         });
-        
+
+        // bring them back on top.
         assert_order(this, 'move up to top', ['', '1', '2', '3', '4', '5','6'])
 
     });

--- a/notebook/tests/notebook/move_multiselection.js
+++ b/notebook/tests/notebook/move_multiselection.js
@@ -1,0 +1,62 @@
+
+
+// Test
+casper.notebook_test(function () {
+    this.append_cell('1');
+    this.append_cell('2');
+    this.append_cell('3');
+    this.append_cell('4');
+    this.append_cell('5');
+    this.append_cell('6');
+
+    function assert_order(that, pre_message, expected_state){
+
+        for (var i=1; i<expected_state.length; i++){
+            that.test.assertEquals(that.get_cell_text(i), expected_state[i],
+                    pre_message+': Verify that cell `' + i +  '` has for content: `'+ expected_state[i] + '` found : ' + that.get_cell_text(i)
+            );
+        }
+
+
+
+    }
+
+
+
+    this.then(function () {
+         // Copy/paste/cut
+        this.select_cell(0);
+        this.select_cell(2, false);
+
+        this.evaluate(function () {
+            Jupyter.notebook.move_selection_up();
+        });
+
+        assert_order(this, 'move up at top', ['', '1', '2', '3', '4', '5','6'])
+        
+        this.evaluate(function () {
+            Jupyter.notebook.move_selection_down();
+            Jupyter.notebook.move_selection_down();
+            Jupyter.notebook.move_selection_down();
+            Jupyter.notebook.move_selection_down();
+        });
+
+        assert_order(this, 'move down to bottom', [ '3', '4', '5','6', '', '1', '2'])
+        
+        this.evaluate(function () {
+            Jupyter.notebook.move_selection_down();
+        });
+
+        assert_order(this, 'move at to top', [ '3', '4', '5','6', '', '1', '2'])
+        
+        this.evaluate(function () {
+            Jupyter.notebook.move_selection_up();
+            Jupyter.notebook.move_selection_up();
+            Jupyter.notebook.move_selection_up();
+            Jupyter.notebook.move_selection_up();
+        });
+        
+        assert_order(this, 'move up to top', ['', '1', '2', '3', '4', '5','6'])
+
+    });
+});

--- a/notebook/tests/notebook/multiselect_toggle.js
+++ b/notebook/tests/notebook/multiselect_toggle.js
@@ -65,57 +65,6 @@ casper.notebook_test(function () {
         this.test.assert(cell_outputs_cleared.every(function(cell_output_state) {
             return cell_output_state == "";
         }), "ensure that all cells are cleared");
-        
-        /**
-        * Test the multiselection 2 moves down.
-        **/
-        this.test.assert(this.evaluate( function() {
-          Jupyter.notebook.select(0);
-          Jupyter.notebook.extend_selection_by(2);
-          var indices_it = [2,3,4].entries();
-          Jupyter.notebook.move_selection_down();
-          Jupyter.notebook.move_selection_down();
-          var result = Jupyter.notebook.get_selected_cells_indices();
-          return result.every( function(i){return i === indices_it.next().value[1];})
-        }));
-        
-        /** 
-        * Test multiselection 2 moves up.
-        **/
-        this.test.assert( this.evaluate( function(){
-          Jupyter.notebook.select(2);
-          Jupyter.notebook.extend_selection_by(3);
-          var indices_it = [0,1,2,3].entries();
-          Jupyter.notebook.move_selection_up();
-          Jupyter.notebook.move_selection_up();
-          var result = Jupyter.notebook.get_selected_cells_indices();
-          return result.every( function(i){return i === indices_it.next().value[1];})
-        }));
-        
-        
-        /**
-        * Test the multiselection move up at beginning of a Notebook
-        **/
-        this.test.assert(this.evaluate( function() {
-          Jupyter.notebook.select(0);
-          Jupyter.notebook.extend_selection_by(2);
-          var indices_it = Jupyter.notebook.get_selected_cells_indices().entries();
-          Jupyter.notebook.move_selection_up();
-          var result = Jupyter.notebook.get_selected_cells_indices();
-          return result.every( function(i){return i === indices_it.next().value[1];})
-        }));
-        
-        /**
-        * Test the move down at the end of the notebook
-        **/
-        this.test.assert(this.evaluate( function() {
-          var last_index = Jupyter.notebook.get_cells().length
-          Jupyter.notebook.select(last_index - 3);
-          Jupyter.notebook.extend_selection_by(2);
-          var indices_it = Jupyter.notebook.get_selected_cells_indices().entries();
-          Jupyter.notebook.move_selection_down();
-          var result = Jupyter.notebook.get_selected_cells_indices();
-          return result.every( function(i){return i === indices_it.next().value[1];})
-        }));
+
     });
 });

--- a/notebook/tests/notebook/multiselect_toggle.js
+++ b/notebook/tests/notebook/multiselect_toggle.js
@@ -112,7 +112,7 @@ casper.notebook_test(function () {
           var last_index = Jupyter.notebook.get_cells().length
           Jupyter.notebook.select(last_index - 3);
           Jupyter.notebook.extend_selection_by(2);
-          var indices.it() = Jupyter.notebook.get_selected_cells_indices().entries();
+          var indices_it = Jupyter.notebook.get_selected_cells_indices().entries();
           Jupyter.notebook.move_selection_down();
           var result = Jupyter.notebook.get_selected_cells_indices();
           return result.every( function(i){return i === indices_it.next().value[1];})

--- a/notebook/tests/notebook/multiselect_toggle.js
+++ b/notebook/tests/notebook/multiselect_toggle.js
@@ -65,6 +65,44 @@ casper.notebook_test(function () {
         this.test.assert(cell_outputs_cleared.every(function(cell_output_state) {
             return cell_output_state == "";
         }), "ensure that all cells are cleared");
-
+        
+        /**
+        * Test the multiselection 2 moves down.
+        **/
+        var result_indices = this.evaluate( function() {
+          Jupyter.notebook.select(0);
+          Jupyter.notebook.extend_selection_by(2);
+          var indices = Jupyter.notebook.get_selected_cells_indices();
+          Jupyter.notebook.move_selection_down();
+          Jupyter.notebook.move_selection_down();
+          return Jupyter.notebook.get_selected_cells_indices();
+        });
+        var result = [2,3,4].entries();
+        this.test.assert(result_indices.every( function(i){ return i === result.next().value[1];}))
+        
+        /**
+        * Test the multiselection move up at beginning of a Notebook
+        **/
+        this.test.assert(this.evaluate( function() {
+          Jupyter.notebook.select(0);
+          Jupyter.notebook.extend_selection_by(2);
+          var indices_it = Jupyter.notebook.get_selected_cells_indices().entries();
+          Jupyter.notebook.move_selection_up();
+          var result = Jupyter.notebook.get_selected_cells_indices();
+          return result.every( function(i){return i === indices_it.next().value[1];})
+        }));
+        
+        /**
+        * Test the move down at the end of the notebook
+        **/
+        this.test.assert(this.evaluate( function() {
+          var last_index = Jupyter.notebook.get_cells().length
+          Jupyter.notebook.select(last_index - 3);
+          Jupyter.notebook.extend_selection_by(2);
+          var indices.it() = Jupyter.notebook.get_selected_cells_indices().entries();
+          Jupyter.notebook.move_selection_down();
+          var result = Jupyter.notebook.get_selected_cells_indices();
+          return result.every( function(i){return i === indices_it.next().value[1];})
+        }));
     });
 });

--- a/notebook/tests/notebook/multiselect_toggle.js
+++ b/notebook/tests/notebook/multiselect_toggle.js
@@ -69,16 +69,29 @@ casper.notebook_test(function () {
         /**
         * Test the multiselection 2 moves down.
         **/
-        var result_indices = this.evaluate( function() {
+        this.test.assert(this.evaluate( function() {
           Jupyter.notebook.select(0);
           Jupyter.notebook.extend_selection_by(2);
-          var indices = Jupyter.notebook.get_selected_cells_indices();
+          var indices_it = [2,3,4].entries();
           Jupyter.notebook.move_selection_down();
           Jupyter.notebook.move_selection_down();
-          return Jupyter.notebook.get_selected_cells_indices();
-        });
-        var result = [2,3,4].entries();
-        this.test.assert(result_indices.every( function(i){ return i === result.next().value[1];}))
+          var result = Jupyter.notebook.get_selected_cells_indices();
+          return result.every( function(i){return i === indices_it.next().value[1];})
+        }));
+        
+        /** 
+        * Test multiselection 2 moves up.
+        **/
+        this.test.assert( this.evaluate( function(){
+          Jupyter.notebook.select(2);
+          Jupyter.notebook.extend_selection_by(3);
+          var indices_it = [0,1,2,3].entries();
+          Jupyter.notebook.move_selection_up();
+          Jupyter.notebook.move_selection_up();
+          var result = Jupyter.notebook.get_selected_cells_indices();
+          return result.every( function(i){return i === indices_it.next().value[1];})
+        }));
+        
         
         /**
         * Test the multiselection move up at beginning of a Notebook


### PR DESCRIPTION
Move the selection by detach/attach previous/next cell, and reselect the
moved selection.

Closes #793 (once test written).