### PR TITLE
channel.closed is a method

### DIFF
--- a/notebook/services/kernels/kernelmanager.py
+++ b/notebook/services/kernels/kernelmanager.py
@@ -115,7 +115,7 @@ class MappingKernelManager(MultiKernelManager):
         
         def finish():
             """Common cleanup when restart finishes/fails for any reason."""
-            if not channel.closed:
+            if not channel.closed():
                 channel.close()
             loop.remove_timeout(timeout)
             kernel.remove_restart_callback(on_restart_failed, 'dead')


### PR DESCRIPTION
since we weren't calling it, `channel.closed` is always True, so the restart channel was never closed, causing process teardown to hang *sometimes*, depending on garbage collection.

I also added explicit teardown of the zmq Context at the end of each test group,
which increases our chances of noticing when we aren't cleaning up our sockets  properly.

closes #1043