### PR TITLE
Mark thread for test server as daemonic

### DIFF
--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -115,7 +115,7 @@ class NotebookTestBase(TestCase):
                 # set the event, so failure to start doesn't cause a hang
                 started.set()
                 app.session_manager.close()
-        cls.notebook_thread = Thread(target=start_thread)
+        cls.notebook_thread = Thread(target=start_thread, daemon=True)
         cls.notebook_thread.start()
         started.wait()
         cls.wait_until_alive()

--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -115,7 +115,8 @@ class NotebookTestBase(TestCase):
                 # set the event, so failure to start doesn't cause a hang
                 started.set()
                 app.session_manager.close()
-        cls.notebook_thread = Thread(target=start_thread, daemon=True)
+        cls.notebook_thread = Thread(target=start_thread)
+        cls.notebook_thread.daemon = True
         cls.notebook_thread.start()
         started.wait()
         cls.wait_until_alive()


### PR DESCRIPTION
I don't understand how, but I suspect that the threaded server is somehow involved in the hangs we see after the tests complete. This marks it as daemonic so that if it somehow escapes it won't keep the
test process alive.

Heisendebugging the slow way.