### PR TITLE
Don't clear output on set_next_input(replace=True)

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -43,6 +43,7 @@ UI changes:
 Other improvements:
 
 - Custom KernelManager methods can be Tornado coroutines, allowing async operations.
+- No longer clear output when rewriting input with ``set_next_input(replace=True)``.
 - Added support for TLS client authentication via ``--NotebookApp.client-ca``.
 - Added tags to ``jupyter/notebook`` releases on DockerHub. ``latest`` continues to track the master branch.
 

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -197,7 +197,6 @@ define(function (require) {
         this.events.on('set_next_input.Notebook', function (event, data) {
             if (data.replace) {
                 data.cell.set_text(data.text);
-                data.cell.clear_output();
             } else {
                 var index = that.find_cell_index(data.cell);
                 var new_cell = that.insert_cell_below('code',index);


### PR DESCRIPTION
rewriting input shouldn't force removal of output

rewriting can be autocorrect-style, e.g. autocall or other markers on the cell that was executed