### PR TITLE
Fixed missing import of to_api_path in post_save_hook example

### DIFF
--- a/docs/source/extending/savehooks.rst
+++ b/docs/source/extending/savehooks.rst
@@ -45,7 +45,8 @@ A post-save hook to make a script equivalent whenever the notebook is saved
 
     import io
     import os
-
+    from notebook.utils import to_api_path
+    
     _script_exporter = None
 
     def script_post_save(model, os_path, contents_manager, **kwargs):


### PR DESCRIPTION
Fix #922 