### PR TITLE
add clear_output option to set_next_input payload

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -43,7 +43,7 @@ UI changes:
 Other improvements:
 
 - Custom KernelManager methods can be Tornado coroutines, allowing async operations.
-- No longer clear output when rewriting input with ``set_next_input(replace=True)``.
+- Make clearing output optional when rewriting input with ``set_next_input(replace=True)``.
 - Added support for TLS client authentication via ``--NotebookApp.client-ca``.
 - Added tags to ``jupyter/notebook`` releases on DockerHub. ``latest`` continues to track the master branch.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -43,6 +43,7 @@ UI changes:
 Other improvements:
 
 - Custom KernelManager methods can be Tornado coroutines, allowing async operations.
+- No longer clear output when rewriting input with ``set_next_input(replace=True)``.
 - Added support for TLS client authentication via ``--NotebookApp.client-ca``.
 - Added tags to ``jupyter/notebook`` releases on DockerHub. ``latest`` continues to track the master branch.
 

--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -385,7 +385,12 @@ define([
      * @private
      */
     CodeCell.prototype._handle_set_next_input = function (payload) {
-        var data = {'cell': this, 'text': payload.text, replace: payload.replace};
+        var data = {
+            cell: this,
+            text: payload.text,
+            replace: payload.replace,
+            clear_output: payload.clear_output,
+        };
         this.events.trigger('set_next_input.Notebook', data);
     };
 

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -197,6 +197,10 @@ define(function (require) {
         this.events.on('set_next_input.Notebook', function (event, data) {
             if (data.replace) {
                 data.cell.set_text(data.text);
+                if (data.clear_output !== false) {
+                  // default (undefined) is true to preserve prior behavior
+                  data.cell.clear_output();
+                }
             } else {
                 var index = that.find_cell_index(data.cell);
                 var new_cell = that.insert_cell_below('code',index);

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -197,7 +197,6 @@ define(function (require) {
         this.events.on('set_next_input.Notebook', function (event, data) {
             if (data.replace) {
                 data.cell.set_text(data.text);
-                data.cell.clear_output();
             } else {
                 var index = that.find_cell_index(data.cell);
                 var new_cell = that.insert_cell_below('code',index);


### PR DESCRIPTION
default preserves prior behavior

alternative to #874, making skipping clear_output optional and non-default, so that current behavior is completely unchanged.