### PR TITLE
Nested svg

### DIFF
--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -651,7 +651,7 @@ define([
         var toinsert = this.create_output_subarea(md, "output_svg", type);
 
         // Get the svg element from within the HTML.
-        var svg = $('<div />').html(svg_html).find('svg');
+        var svg = $('<svg \>').html(svg_html);
         var svg_area = $('<div />');
         var width = svg.attr('width');
         var height = svg.attr('height');

--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -650,8 +650,9 @@ define([
         var type = 'image/svg+xml';
         var toinsert = this.create_output_subarea(md, "output_svg", type);
 
-        // Get the svg element from within the HTML.
-        var svg = $('<svg \>').html(svg_html);
+        // Get the svg element from within the HTML. 
+        // One svg is supposed, but could embed other nested svgs
+        var svg = $($('<div \>').html(svg_html).find('svg')[0]);
         var svg_area = $('<div />');
         var width = svg.attr('width');
         var height = svg.attr('height');

--- a/notebook/tests/notebook/output.js
+++ b/notebook/tests/notebook/output.js
@@ -95,4 +95,32 @@ casper.notebook_test(function () {
             text: "3\n"
         }]
     );
+    this.test_coalesced_output("test nested svg", [
+        'from IPython.display import SVG',
+        'nested_svg="""',
+        '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100" >',
+        '  <svg x="0">',
+        '    <rect x="10" y="10" height="80" width="80" style="fill: #0000ff"/>',
+        '  </svg>',
+        '  <svg x="100">',
+        '    <rect x="10" y="10" height="80" width="80" style="fill: #00cc00"/>',
+        '  </svg>',
+        '</svg>"""',
+        'SVG(nested_svg)'
+        ].join("\n"), [{
+            output_type: "execute_result",
+            data: { 
+            "text/plain" : "<IPython.core.display.SVG object>",
+            "image/svg+xml": [
+              '<svg height="200" width="100" xmlns="http://www.w3.org/2000/svg">',
+              '  <svg x="0">',
+              '    <rect height="80" style="fill: #0000ff" width="80" x="10" y="10"/>',
+              '  </svg>',
+              '  <svg x="100">',
+              '    <rect height="80" style="fill: #00cc00" width="80" x="10" y="10"/>',
+              '  </svg>',
+              '</svg>'].join("\n")
+            },
+        }]
+    );
 });


### PR DESCRIPTION
Solve the nested svg issue FIX #982.

The old implementation use find that return an array of all svg, then silently reorganised by jquery.

This new one also suppose a unique svg parent (first element of find) but allow nested element to be untouched. 