### PR TITLE
Last selected styling

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -690,7 +690,7 @@ define(function (require) {
         var low  = Math.min(i1, i2);
         var high = Math.max(i1, i2);
         this.get_cells().map(function(cell, index, all){
-            if( low <= index && index <= high && low !== high){
+            if( low <= index && index <= high ){
                 cell.element.addClass(_SOFT_SELECTION_CLASS);
             } else {
                 cell.element.removeClass(_SOFT_SELECTION_CLASS);

--- a/notebook/static/notebook/less/cell.less
+++ b/notebook/static/notebook/less/cell.less
@@ -11,13 +11,14 @@ div.cell {
     .vbox();
     .corner-all();
     .border-box-sizing();
-    
+
     border-width: @cell_border_width;
     border-style: solid;
     border-color: transparent;
 
     width: 100%;
     padding: @_cell_padding_minus_border;
+
     /* This acts as a spacer between cells, that is outside the border */
     margin: 0px;
     outline: none;
@@ -45,10 +46,6 @@ div.cell {
         @media print {
             border-color: transparent;
         }
-    }
-
-    &.selected.jupyter-soft-selected {
-        ._selected_style(@selected_border_color, @soft_select_color, 7px, 0);
     }
 
     .edit_mode &.selected {
@@ -122,7 +119,7 @@ div.unrecognized_cell {
     // from text_cell
     padding: 5px @_cell_padding_minus_border 5px 0px;
     .hbox();
-    
+
     .inner_cell {
         .border-radius(@border-radius-base);
         padding: @_cell_padding_minus_border;

--- a/notebook/tests/notebook/multiselect.js
+++ b/notebook/tests/notebook/multiselect.js
@@ -23,7 +23,7 @@ casper.notebook_test(function () {
         }), 1, 'only one cell is selected programmatically');
 
         this.test.assertEquals(this.evaluate(function() {
-            return $('.cell.jupyter-soft-selected, .cell.selected').length;
+            return $('.cell.jupyter-soft-selected').length;
         }), 1, 'one cell is selected');
 
         this.test.assertEquals(this.evaluate(function() { 


### PR DESCRIPTION
Opening the PR since I had the branch hanging around wrt multi-selection styling after the discussion on gitter with @ellisonbg . The goal to not make the case where a single cell is selected a special case.

![multi-select](https://cloud.githubusercontent.com/assets/2397974/11877596/47601e18-a4be-11e5-9cc9-4c72049b817d.gif)

This makes it a bit more similar to excel:

<img width="274" alt="excel-selection" src="https://cloud.githubusercontent.com/assets/2397974/11877621/72eca646-a4be-11e5-91d6-9c67922be1d7.png">

And it also simplifies the code.

cc @cameronoelsen @Carreau 
