### PR TITLE
Do not violently remove `config_dir` kwarg of config manager.

### DIFF
--- a/notebook/services/config/manager.py
+++ b/notebook/services/config/manager.py
@@ -9,8 +9,17 @@ from traitlets.config.manager import BaseJSONConfigManager
 from jupyter_core.paths import jupyter_config_dir
 from traitlets import Unicode
 
+import warnings
+
 class ConfigManager(BaseJSONConfigManager):
     """Config Manager used for storing notebook frontend config"""
+
+    def __init__(self, **kwargs):
+
+        if kwargs.get('config_dir', None) is not None:
+            warnings.warn('ConfigManager `config_dir` kwarg will likely have no effect and might be removed in future Notebook versions.')
+        super(ConfigManager, self).__init__(**kwargs)
+            
     
     config_dir = Unicode(config=True)
     def _config_dir_default(self):


### PR DESCRIPTION
Pr #882 removed `config_dir` kwarg as it was ignored.

Though, #893 argues that we might need it and that it will be complex to
reintroduce it.

This use a convoluted way to :

 - warn that this kwarg might not be given to config managers in future version
 - but do not warn on default installs with default config.
 - warn that the keyword is ignored when people use subclasses of out
   config manager, and pass the keyword to super().

Thus this actually advertise that the keyword **might** be removed,
by still allowing us to keep it if in the end it appears that we need
it.

Should help with #893 without un-fixing #882.

-- 
It annoys me to go to that much convolution and weird things that close to final release, but if it's the cost of actually moving forward so be it. 

Would that please both @ellisonbg  and @damianavila ? 