### PR TITLE
[WIP] add trust to markdown cells

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "codemirror": "~5.8",
     "es6-promise": "~1.0",
     "font-awesome": "components/font-awesome#~4.2.0",
-    "google-caja": "5669",
+    "google-caja": "6005",
     "jquery": "components/jquery#~2.0",
     "jquery-ui": "components/jqueryui#~1.10",
     "marked": "~0.3",

--- a/notebook/static/base/js/security.js
+++ b/notebook/static/base/js/security.js
@@ -70,11 +70,13 @@ define([
         return h.html();
     };
     
-    var sanitize_html = function (html, allow_css) {
+    var sanitize_html = function (html, allow_css, hook) {
         /**
          * sanitize HTML
          * if allow_css is true (default: false), CSS is sanitized as well.
          * otherwise, CSS elements and attributes are simply removed.
+         *
+         * If specified, hook will be called with any sanitization events.
          */
         var html4 = caja.html4;
 
@@ -91,6 +93,9 @@ define([
         
         var record_messages = function (msg, opts) {
             console.log("HTML Sanitizer", msg, opts);
+            if (hook) {
+              hook(msg, opts);
+            }
         };
         
         var policy = function (tagName, attribs) {

--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -473,6 +473,9 @@ define([
         var data = {};
         // deepcopy the metadata so copied cells don't share the same object
         data.metadata = JSON.parse(JSON.stringify(this.metadata));
+        if (this.trusted === true || this.trusted === false) {
+            data.metadata.trusted = this.trusted;
+        }
         data.cell_type = this.cell_type;
         return data;
     };
@@ -484,6 +487,7 @@ define([
     Cell.prototype.fromJSON = function (data) {
         if (data.metadata !== undefined) {
             this.metadata = data.metadata;
+            this.trusted = data.metadata.trusted;
         }
     };
 


### PR DESCRIPTION
This restores the pre-3.0 ability to have fully arbitrary HTML/CSS/JS in markdown cells when the notebook is trusted.

- cell.render checks for trust before rendering
- 'safe' (no sanitization to do) markdown is automatically trusted
- 'unsafe' and untrusted markdown is left unrendered until user requests render
- cell.execute (the shift-enter/run all action) sets explicit trust, just like code cells


See discussion in #1123

TODO:

- UI indicator beyond unrendered markdown on load
- support trust of markdown cells in nbformat (will require new nbformat release, or wrappers in this repo to handle the trusted flag server-side)
- changing what's considered for signatures needs to invalidate trust of all existing notebooks.
  Since current notebook signatures only consider code cell output for trust,
  we need to take care that previously sanitized markdown in trusted notebooks does not end up being trusted implicitly on upgrade.