### PR TITLE
allow faillure on py3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ matrix:
           env: GROUP=python
         - python: 3.4
           env: GROUP=python
+    allow_failures:
+        - python: 3.5
+          env: GROUP=python
 
 after_success:
     - coveralls


### PR DESCRIPTION
That obviously does not fix #956, but then it would allow us to move forward on PR, and revert that later once we find the reason for failure/travis stop failling.