### PR TITLE
allow notebook-dir to be root

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -805,6 +805,11 @@ class NotebookApp(JupyterApp):
 
     def _notebook_dir_validate(self, value, trait):
         # Strip any trailing slashes
+        # *except* if it's root
+        _, path = os.path.splitdrive(value)
+        if path == os.sep:
+            return value
+
         value = value.rstrip(os.sep)
 
         if not os.path.isabs(value):

--- a/notebook/tests/test_notebookapp.py
+++ b/notebook/tests/test_notebookapp.py
@@ -68,6 +68,11 @@ def test_nb_dir_with_slash():
         app = NotebookApp(notebook_dir=td)
         nt.assert_false(app.notebook_dir.endswith("/"))
 
+def test_nb_dir_root():
+    root = os.path.abspath(os.sep) # gets the right value on Windows, Posix
+    app = NotebookApp(notebook_dir=root)
+    nt.assert_equal(app.notebook_dir, root)
+
 def test_generate_config():
     with TemporaryDirectory() as td:
         app = NotebookApp(config_dir=td)


### PR DESCRIPTION
we were stripping `/`, which is fine except when that's the whole string,
which we were then interpreting as `''`, which gives the CWD.

This is a regression in 4.1 (#411)