### PR TITLE
Exempt javascript files from files check

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -647,6 +647,7 @@ define([
         var uri_prefix = NotebookList.uri_prefixes[model.type];
         if (model.type === 'file' &&
             model.mimetype && model.mimetype.substr(0,5) !== 'text/'
+            && !model.mimetype.endsWith('javascript')
         ) {
             // send text/unidentified files to editor, others go to raw viewer
             uri_prefix = 'files';


### PR DESCRIPTION
Closes #1040.

External JS files are loaded with `application/javascript` mimetype.

cc: @Carreau @michaelsbradleyjr 