### PR TITLE
[Dockerfile change]: Add 2 dependencies to python build layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Installs Jupyter Notebook and IPython kernel from the current branch
 # Another Docker container should inherit with `FROM jupyter/notebook`
 # to run actual services.
+#
+# For opinionated stacks of ready-to-run Jupyter applications in Docker, 
+# check out docker-stacks <https://github.com/jupyter/docker-stacks>
 
 FROM jupyter/ubuntu_14_04_locale_fix
 
@@ -28,10 +31,8 @@ RUN apt-get update -qq && \
         build-essential \
         ca-certificates \
         curl \
-        gfortran \
         git \
         language-pack-en \
-        libatlas-base-dev \
         libcurl4-openssl-dev \
         libffi-dev \
         libsqlite3-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,10 @@ RUN apt-get update -qq && \
         build-essential \
         ca-certificates \
         curl \
+        gfortran \
         git \
         language-pack-en \
+        libatlas-base-dev \
         libcurl4-openssl-dev \
         libffi-dev \
         libsqlite3-dev \


### PR DESCRIPTION
Hi there. I'll first start by saying, the regular contributors to this project are much more knowledgeable than I am, so if there is some inherent reason why my additions do not exist, feel free to reject this pull (but please tell me why so I can learn! :innocent: )

I noticed that, in it's current form, I cannot simply run this image, open a terminal, and install the scipy package using pip. After some research, I found that the failures occur because that particular package (and others) depends on `libatlas-base-dev` and `gfortran`.

I created a Dockerfile based off of the current image and added the two packages using apt and I can confirm that this change allows scipy to be installed using pip without any issues. (I also installed `pip-tools` on my image for other reasons, so I suppose my test wasn't exactly a 100% clean test - If this build fails, that'll be why)

Thanks so much for your stellar work on this! :beers: 