### PR TITLE
Adds a Move button to the notebooklist interface next to Rename.

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -785,15 +785,16 @@ define([
     };
 
     NotebookList.prototype.move_selected = function() {
+        var that = this;
+
         // TODO(nhdaly): Support moving multiple items at once.
-        if (this.selected.length !== 1){
+        if (that.selected.length !== 1){
             return;
         }
 
-        var that = this;
-        var item_path = this.selected[0].path;
-        var item_name = this.selected[0].name;
-        var item_type = this.selected[0].type;
+        var item_path = that.selected[0].path;
+        var item_name = that.selected[0].name;
+        var item_type = that.selected[0].type;
 
         // Open a dialog to enter the new path, with current path as default.
         var input = $('<input/>').attr('type','text').attr('size','25').addClass('form-control')
@@ -808,6 +809,7 @@ define([
             title : "Move "+ item_type,
             body : dialog_body,
             buttons : {
+                Cancel : {},
                 OK : {
                     class: "btn-primary",
                     click: function() {
@@ -830,8 +832,7 @@ define([
                             console.warn('Error durring moving :', e);
                         });
                     }
-                },
-                Cancel : {}
+                }
             },
             open : function () {
                 // Upon ENTER, click the OK button.

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -835,6 +835,7 @@ define([
                     }
                 }
             },
+            // TODO: Consider adding fancier UI per Issue #941.
             open : function () {
                 // Upon ENTER, click the OK button.
                 input.keydown(function (event) {

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -775,6 +775,7 @@ define([
                     }
                 });
                 input.focus();
+                // Highlight the filename (up to the filetype suffix) in the input field.
                 if (input.val().indexOf(".") > 0) {
                     input[0].setSelectionRange(0,input.val().indexOf("."));
                 } else {
@@ -842,9 +843,8 @@ define([
                         return false;
                     }
                 });
+                // Put the cursor at the end of the input.
                 input.focus();
-                // Highlight the current path in the input box.
-                input.select();
             }
         });
     };

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -843,11 +843,8 @@ define([
                     }
                 });
                 input.focus();
-                if (input.val().indexOf(".") > 0) {
-                    input[0].setSelectionRange(0,input.val().indexOf("."));
-                } else {
-                    input.select();
-                }
+                // Highlight the current path in the input box.
+                input.select();
             }
         });
     };

--- a/notebook/static/tree/less/tree.less
+++ b/notebook/static/tree/less/tree.less
@@ -327,6 +327,10 @@ ul#new-menu {
     display: none;
 }
 
+.move-button {
+    display: none;
+}
+
 .shutdown-button {
     display: none;
 }

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -31,6 +31,7 @@ data-terminals-available="{{terminals_available}}"
               <div class="dynamic-buttons">
                   <button title="Duplicate selected" class="duplicate-button btn btn-default btn-xs">Duplicate</button>
                   <button title="Rename selected" class="rename-button btn btn-default btn-xs">Rename</button>
+                  <button title="Move selected" class="move-button btn btn-default btn-xs">Move</button>
                   <button title="Shutdown selected notebook(s)" class="shutdown-button btn btn-default btn-xs btn-warning">Shutdown</button>
                   <button title="Delete selected" class="delete-button btn btn-default btn-xs btn-danger"><i class="fa fa-trash"></i></button>
               </div>


### PR DESCRIPTION
With this button, you can now move files or directories to any path in
the notebook, including creating new directories (like 'mv -p'). To move
a file, you specify the new destination directory's path.

This achieves the same effect as renaming a file with a new relative
path, but is more clear to users unfamiliar with unix commands --
especially with regard to moving to a parent directory.

Can only move one file at a time currently.

Addresses Issue #471.