### PR TITLE
disable MathJax renderer selection menu

### DIFF
--- a/notebook/static/notebook/js/mathjaxutils.js
+++ b/notebook/static/notebook/js/mathjaxutils.js
@@ -28,7 +28,10 @@ define([
                     webFont: "STIX-Web",
                     styles: {'.MathJax_Display': {"margin": 0}},
                     linebreaks: { automatic: true }
-                }
+                },
+                MathMenu: {
+                    showRenderer: false,
+                },
             });
             MathJax.Hub.Configured();
         } else if (window.mathjax_url !== "") {


### PR DESCRIPTION
since we don't ship all renderers, and MathJax can hang if a nonexistent renderer is selected.

closes #1035