### PR TITLE
Don't use arrow functions in webpack js config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ var commonConfig = {
         root: [
             '.', /* allows npm packages to be loaded */
             './notebook/static'
-        ].map(x =>path.resolve(x)),
+        ].map(function(p) {return path.resolve(p);}),
         modulesDirectories: [
             "components", /* bower */
             "node_modules" /* npm */
@@ -71,4 +71,4 @@ module.exports = [
         },
         devtool: 'source-map',
     }),
-].map(x => buildConfig(x));
+].map(buildConfig);


### PR DESCRIPTION
The => syntax doesn't work on the version of Node currently packaged in Ubuntu - which is admittedly two years old, but it's what the development install instructions point people to.