### PR TITLE
Ensure user site packages is on PYTHONPATH for notebook test server

### DIFF
--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -73,6 +73,7 @@ class NotebookTestBase(TestCase):
         data_dir = TemporaryDirectory()
         cls.env_patch = patch.dict('os.environ', {
             'HOME': cls.home_dir.name,
+            'PYTHONPATH': os.pathsep.join(sys.path),
             'IPYTHONDIR': pjoin(cls.home_dir.name, '.ipython'),
             'JUPYTER_DATA_DIR' : data_dir.name
         })


### PR DESCRIPTION
We modify `$HOME`, so it was failing to find my user site packages when trying to start kernels in the tests. Setting PYTHONPATH lets it use these packages.