### PR TITLE
Clarify notebook heading in new menu

### DIFF
--- a/notebook/static/tree/less/tree.less
+++ b/notebook/static/tree/less/tree.less
@@ -256,6 +256,13 @@ ul#new-menu {
     right: 0;
 }
 
+#new-menu .dropdown-header {
+    font-size: 10px;
+    border-bottom: 1px solid #e5e5e5;
+    padding: 0 0 3px;
+    margin: -3px 20px 0;
+}
+
 .kernel-menu-icon {
     padding-right: 12px;
     width: 24px;

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -70,7 +70,7 @@ data-terminals-available="{{terminals_available}}"
                     </li>
                     {% endif %}
                     <li role="presentation" class="divider"></li>
-                    <li role="presentation" class="dropdown-header" id="notebook-kernels">Notebooks</li>
+                    <li role="presentation" class="dropdown-header" id="notebook-kernels">Notebook:</li>
                   </ul>
                 </div>
                 <div class="btn-group">


### PR DESCRIPTION
As discussed on jupyter/jupyter#97, it's not very clear that the 'Notebooks' entry in the new menu is supposed to be a heading instead of a disabled menu entry. This aims to make the distinction clearer.

Before:

![nb new menu before](https://cloud.githubusercontent.com/assets/327925/13576120/ee1d4ece-e483-11e5-9bfc-11dd58c25ab6.png)

After:

![notebook new menu after](https://cloud.githubusercontent.com/assets/327925/13576122/f10ee0c0-e483-11e5-9f56-de9dfb894a93.png)