### PR TITLE
add ctrl-alt-[ shortcut for indentAuto

### DIFF
--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -114,9 +114,15 @@ define([
             readOnly: false,
             theme: "default",
             extraKeys: {
-                "Cmd-Right":"goLineRight",
-                "End":"goLineRight",
-                "Cmd-Left":"goLineLeft"
+                "Cmd-Right": "goLineRight",
+                "End": "goLineRight",
+                "Cmd-Left": "goLineLeft",
+                "Tab": "indentMore",
+                "Shift-Tab" : "indentLess",
+                "Cmd-Alt-[" : "indentAuto",
+                "Ctrl-Alt-[" : "indentAuto",
+                "Cmd-/" : "toggleComment",
+                "Ctrl-/" : "toggleComment",
             }
         }
     };

--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -125,11 +125,7 @@ define([
     CodeCell.options_default = {
         cm_config : {
             extraKeys: {
-                "Tab" :  "indentMore",
-                "Shift-Tab" : "indentLess",
                 "Backspace" : "delSpaceToPrevTabStop",
-                "Cmd-/" : "toggleComment",
-                "Ctrl-/" : "toggleComment"
             },
             mode: 'text',
             theme: 'ipython',

--- a/notebook/static/notebook/js/textcell.js
+++ b/notebook/static/notebook/js/textcell.js
@@ -70,7 +70,6 @@ define([
 
     TextCell.options_default = {
         cm_config : {
-            extraKeys: {"Tab": "indentMore","Shift-Tab" : "indentLess"},
             mode: 'htmlmixed',
             lineWrapping : true,
         }


### PR DESCRIPTION
aka `cmd-opt-[`

indentAuto is CodeMirror's best guess for the indentation.

This is the shortcut from TextMate, I didn't look up other editors if there's a better choice.

I also moved the common cell commands to Cell base config.

closes #951