### PR TITLE
simplify js build steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/jupyter/notebook.git"
   },
   "scripts": {
-    "bower": "bower install",
+    "bower": "bower install --allow-root --config.interactive=false",
     "build:watch": "concurrent \"npm run build:css:watch\" \"npm run build:js:watch\"",
     "build": "npm run build:css && npm run build:js",
     "build:css": "python setup.py css",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ from setupbase import (
     check_package_data_first,
     CompileCSS,
     CompileJS,
-    Bower,
+    JavascriptDependencies,
     JavascriptVersion,
     css_js_prerelease,
 )
@@ -119,7 +119,7 @@ setup_args['cmdclass'] = {
     'sdist' : css_js_prerelease(sdist, strict=True),
     'css' : CompileCSS,
     'js' : CompileJS,
-    'jsdeps' : Bower,
+    'jsdeps' : JavascriptDependencies,
     'jsversion' : JavascriptVersion,
 }
 

--- a/setupbase.py
+++ b/setupbase.py
@@ -470,17 +470,27 @@ class JavascriptVersion(Command):
     
     def run(self):
         nsfile = pjoin(repo_root, "notebook", "static", "base", "js", "namespace.js")
+        lines = []
+        found = False
         with open(nsfile) as f:
-            lines = f.readlines()
-        with open(nsfile, 'w') as f:
-            found = False
-            for line in lines:
+            for line in f.readlines():
                 if line.strip().startswith("Jupyter.version"):
-                    line = '    Jupyter.version = "{0}";\n'.format(version)
                     found = True
+                    new_line = '    Jupyter.version = "{0}";\n'.format(version)
+                    if new_line == line:
+                        # no change, don't rewrite file
+                        return
+                    lines.append(new_line)
+                else:
+                    lines.append(line)
+
+        if not found:
+            raise RuntimeError("Didn't find Jupyter.version line in %s" % nsfile)
+        
+        print("Writing version=%s to %s" % (version, nsfile))
+        with open(nsfile, 'w') as f:
+            for line in lines:
                 f.write(line)
-            if not found:
-                raise RuntimeError("Didn't find Jupyter.version line in %s" % nsfile)
 
 
 def css_js_prerelease(command, strict=False):

--- a/setupbase.py
+++ b/setupbase.py
@@ -329,15 +329,11 @@ def run(cmd, *args, **kwargs):
 class JavascriptDependencies(Command):
     description = "Fetch Javascript dependencies with npm and bower"
     
-    user_options = [
-        ('force', 'f', "Force fetching of Javascript dependencies"),
-    ]
-    
     def initialize_options(self):
-        self.force = False
+        pass
     
     def finalize_options(self):
-        self.force = bool(self.force)
+        pass
     
     bower_dir = pjoin(static, 'components')
     node_modules = pjoin(repo_root, 'node_modules')
@@ -501,7 +497,7 @@ def css_js_prerelease(command, strict=False):
             jsdeps = self.distribution.get_command_obj('jsdeps')
             js = self.distribution.get_command_obj('js')
             css = self.distribution.get_command_obj('css')
-            jsdeps.force = js.force = strict
+            js.force = strict
 
             targets = [ jsdeps.bower_dir ]
             targets.extend(js.targets)

--- a/setupbase.py
+++ b/setupbase.py
@@ -327,10 +327,10 @@ def run(cmd, *args, **kwargs):
 
 
 class JavascriptDependencies(Command):
-    description = "fetch static client-side components with npm and bower"
+    description = "Fetch Javascript dependencies with npm and bower"
     
     user_options = [
-        ('force', 'f', "force fetching of bower dependencies"),
+        ('force', 'f', "Force fetching of Javascript dependencies"),
     ]
     
     def initialize_options(self):


### PR DESCRIPTION
- Run npm, bower install every time (except from sdist).
  Removes need to check npm, bower sources.
  These commands aren't slow enough that we need to save this time (~1s).
- Only check `built/index.js` as build target,
  since webpack is only a single step now.

closes #1137