### PR TITLE
Fix long lines escaping from the cell container

### DIFF
--- a/notebook/static/notebook/less/cell.less
+++ b/notebook/static/notebook/less/cell.less
@@ -97,16 +97,9 @@ div.cell {
 }
 
 div.inner_cell {
+    min-width: 0;
     .vbox();
     .box-flex1();
-}
-
-@-moz-document url-prefix() {
-    div.inner_cell {
-        // hack around FF bug causing cell to expand when lines are long
-        // instead of scrolling
-        overflow-x: hidden;
-    }
 }
 
 /* input_area and input_prompt must match in top border and margin for alignment */


### PR DESCRIPTION
by setting:

    min-width: 0

on div.inner_cell ([reference](https://drafts.csswg.org/css-flexbox/#min-size-auto)).

(*obviously* min-width needs to be defined for it to respect its maximum width. Yay, CSS!)

Fixes what [we thought](https://github.com/ipython/ipython/issues/7724) was a Firefox bug, but Chrome devs have [pointed out](https://bugs.chromium.org/p/chromium/issues/detail?id=582141#c4) that Firefox was doing it right all along, and all the other browsers were wrong.

A bugfix in Chrome 48 brought Chrome's behavior in sync with Firefox, which we thought was a bug.

closes #1003

We should backport at least to 4.2, and possibly to 4.1.1 if we're going to do one.