### PR TITLE
Fix ANSI code for "bold"

### DIFF
--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -207,7 +207,7 @@ define([
 
     //Map from terminal commands to CSS classes
     var ansi_colormap = {
-        "01":"ansibold",
+        "1":"ansibold",
         
         "30":"ansiblack",
         "31":"ansired",


### PR DESCRIPTION
This is **untested**, since I couldn't build the notebook locally.

However, there's a similar error in [nbconvert](https://github.com/jupyter/nbconvert/blob/560a1fc8ead384e1953349f2300185ee7041882c/nbconvert/filters/ansi.py#L28), where changing `01` to `1` fixes the problem.