### PR TITLE
Use require.toUrl for help_links

### DIFF
--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -402,7 +402,7 @@ define([
                 .append($("<a>")
                     .attr('target', '_blank')
                     .attr('title', 'Opens in a new window')
-                    .attr('href', link.url)
+                    .attr('href', require.toUrl(link.url))
                     .append($("<i>")
                         .addClass("fa fa-external-link menu-icon pull-right")
                     )


### PR DESCRIPTION
The kernel doesn't know about the `base_url` of the notebook, so he
cannot generate local urls. This is important if you want to serve
documentation locally, for example see
http://trac.sagemath.org/ticket/19885

Require.toUrl rewrites non-relative paths according to the path
configuration. For example, a help_link defined like
~~~~
{
    'text': 'Sage Documentation',
    'url': 'kernelspecs/foo/bar.html',
},
~~~~
is then correctly transformed to `/base_url/kernelspecs/foo/bar.html`