### PR TITLE
Remove left border on softselected cells

### DIFF
--- a/notebook/static/notebook/less/cell.less
+++ b/notebook/static/notebook/less/cell.less
@@ -27,7 +27,10 @@ div.cell {
     &.jupyter-soft-selected {
         border-left-color: @selected_border_color_light;
         border-left-color: @soft_select_color;
-        ._selected_style(@selected_border_color_light, @soft_select_color, 5px, 0px);
+        border-left-width: @cell_border_width;
+        padding-left: @cell_padding - @cell_border_width;
+        background: @soft_select_color;
+
 
         @media print {
             border-color: transparent;


### PR DESCRIPTION
As requested per @ellisonbg , @fperez 

<img width="486" alt="screen shot 2015-12-30 at 11 17 40" src="https://cloud.githubusercontent.com/assets/335567/12049406/fffcbd1e-aee6-11e5-90a6-0b3b7a31355b.png">
<img width="514" alt="screen shot 2015-12-30 at 11 15 18" src="https://cloud.githubusercontent.com/assets/335567/12049407/00013d94-aee7-11e5-91e0-d04371b13375.png">

I'm actually -1 on this change, please vote wether or not you want it. 