### PR TITLE
Implement delayed evaluation for the cell executions happening before a kernel is set up

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -301,24 +301,21 @@ define([
      * @method execute
      */
     CodeCell.prototype.execute = function (stop_on_error) {
-        if (!this.kernel || !this.kernel.is_connected()) {
+        if (!this.kernel) {
             console.log("Can't execute, kernel is not connected.");
             return;
         }
-
-        this.output_area.clear_output(false, true);
 
         if (stop_on_error === undefined) {
             stop_on_error = true;
         }
 
+        this.output_area.clear_output(false, true);
         var old_msg_id = this.last_msg_id;
-
         if (old_msg_id) {
             this.kernel.clear_callbacks_for_msg(old_msg_id);
-            if (old_msg_id) {
-                delete CodeCell.msg_cells[old_msg_id];
-            }
+            delete CodeCell.msg_cells[old_msg_id];
+            this.last_msg_id = null;
         }
         if (this.get_text().trim().length === 0) {
             // nothing to do

--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -302,7 +302,7 @@ define([
      */
     CodeCell.prototype.execute = function (stop_on_error) {
         if (!this.kernel) {
-            console.log("Can't execute, kernel is not connected.");
+            console.log("Can't execute cell since kernel is not set.");
             return;
         }
 

--- a/notebook/tests/notebook/buffering.js
+++ b/notebook/tests/notebook/buffering.js
@@ -1,0 +1,36 @@
+//
+// Test buffering for execution requests.
+//
+casper.notebook_test(function () {
+    this.evaluate(function () {
+        var cell = IPython.notebook.get_cell(0);
+        cell.set_text('a=10; print(a)');
+        IPython.notebook.kernel.stop_channels();
+        IPython.notebook.execute_cells([0]);
+        IPython.notebook.kernel.reconnect(1);
+    });
+
+    this.wait_for_output(0);
+
+    this.then(function () {
+        var result = this.get_output_cell(0);
+        this.test.assertEquals(result.text, '10\n', 'kernels buffer execution requests if connection is down');
+    });
+    
+    this.thenEvaluate(function () {
+        var cell = IPython.notebook.get_cell(0);
+        cell.set_text('a=11; print(a)');
+        cell.kernel = null;
+        IPython.notebook.kernel = null;
+        IPython.notebook.execute_cells([0]);
+        IPython.notebook._session_started();
+    });
+
+    this.wait_for_output(0);
+
+    this.then(function () {
+        var result = this.get_output_cell(0);
+        this.test.assertEquals(result.text, '11\n', 'notebooks buffer cell execution requests if kernel is not set');
+    });
+    
+});

--- a/notebook/tests/notebook/buffering.js
+++ b/notebook/tests/notebook/buffering.js
@@ -2,10 +2,17 @@
 // Test buffering for execution requests.
 //
 casper.notebook_test(function () {
-    this.evaluate(function () {
+    this.then(function() {
+      // make sure there are at least three cells for the tests below.
+      this.append_cell();
+      this.append_cell();
+      this.append_cell();
+    })
+
+    this.thenEvaluate(function () {
+        IPython.notebook.kernel.stop_channels();
         var cell = IPython.notebook.get_cell(0);
         cell.set_text('a=10; print(a)');
-        IPython.notebook.kernel.stop_channels();
         IPython.notebook.execute_cells([0]);
         IPython.notebook.kernel.reconnect(1);
     });
@@ -14,23 +21,36 @@ casper.notebook_test(function () {
 
     this.then(function () {
         var result = this.get_output_cell(0);
-        this.test.assertEquals(result.text, '10\n', 'kernels buffer execution requests if connection is down');
+        this.test.assertEquals(result.text, '10\n', 'kernels buffer messages if connection is down');
     });
-    
+
     this.thenEvaluate(function () {
         var cell = IPython.notebook.get_cell(0);
-        cell.set_text('a=11; print(a)');
-        cell.kernel = null;
-        IPython.notebook.kernel = null;
+        var cellplus = IPython.notebook.get_cell(1);
+        var cellprint = IPython.notebook.get_cell(2);
+        cell.set_text('k=1');
+        cellplus.set_text('k+=1');
+        cellprint.set_text('k*=2')
+
+        IPython.notebook.kernel.stop_channels();
+
+        // Repeated execution of cell queued up in the kernel executes
+        // each execution request in order.
         IPython.notebook.execute_cells([0]);
-        IPython.notebook._session_started();
+        IPython.notebook.execute_cells([2]);
+        IPython.notebook.execute_cells([1]);
+        IPython.notebook.execute_cells([1]);
+        IPython.notebook.execute_cells([1]);
+        cellprint.set_text('print(k)')
+        IPython.notebook.execute_cells([2]);
+
+        IPython.notebook.kernel.reconnect(1);
     });
 
-    this.wait_for_output(0);
+    this.wait_for_output(2);
 
     this.then(function () {
-        var result = this.get_output_cell(0);
-        this.test.assertEquals(result.text, '11\n', 'notebooks buffer cell execution requests if kernel is not set');
+        var result = this.get_output_cell(2);
+        this.test.assertEquals(result.text, '5\n', 'kernels send buffered messages in order');
     });
-    
 });


### PR DESCRIPTION
This is an attempt at taking care of #994. We implement two queues for cell executions. One is at the notebook level, to queue up executions when a kernel does not exist. Another is at the kernel level, to queue up messages when the kernel is not connected.

*Edit: We scrapped the notebook-level queue, and now just have a kernel-level message queue for when the kernel isn't connected*