### PR TITLE
Lowercase file extension before looking it up in CodeMirror

### DIFF
--- a/notebook/static/edit/js/editor.js
+++ b/notebook/static/edit/js/editor.js
@@ -116,7 +116,8 @@ function($,
 
             if (ext_idx > 0) {
                 // CodeMirror.findModeByExtension wants extension without '.'
-                modeinfo = CodeMirror.findModeByExtension(model.name.slice(ext_idx + 1));
+                modeinfo = CodeMirror.findModeByExtension(
+                    model.name.slice(ext_idx + 1).toLowerCase());
             }
         }
         if (modeinfo) {


### PR DESCRIPTION
It looks like CodeMirror stores no capitalised extensions:
https://github.com/codemirror/CodeMirror/blob/master/mode/meta.js

If there ever are any, this would break looking them up. But that seems fairly unlikely.

Closes gh-1073