### PR TITLE
Fix Uncaught ReferenceError: Pos is not defined

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -50,12 +50,12 @@ define([
      */
     CodeMirror.commands.delSpaceToPrevTabStop = function(cm){
         var from = cm.getCursor(true), to = cm.getCursor(false), sel = !posEq(from, to);
-         if (sel) { 
+         if (sel) {
             var ranges = cm.listSelections();
             for (var i = ranges.length - 1; i >= 0; i--) {
-              var head = ranges[i].head;
-              var anchor = ranges[i].anchor;
-              cm.replaceRange("", Pos(head.line, head.ch), CodeMirror.Pos(anchor.line, anchor.ch));
+                var head = ranges[i].head;
+                var anchor = ranges[i].anchor;
+                cm.replaceRange("", CodeMirror.Pos(head.line, head.ch), CodeMirror.Pos(anchor.line, anchor.ch));
             }
             return;
         }


### PR DESCRIPTION
Fix for bug #917, which was introduced by a typo in 89b7d96ccd87d03226b7977b469e69172c39ef0e

It should have read `CodeMirror.Pos`, instead of just `Pos`