### PR TITLE
scroll long tracebacks to the bottom

### DIFF
--- a/notebook/static/base/less/error.less
+++ b/notebook/static/base/less/error.less
@@ -17,4 +17,8 @@ div.traceback-wrapper {
     text-align: left;
     max-width: 800px;
     margin: auto;
+    pre.traceback {
+      max-height: 600px;
+      overflow: auto;
+    }
 }

--- a/notebook/templates/error.html
+++ b/notebook/templates/error.html
@@ -29,3 +29,14 @@ div#header, div#site {
 </header>
 
 {% endblock %}
+
+{% block script %}
+{{super()}}
+<script type='text/javascript'>
+require(['jquery'], function($) {
+  // scroll long tracebacks to the bottom
+  var tb = $(".traceback")[0];
+  tb.scrollTop = tb.scrollHeight;
+});
+</script>
+{% endblock script %}


### PR DESCRIPTION
since that's usually where the most important info is

related: jupyter/nbconvert#233 which will start producing big tracebacks on latex failures