### PR TITLE
Add sidebar box in doc's index for 4.1.x

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,8 @@ Jupyter notebook changelog
 A summary of changes in the Jupyter notebook.
 For more detailed information, see `GitHub <https://github.com/jupyter/notebook>`__.
 
+.. _release-4.1.x:
+
 4.1.0
 -----
 
@@ -25,11 +27,11 @@ UI Changes:
 - Added multiple-cell selection (``Shift-Up/Down`` to extend selection), and actions on multiple-cells, including cut/copy/paste and execute.
 
   .. image:: /_static/images/multi-select-41.png
-  
+
 - Added a command palette for executing Jupyter actions by name
 
   .. image:: /_static/images/command-palette-41.png
-  
+
 - Added the find and replace dialog (in the Edit menu or ``F`` in command-mode).
 
   .. image:: /_static/images/find-replace-41.png

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,6 +2,15 @@
 The Jupyter notebook
 ====================
 
+.. sidebar:: What's New in Jupyter Notebook
+   :subtitle: :ref:`release-4.1.x` **Beta 4.1.0b**
+
+   - Cell toolbar selector moved to View menu
+   - Restart & Run All Cells added to Kernel menu
+   - Multiple-cell selection and actions including cut, copy, paste and execute
+   - Command palette added for executing Jupyter actions
+   - Find and replace added to Edit menu
+
 .. toctree::
    :maxdepth: 1
    :caption: User Documentation


### PR DESCRIPTION
Adds a release link to changelog.rst and a sidebar box to index.rst. Displays as below:
<img width="1097" alt="screen shot 2015-12-14 at 8 16 37 pm" src="https://cloud.githubusercontent.com/assets/2680980/11802467/d6ce52c4-a2a5-11e5-8406-2749e840a8c8.png">
