### PR TITLE
Updated Move Dialog's buttons per #744 for #742.

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -814,9 +814,10 @@ define([
         var d = dialog.modal({
             title : "Move "+ item_type,
             body : dialog_body,
+            default_button: "Cancel",
             buttons : {
                 Cancel : {},
-                OK : {
+                Move : {
                     class: "btn-primary",
                     click: function() {
                       // Construct the new path using the user input and its name.


### PR DESCRIPTION
Changes "OK" -> "Move" and sets "Cancel" as default button.

I think I added this button in between the commits for #744 and it being merged in, so it got missed.
This is part of #742.