### PR TITLE
Update tests/README.md

### DIFF
--- a/notebook/tests/README.md
+++ b/notebook/tests/README.md
@@ -5,24 +5,21 @@ depend on [CasperJS](http://casperjs.org/), which in turn requires a recent
 version of [PhantomJS](http://phantomjs.org/).
 
 The JavaScript tests are organized into subdirectories that match those in
-`static` (`base', `notebook`, `services`, `tree`, etc.).
+`static` (`base`, `notebook`, `services`, `tree`, etc.).
 
 To run all of the JavaScript tests do:
 
 ```
-iptest js
+python -m notebook.jstest 
 ```
 
-To run the JavaScript tests in a single subdirectory (`notebook` in this
-case) do:
+To run the JavaScript tests for a specific file (`base/utils.js` in this case)
+do:
 
 ```
-iptest js/notebook
+python -m notebook.jstest base/utils.js
 ```
 
-The file `util.js` contains utility functions for tests, including a path to
-a running notebook server on localhost (http://127.0.0.1) with the port
-number specified as a command line argument to the test suite. Port 8888 is
-used if `--port=` is not specified. When you run these tests using `iptest`
-you do not, however, have to start a notebook server yourself; that is done
-automatically.
+The file `jstest.py` will automatically launch a notebook server to run the
+tests against. You can however specify the url of a running notebook server
+by using `--url=http://localhost:8888`.


### PR DESCRIPTION
This updates tests/README.md to point towards using `notebook.jstest` instead of `iptest` (which does not seem to work anymore).