### PR TITLE
add missing url-encoding of base_url in terminal/edit templates

### DIFF
--- a/notebook/templates/edit.html
+++ b/notebook/templates/edit.html
@@ -11,7 +11,7 @@
 {% block bodyclasses %}edit_app {{super()}}{% endblock %}
 
 {% block params %}
-data-base-url="{{base_url}}"
+data-base-url="{{base_url | urlencode}}"
 data-file-path="{{file_path}}"
 {{super()}}
 {% endblock %}

--- a/notebook/templates/terminal.html
+++ b/notebook/templates/terminal.html
@@ -6,7 +6,7 @@
 
 {% block params %}
 
-data-base-url="{{base_url}}"
+data-base-url="{{base_url | urlencode}}"
 data-ws-path="{{ws_path}}"
 
 {% endblock %}


### PR DESCRIPTION
This was fixed in the notebook and tree views, but overlooked in edit, terminal.

This completes the fix in #472 and should be backported to 4.2, and 4.1.1 if there is one.