### PR TITLE
Add download button to the tree template

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -130,6 +130,7 @@ define([
             // Bind events for action buttons.
             $('.rename-button').click($.proxy(this.rename_selected, this));
             $('.move-button').click($.proxy(this.move_selected, this));
+            $('.download-button').click($.proxy(this.download_selected, this));
             $('.shutdown-button').click($.proxy(this.shutdown_selected, this));
             $('.duplicate-button').click($.proxy(this.duplicate_selected, this));
             $('.delete-button').click($.proxy(this.delete_selected, this));
@@ -560,6 +561,15 @@ define([
             $('.move-button').css('display', 'none');
         }
 
+        // Download is only visible when one item is selected, and it is not a
+        // running notebook or a directory
+        // TODO(nhdaly): Add support for download multiple items at once.
+        if (selected.length === 1 && !has_running_notebook && !has_directory) {
+            $('.download-button').css('display', 'inline-block');
+        } else {
+            $('.download-button').css('display', 'none');
+        }
+
         // Shutdown is only visible when one or more notebooks running notebooks
         // are selected and no non-notebook items are selected.
         if (has_running_notebook && !(has_file || has_directory)) {
@@ -853,6 +863,19 @@ define([
                 input.focus();
             }
         });
+    };
+
+    NotebookList.prototype.download_selected = function() {
+        var that = this;
+
+        // TODO(nhdaly): Support download multiple items at once.
+        if (that.selected.length !== 1){
+            return;
+        }
+
+        var item_path = that.selected[0].path;
+
+        window.open(utils.url_path_join('/files', item_path) + '?download=1');
     };
 
     NotebookList.prototype.delete_selected = function() {

--- a/notebook/static/tree/less/tree.less
+++ b/notebook/static/tree/less/tree.less
@@ -331,6 +331,10 @@ ul#new-menu {
     display: none;
 }
 
+.download-button {
+    display: none;
+}
+
 .shutdown-button {
     display: none;
 }

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -32,6 +32,7 @@ data-terminals-available="{{terminals_available}}"
                   <button title="Duplicate selected" class="duplicate-button btn btn-default btn-xs">Duplicate</button>
                   <button title="Rename selected" class="rename-button btn btn-default btn-xs">Rename</button>
                   <button title="Move selected" class="move-button btn btn-default btn-xs">Move</button>
+                  <button title="Download selected" class="download-button btn btn-default btn-xs">Download</button>
                   <button title="Shutdown selected notebook(s)" class="shutdown-button btn btn-default btn-xs btn-warning">Shutdown</button>
                   <button title="Delete selected" class="delete-button btn btn-default btn-xs btn-danger"><i class="fa fa-trash"></i></button>
               </div>


### PR DESCRIPTION
First of all, thank you for this amazing library.

As a Kaggler I found it *extremely* painful to open files before download them (usually it's some .csv predictions to send for and usually there're bunch of them).

So I decided to add Download button for single files inside the tree template.
Works like a charm for me — disappears when it needs to, downloads any single file except running ipython.