### PR TITLE
Use default_url instead of hardcoding /tree for initial url

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1096,7 +1096,7 @@ class NotebookApp(JupyterApp):
                 relpath = os.path.relpath(self.file_to_run, self.notebook_dir)
                 uri = url_escape(url_path_join('notebooks', *relpath.split(os.sep)))
             else:
-                uri = 'tree'
+                uri = self.default_url
             if browser:
                 b = lambda : browser.open(url_path_join(self.connection_url, uri),
                                           new=2)


### PR DESCRIPTION
Even when launching with `--NotebookApp.default_url='/foo'` the notebook starts at `/tree`. Seems to be an obvious oversight.