### PR TITLE
Avoid error when using a cross-origin websocket

### DIFF
--- a/notebook/base/zmqhandlers.py
+++ b/notebook/base/zmqhandlers.py
@@ -101,6 +101,7 @@ class WebSocketMixin(object):
     ping_callback = None
     last_ping = 0
     last_pong = 0
+    stream = None
     
     @property
     def ping_interval(self):


### PR DESCRIPTION
I was getting the following error while working on `jupyter-js-terminal`:

```python
[D 15:50:16.306 NotebookApp] 'TermSocket' object has no attribute 'stream'
[E 15:50:16.306 NotebookApp] Uncaught exception
Traceback (most recent call last):
File "/Users/ssilvester/anaconda/lib/python3.4/site-packages/tornado/http1connection.py", line 238, in _read_message
delegate.finish()
File "/Users/ssilvester/anaconda/lib/python3.4/site-packages/tornado/httpserver.py", line 290, in finish
self.delegate.finish()
File "/Users/ssilvester/anaconda/lib/python3.4/site-packages/tornado/web.py", line 1984, in finish
self.execute()
File "/Users/ssilvester/anaconda/lib/python3.4/site-packages/tornado/web.py", line 2004, in execute
**self.handler_kwargs)
File "/Users/ssilvester/anaconda/lib/python3.4/site-packages/tornado/websocket.py", line 133, in __init__
**kwargs)
File "/Users/ssilvester/anaconda/lib/python3.4/site-packages/tornado/web.py", line 183, in __init__
self.clear()
File "/Users/ssilvester/anaconda/lib/python3.4/site-packages/tornado/web.py", line 287, in clear
self.set_default_headers()
File "/Users/ssilvester/workspace/jupyter/notebook/notebook/base/handlers.py", line 232, in set_default_headers
self.set_header("Access-Control-Allow-Origin", self.allow_origin)
File "/Users/ssilvester/anaconda/lib/python3.4/site-packages/tornado/websocket.py", line 388, in _disallow_for_websocket
if self.stream is None:
AttributeError: 'TermSocket' object has no attribute 'stream'
```