### PR TITLE
Allow all MathJax output formats

### DIFF
--- a/notebook/static/notebook/js/mathjaxutils.js
+++ b/notebook/static/notebook/js/mathjaxutils.js
@@ -29,9 +29,11 @@ define([
                     styles: {'.MathJax_Display': {"margin": 0}},
                     linebreaks: { automatic: true }
                 },
-                MathMenu: {
-                    showRenderer: false,
-                },
+            });
+            MathJax.Hub.Register.StartupHook("MathMenu Ready", function () {
+              var renderers = MathJax.Menu.menu.Find("Math Settings").submenu.Find("Math Renderer").submenu;
+              // disable SVG output, which we don't ship
+              renderers.Find("SVG").disabled = true;
             });
             MathJax.Hub.Configured();
         } else if (window.mathjax_url !== "") {

--- a/notebook/static/notebook/js/mathjaxutils.js
+++ b/notebook/static/notebook/js/mathjaxutils.js
@@ -30,11 +30,6 @@ define([
                     linebreaks: { automatic: true }
                 },
             });
-            MathJax.Hub.Register.StartupHook("MathMenu Ready", function () {
-              var renderers = MathJax.Menu.menu.Find("Math Settings").submenu.Find("Math Renderer").submenu;
-              // disable SVG output, which we don't ship
-              renderers.Find("SVG").disabled = true;
-            });
             MathJax.Hub.Configured();
         } else if (window.mathjax_url !== "") {
             // Don't have MathJax, but should. Show dialog.

--- a/setupbase.py
+++ b/setupbase.py
@@ -162,16 +162,18 @@ def find_package_data():
     
     trees = []
     mj_out = mj('jax', 'output')
-    for output in os.listdir(mj_out):
-        if output == 'SVG':
-            # strip SVG output
-            continue
-        path = pjoin(mj_out, output)
-        static_data.append(pjoin(path, '*.js'))
-        autoload = pjoin(path, 'autoload')
-        if os.path.isdir(autoload):
-            trees.append(autoload)
     
+    if os.path.exists(mj_out):
+        for output in os.listdir(mj_out):
+            if output == 'SVG':
+                # strip SVG output
+                continue
+            path = pjoin(mj_out, output)
+            static_data.append(pjoin(path, '*.js'))
+            autoload = pjoin(path, 'autoload')
+            if os.path.isdir(autoload):
+                trees.append(autoload)
+
     for tree in trees + [
         mj('localization'), # limit to en?
         mj('fonts', 'HTML-CSS', 'STIX-Web', 'woff'),

--- a/setupbase.py
+++ b/setupbase.py
@@ -158,21 +158,30 @@ def find_package_data():
         mj('MathJax.js'),
         mj('config', 'TeX-AMS_HTML-full.js'),
         mj('config', 'Safe.js'),
-        mj('extensions', 'Safe.js'),
-        mj('jax', 'output', 'HTML-CSS', '*.js'),
     ])
-    for tree in [
+    
+    trees = []
+    mj_out = mj('jax', 'output')
+    for output in os.listdir(mj_out):
+        if output == 'SVG':
+            # strip SVG output
+            continue
+        path = pjoin(mj_out, output)
+        static_data.append(pjoin(path, '*.js'))
+        autoload = pjoin(path, 'autoload')
+        if os.path.isdir(autoload):
+            trees.append(autoload)
+    
+    for tree in trees + [
         mj('localization'), # limit to en?
         mj('fonts', 'HTML-CSS', 'STIX-Web', 'woff'),
-        mj('extensions', 'TeX'),
+        mj('extensions'),
         mj('jax', 'input', 'TeX'),
-        mj('jax', 'output', 'HTML-CSS', 'autoload'),
         mj('jax', 'output', 'HTML-CSS', 'fonts', 'STIX-Web'),
     ]:
         for parent, dirs, files in os.walk(tree):
             for f in files:
                 static_data.append(pjoin(parent, f))
-    
 
     os.chdir(os.path.join('tests',))
     js_tests = glob('*.js') + glob('*/*.js')

--- a/setupbase.py
+++ b/setupbase.py
@@ -165,9 +165,6 @@ def find_package_data():
     
     if os.path.exists(mj_out):
         for output in os.listdir(mj_out):
-            if output == 'SVG':
-                # strip SVG output
-                continue
             path = pjoin(mj_out, output)
             static_data.append(pjoin(path, '*.js'))
             autoload = pjoin(path, 'autoload')
@@ -180,6 +177,7 @@ def find_package_data():
         mj('extensions'),
         mj('jax', 'input', 'TeX'),
         mj('jax', 'output', 'HTML-CSS', 'fonts', 'STIX-Web'),
+        mj('jax', 'output', 'SVG', 'fonts', 'STIX-Web'),
     ]:
         for parent, dirs, files in os.walk(tree):
             for f in files:


### PR DESCRIPTION
rather than white-listing HTML-CSS and scrubbing all others. This means the various other renderers (perhaps most importantly, MML) are available, not just HTML-CSS.

Fonts other than STIX-Web are still scrubbed, since much of the size is due to the many font choices.

This increases the size of a notebook install by ~3.5k/19MB or 18%.

A smaller change would be to *only* add MML, which would have a negligible affect on install size.

closes #1037