### PR TITLE
Clarify keyboard shortcut help for "split cell"

### DIFF
--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -79,7 +79,6 @@ define([
             'up'                  : 'jupyter-notebook:move-cursor-up',
             'down'                : 'jupyter-notebook:move-cursor-down',
             'ctrl-shift--'        : 'jupyter-notebook:split-cell-at-cursor',
-            'ctrl-shift-subtract' : 'jupyter-notebook:split-cell-at-cursor',
         };
     };
 

--- a/notebook/static/notebook/js/quickhelp.js
+++ b/notebook/static/notebook/js/quickhelp.js
@@ -113,6 +113,7 @@ define([
         'end':'End',
         'space':'Space',
         'backspace':'Backspace',
+        '-':'Minus'
         };
     
     var humanize_map;
@@ -123,7 +124,7 @@ define([
         humanize_map = default_humanize_map;
     }
 
-    var special_case = { pageup: "PageUp", pagedown: "Page Down", 'minus': '-' };
+    var special_case = { pageup: "PageUp", pagedown: "Page Down" };
     
     function humanize_key(key){
         if (key.length === 1){

--- a/notebook/static/notebook/less/quickhelp.less
+++ b/notebook/static/notebook/less/quickhelp.less
@@ -4,7 +4,7 @@
 }
 .shortcut_key {
     display: inline-block;
-    width: 20ex;
+    width: 21ex;
     text-align: right;
     font-family: @font-family-monospace;
 }

--- a/notebook/tests/notebook/dualmode_merge.js
+++ b/notebook/tests/notebook/dualmode_merge.js
@@ -41,7 +41,7 @@ casper.notebook_test(function () {
         this.set_cell_text(0, 'abcd');
         this.set_cell_editor_cursor(0, 0, 2);
         this.test.assertEquals(this.get_cell_text(0), 'abcd', 'Verify that cell 0 has the new contents.');
-        this.trigger_keydown('ctrl-shift-subtract'); // Split
+        this.trigger_keydown('ctrl-shift--'); // Split
         this.test.assertEquals(this.get_cell_text(0), 'ab', 'split; Verify that cell 0 has the first half.');
         this.test.assertEquals(this.get_cell_text(1), 'cd', 'split; Verify that cell 1 has the second half.');
         this.validate_notebook_state('split', 'edit', 1);
@@ -125,12 +125,12 @@ casper.notebook_test(function () {
         this.select_cell(1);
         this.trigger_keydown('enter');
         this.set_cell_editor_cursor(1, 0, 2);
-        this.trigger_keydown('ctrl-shift-subtract'); // Split
+        this.trigger_keydown('ctrl-shift--'); // Split
         this.test.assertEquals(this.get_cells_length(), N, 'Split cell 1: There are still '+N+' cells');
         this.test.assertEquals(this.get_cell_text(0), a, 'Split cell 1: Cell 0 is unchanged');
         this.test.assertEquals(this.get_cell_text(1), b, 'Split cell 1: Cell 1 is unchanged');
         this.test.assertEquals(this.get_cell_text(2), c, 'Split cell 1: Cell 2 is unchanged');
-        this.validate_notebook_state('ctrl-shift-subtract', 'edit', 1); 
+        this.validate_notebook_state('ctrl-shift--', 'edit', 1); 
     });
 
     // Try to merge cell 1 down, should fail, as 1 is locked


### PR DESCRIPTION
## Before
### OSX
<img width="256" alt="screen shot 2016-02-20 at 12 13 16 pm" src="https://cloud.githubusercontent.com/assets/780375/13198752/d3d699da-d7d6-11e5-8a28-e907a5bd53c1.png">
### Everything else
![image](https://cloud.githubusercontent.com/assets/780375/13198762/2b008bbc-d7d7-11e5-89cf-308cfd5f0c8b.png)

## After
### OSX
<img width="196" alt="screen shot 2016-02-20 at 11 52 01 am" src="https://cloud.githubusercontent.com/assets/780375/13198753/d3ddcd0e-d7d6-11e5-9319-1f89d075969e.png">
### Everything else
<img width="275" alt="screen shot 2016-02-20 at 11 52 30 am" src="https://cloud.githubusercontent.com/assets/780375/13198754/d3de751a-d7d6-11e5-8aa0-0e2318585170.png">

I went with "Minus" for places where "- -" gets confusing and kept the "-" on OSX where there aren't dashes to make things confusing, per brief discussion in #1008. Open to other alternatives.

Closes #1008 