### PR TITLE
use math.ceill to allow values < 5s as input

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -2518,8 +2518,9 @@ define(function (require) {
         if (this.autosave_interval) {
             // new save interval: higher of 10x save duration or parameter (default 30 seconds)
             var interval = Math.max(10 * duration, this.minimum_autosave_interval);
-            // round to 10 seconds, otherwise we will be setting a new interval too often
-            interval = 10000 * Math.round(interval / 10000);
+            // ceil to 10 seconds, otherwise we will be setting a new interval too often
+            // do not round or anything below 5000ms will desactivate saving.
+            interval = 10000 * Math.ceil(interval / 10000);
             // set new interval, if it's changed
             if (interval !== this.autosave_interval) {
                 this.set_autosave_interval(interval);


### PR DESCRIPTION
Discovered while trying to get a response for @hamsal on gitter (ping'ed by @willingc):

```
What are my options if the autosave is not happening as frequently as I want? even if I set %autosave 15 it seems to only be happening on the order of minutes
I also used IPython.notebook.minimum_autosave_interval = 15000; and it was still not happening except every few minutes
```

To whom I'll respond that the autosave frequency depends on how long it takes to save the notebook, you canot save more often than the time to upload a notebook. And the correct way to change the notebook minimal save time would be the following :  

```js
// ~/.jupyter/custom/custom.js
define(['base/js/namespace', 'base/js/events'], function(Jupyter, events){
    events.on("notebook_loaded.Notebook", function () {
        // Anything below 5000 will disbale autosave on < 4.2
        Jupyter.notebook.minimum_autosave_interval = 15000; 
    });
});
```
