### PR TITLE
show warnings during tests

### DIFF
--- a/notebook/services/contents/tests/test_contents_api.py
+++ b/notebook/services/contents/tests/test_contents_api.py
@@ -17,7 +17,7 @@ from ..filecheckpoints import GenericFileCheckpoints
 from traitlets.config import Config
 from notebook.utils import url_path_join, url_escape, to_os_path
 from notebook.tests.launchnotebook import NotebookTestBase, assert_http_error
-from nbformat import read, write, from_dict
+from nbformat import write, from_dict
 from nbformat.v4 import (
     new_notebook, new_markdown_cell,
 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,11 @@
 [bdist_wheel]
 universal=1
+
+[nosetests]
+warningfilters=module   |.*            |DeprecationWarning |notebook.*
+               default  |.* | Warning | notebook.*
+               ignore   |.*metadata.*  |DeprecationWarning |notebook.*
+               ignore   |.*schema.*    |UserWarning        |nbfor.*
+               ignore   |The 'warn' method is deprecated, use 'warning' instead     | DeprecationWarning |notebook.*
+               error    |encodestring\(\) is a deprecated alias, use encodebytes\(\)| DeprecationWarning | notebook.*
+

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ extras_require = {
     ':sys_platform != "win32"': ['terminado>=0.3.3'],
     'doc': ['Sphinx>=1.1'],
     'test:python_version == "2.7"': ['mock'],
-    'test': ['nose', 'requests'],
+    'test': ['nose', 'requests', 'nose_warnings_filters'],
 }
 
 if 'setuptools' in sys.modules:


### PR DESCRIPTION
There was no nose plugin that I can find to enable warnings selectively, so [I wrote one](https://github.com/Carreau/nose_warnings_filters).

This is to complement issues like https://github.com/jupyter/notebook/issues/928, where we get rid in our codebase of `log.warn`, and turn the warning into an error not to reintroduce it.

I guess `nose_warnings_filters` would need to be a bit more stable before we use it, but it's a bit a chicken and egg problem. It can stabilise if it's not used. So advice appreciated.