### PR TITLE
Remove hard-coding of jupyter_config_dir config_dir at the notebookapp level

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -827,8 +827,7 @@ class NotebookApp(JupyterApp):
         )
         self.config_manager = self.config_manager_class(
             parent=self,
-            log=self.log,
-            config_dir=os.path.join(self.config_dir, 'nbconfig'),
+            log=self.log
         )
 
     def init_logging(self):


### PR DESCRIPTION
Let's the ConfigManager to deal with the default value, so we can make it truly configurable.

Pretend to fix #880 