### PR TITLE
Multi-select: avoid adding a css class to body element

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -673,13 +673,8 @@ define(function (require) {
         var i2 = this.get_anchor_index();
         var low  = Math.min(i1, i2);
         var high = Math.max(i1, i2);
-        if (low !== high){
-            $('body').addClass('jupyter-multi-select');
-        } else {
-            $('body').removeClass('jupyter-multi-select');
-        }
         this.get_cells().map(function(cell, index, all){
-            if( low <= index && index <= high ){
+            if( low <= index && index <= high && low !== high){
                 cell.element.addClass(_SOFT_SELECTION_CLASS);
             } else {
                 cell.element.removeClass(_SOFT_SELECTION_CLASS);

--- a/notebook/static/notebook/less/cell.less
+++ b/notebook/static/notebook/less/cell.less
@@ -21,30 +21,29 @@ div.cell {
     /* This acts as a spacer between cells, that is outside the border */
     margin: 0px;
     outline: none;
-   
+
     ._selected_style(transparent, transparent, @cell_border_width);
 
-    .jupyter-multi-select &.jupyter-soft-selected {
+    &.jupyter-soft-selected {
         border-left-color: @selected_border_color_light;
         border-left-color: @soft_select_color;
         ._selected_style(@selected_border_color_light, @soft_select_color, 5px, 0px);
-        
+
         @media print {
             border-color: transparent;
         }
     }
 
-     &.selected {
+    &.selected {
         border-color: @border_color;
         ._selected_style(@selected_border_color, transparent, 5px, 0px);
-        
-        
+
         @media print {
             border-color: transparent;
         }
     }
 
-    .jupyter-multi-select &.selected.jupyter-soft-selected {
+    &.selected.jupyter-soft-selected {
         ._selected_style(@selected_border_color, @soft_select_color, 7px, 0);
     }
 

--- a/notebook/tests/notebook/multiselect.js
+++ b/notebook/tests/notebook/multiselect.js
@@ -22,10 +22,10 @@ casper.notebook_test(function () {
             return Jupyter.notebook.get_selected_cells().length; 
         }), 1, 'only one cell is selected programmatically');
 
-        this.test.assertEquals(this.evaluate(function() { 
-            return $('.cell.jupyter-soft-selected').length; 
+        this.test.assertEquals(this.evaluate(function() {
+            return $('.cell.jupyter-soft-selected, .cell.selected').length;
         }), 1, 'one cell is selected');
-        
+
         this.test.assertEquals(this.evaluate(function() { 
             Jupyter.notebook.extend_selection_by(1);
             return Jupyter.notebook.get_selected_cells().length; 


### PR DESCRIPTION
This should not change the behavior for the user. It preserves the current behavior without resorting to adding a class to the top `body` element.

cc @Carreau @ellisonbg 
