### PR TITLE
normalize version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ from distutils.core import setup
 # Our own imports
 
 from setupbase import (
-    version,
+    pkg_version,
     find_packages,
     find_package_data,
     check_package_data_first,
@@ -75,7 +75,7 @@ languages, sharing, and interactive widgets.
 Read `the documentation <https://jupyter-notebook.readthedocs.org>`_
 for more information.
     """,
-    version         = version,
+    version         = pkg_version,
     scripts         = glob(pjoin('scripts', '*')),
     packages        = find_packages(),
     package_data     = find_package_data(),

--- a/setupbase.py
+++ b/setupbase.py
@@ -65,8 +65,27 @@ name = 'notebook'
 version_ns = {}
 execfile(pjoin(repo_root, name, '_version.py'), version_ns)
 
-version = version_ns['__version__']
+def normalized_version(version_info):
+    """Normalize version string
+    
+    Avoids prerelease uploads getting different versions from sdist and bdist,
+    due to setuptools normalization.
+    """
+    v = '.'.join(map(str, version_info[:3]))
+    if len(version_info) == 3:
+        return v
+    extra = version_info[3]
+    if extra.startswith(('a', 'b', 'rc')):
+        sep = ''
+    else:
+        sep = '.'
+    # pip ensures there's number on the end
+    if not extra[-1].isdigit():
+        extra += '0'
+    return v + sep + extra
 
+version = version_ns['__version__']
+pkg_version = normalized_version(version_ns['version_info'])
 
 #---------------------------------------------------------------------------
 # Find packages


### PR DESCRIPTION
avoids mismatch between wheel/sdist upload on PyPI due to setuptools normalization of prerelease tags.

alternative to #860