### PR TITLE
Be more explicit about deprecation.

### DIFF
--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -7,6 +7,7 @@
 import io
 import os
 import shutil
+import warnings
 import mimetypes
 import nbformat
 
@@ -32,9 +33,10 @@ _script_exporter = None
 def _post_save_script(model, os_path, contents_manager, **kwargs):
     """convert notebooks to Python script after save with nbconvert
 
-    replaces `ipython notebook --script`
+    replaces `jupyter notebook --script`
     """
     from nbconvert.exporters.script import ScriptExporter
+    warnings.warn("`_post_save_script` is deprecated and will be removed in Notebook 5.0", DeprecationWarning)
 
     if model['type'] != 'notebook':
         return
@@ -62,17 +64,19 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         except AttributeError:
             return getcwd()
 
-    save_script = Bool(False, config=True, help='DEPRECATED, use post_save_hook')
+    save_script = Bool(False, config=True, help='DEPRECATED, use post_save_hook. Will be removed in Notebook 5.0')
     def _save_script_changed(self):
         self.log.warn("""
-        `--script` is deprecated. You can trigger nbconvert via pre- or post-save hooks:
+        `--script` is deprecated and will be removed in notebook 5.0.
+
+        You can trigger nbconvert via pre- or post-save hooks:
 
             ContentsManager.pre_save_hook
             FileContentsManager.post_save_hook
 
         A post-save hook has been registered that calls:
 
-            ipython nbconvert --to script [notebook]
+            jupyter nbconvert --to script [notebook]
 
         which behaves similarly to `--script`.
         """)


### PR DESCRIPTION
Cf #916. Despite the fact that the function is private and meant
to replace an old behavior that will be removed, people explicitly
import it and register it as a post-save-hook.
Hope that explicit version removal will convey the "Don't use" in a more
obvious manner.

-- 

I'm ok if this is not in 4.1
