### PR TITLE
Test for Pep440 non-Complaint version numbers

### DIFF
--- a/notebook/_version.py
+++ b/notebook/_version.py
@@ -1,2 +1,28 @@
-version_info = (4, 1, 0, 'b1')
+"""
+store the current version info of the notebook.
+
+"""
+
+# Downstream maintainer, when running `python.setup.py jsversion`,
+# the version string is propagated to the JavaScript files,  do not forget to
+# patch the JavaScript files in `.postN` release done by distributions. 
+
+# Next beta/alpha/rc release: The version number for beta is X.Y.ZbN **without dots**. 
+
+version_info = (4, 1, '0b1')
 __version__ = '.'.join(map(str, version_info))
+
+import re
+
+pep440re = re.compile('^(\d+)\.(\d+)\.(\d+((a|b|rc)\d+)?)(\.post\d+)?(\.dev\d+)?$')
+
+
+
+def raise_on_bad_version(version):
+    if not pep440re.match(version):
+        raise ValueError("Versions String does apparently not match Pep 440 specification, "
+                         "which might lead to sdist and wheel being seen as 2 different release. "
+                         "E.g: do not use dots for beta/alpha/rc markers.")
+        
+
+raise_on_bad_version(__version__)

--- a/notebook/tests/test_notebookapp.py
+++ b/notebook/tests/test_notebookapp.py
@@ -15,6 +15,8 @@ from traitlets import TraitError
 from notebook import notebookapp
 NotebookApp = notebookapp.NotebookApp
 
+from notebook._version import raise_on_bad_version
+
 
 def test_help_output():
     """ipython notebook --help-all works"""
@@ -74,4 +76,26 @@ def test_generate_config():
         with nt.assert_raises(NoStart):
             app.start()
         assert os.path.exists(os.path.join(td, 'jupyter_notebook_config.py'))
-    
+
+
+
+def test_pep440_version():
+
+    for version in [
+        '4.1.0.b1',
+        '4.1.b1',
+        '4.2',
+        'X.y.z',
+        '1.2.3.dev1.post2',
+        ]:
+        def loc():
+            with nt.assert_raises(ValueError):
+                raise_on_bad_version(version)
+        yield loc
+
+    for version in [
+        '4.1.1',
+        '4.2.1b3',
+        ]:
+
+        yield (raise_on_bad_version, version)


### PR DESCRIPTION
test directly in the version number file, as the version number is
likely to be committed before running tests, so we want **really quick
failure**.

---

Among other this broke the release of the sdist, that was on PyPI appearing as more-recent than the wheel as `0.b1` is bigger than `0b1` and the wheel builder auto update `0.b1` to `0b1` 