### PR TITLE
Add pip to conda yaml for docs build

### DIFF
--- a/docs/conda_env.yml
+++ b/docs/conda_env.yml
@@ -7,5 +7,6 @@ dependencies:
 - nbformat
 - jupyter_client
 - ipykernel
-- sphinxcontrib_spelling
-- pyenchant
+- pip:
+    - sphinxcontrib_spelling
+    - pyenchant


### PR DESCRIPTION
conda needs pip to install sphinx spelling dependencies. 