### PR TITLE
Bump version number to `4.1.0.b1`

### DIFF
--- a/notebook/_version.py
+++ b/notebook/_version.py
@@ -1,2 +1,2 @@
-version_info = (4, 1, 0, 'dev')
+version_info = (4, 1, 0, 'b1')
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
With the version numbering suggested by Pep 440 :

- https://www.python.org/dev/peps/pep-0440/

-- 
To merge only once we are ready to release Beta1. 