### PR TITLE
[WIP] [Image attachment] Add visual indicator that a drop is possible

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "backbone": "components/backbone#~1.2",
     "bootstrap": "components/bootstrap#~3.3",
     "bootstrap-tour": "0.9.0",
-    "codemirror": "julienr/CodeMirror#fix_dragleave",
+    "codemirror": "codemirror/CodeMirror#master",
     "es6-promise": "~1.0",
     "font-awesome": "components/font-awesome#~4.2.0",
     "google-caja": "5669",

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "backbone": "components/backbone#~1.2",
     "bootstrap": "components/bootstrap#~3.3",
     "bootstrap-tour": "0.9.0",
-    "codemirror": "codemirror/CodeMirror#master",
+    "codemirror": "~5.14",
     "es6-promise": "~1.0",
     "font-awesome": "components/font-awesome#~4.2.0",
     "google-caja": "5669",

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "backbone": "components/backbone#~1.2",
     "bootstrap": "components/bootstrap#~3.3",
     "bootstrap-tour": "0.9.0",
-    "codemirror": "~5.8",
+    "codemirror": "julienr/CodeMirror#fix_dragleave",
     "es6-promise": "~1.0",
     "font-awesome": "components/font-awesome#~4.2.0",
     "google-caja": "5669",

--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -946,6 +946,22 @@ define([
         }
     };
 
+    // Test if a drag'n'drop event contains a file (as opposed to an HTML
+    // element/text from the document)
+    var dnd_contain_file = function(event) {
+        // As per the HTML5 drag'n'drop spec, the dataTransfer.types should
+        // contain one "Files" type if a file is being dragged
+        // https://www.w3.org/TR/2011/WD-html5-20110113/dnd.html#dom-datatransfer-types
+        if (event.dataTransfer.types) {
+            for (var i = 0; i < event.dataTransfer.types.length; i++) {
+                if (event.dataTransfer.types[i] == "Files") {
+                    return true;
+                }
+            }
+        }
+        return false;
+    };
+
     var utils = {
         is_loaded: is_loaded,
         load_extension: load_extension,
@@ -990,6 +1006,7 @@ define([
         time: time,
         format_datetime: format_datetime,
         datetime_sort_helper: datetime_sort_helper,
+        dnd_contain_file: dnd_contain_file,
         _ansispan:_ansispan
     };
 

--- a/notebook/static/notebook/js/textcell.js
+++ b/notebook/static/notebook/js/textcell.js
@@ -110,6 +110,7 @@ define([
         inner_cell.append(input_area).append(render_area);
         cell.append(inner_cell);
         this.element = cell;
+        this.inner_cell = inner_cell;
     };
 
 
@@ -282,6 +283,9 @@ define([
         TextCell.apply(this, [$.extend({}, options, {config: config})]);
 
         this.cell_type = 'markdown';
+
+        // Used to keep track of drag events
+        this.drag_counter = 0;
     };
 
     MarkdownCell.options_default = {
@@ -461,7 +465,26 @@ define([
             return true;
         });
 
+        // We want to display a visual indicator that the drop is possible.
+        // The dragleave event is fired when we hover a child element (which
+        // is often immediatly after we got the dragenter), so we keep track
+        // of the number of dragenter/dragleave we got, as discussed here :
+        // http://stackoverflow.com/q/7110353/116067
+        this.code_mirror.on("dragenter", function(cm, evt) {
+          that.drag_counter++;
+          that.inner_cell.addClass('droppable');
+          evt.preventDefault();
+        });
+
+        this.code_mirror.on("dragleave", function(cm, evt) {
+          that.drag_counter--;
+          if (that.drag_counter === 0) {
+            that.inner_cell.removeClass('droppable');
+          }
+        });
+
         this.code_mirror.on("drop", function(cm, evt) {
+          that.inner_cell.removeClass('droppable');
             var files = evt.dataTransfer.files;
             for (var i = 0; i < files.length; ++i) {
                 var file = files[i];

--- a/notebook/static/notebook/less/textcell.less
+++ b/notebook/static/notebook/less/textcell.less
@@ -48,8 +48,9 @@ h1,h2,h3,h4,h5,h6 {
     display:none;
 }
 
-.text_cell .droppable{
-  border: 1px solid #ff0000;
+.text_cell .dropzone .input_area {
+  border-color: #FCFF1E;
+  background-color: #FCFFE3;
 }
 
 .cm-header-1,

--- a/notebook/static/notebook/less/textcell.less
+++ b/notebook/static/notebook/less/textcell.less
@@ -48,6 +48,10 @@ h1,h2,h3,h4,h5,h6 {
     display:none;
 }
 
+.text_cell .droppable{
+  border: 1px solid #ff0000;
+}
+
 .cm-header-1,
 .cm-header-2,
 .cm-header-3,

--- a/notebook/static/notebook/less/textcell.less
+++ b/notebook/static/notebook/less/textcell.less
@@ -49,8 +49,8 @@ h1,h2,h3,h4,h5,h6 {
 }
 
 .text_cell .dropzone .input_area {
-  border-color: #FCFF1E;
-  background-color: #FCFFE3;
+  border: 2px dashed #bababa;
+  margin: -1px;
 }
 
 .cm-header-1,


### PR DESCRIPTION
This adds a visual indicator that a drop is possible when the user drags an image file over a markdown cell. This fixes #1186

This currently highlight the markdown cell with a red border as you can see in the animation below. Some work is needed on the design side, comments/ideas are welcome.

Note that this depends on this code mirror PR : https://github.com/codemirror/CodeMirror/pull/3882

TODO :
- [x] Improve design
- [x] Avoid triggering the effect when drag'n'droping text in edit mode
- [x] Wait for codemirror PR to be merged
- [x] Update bower dependency to the official codemirror


![quickcast-11-03-2016-08-20-03](https://cloud.githubusercontent.com/assets/506602/13713122/b805b24e-e7c7-11e5-8acd-d0c4f2a8ee03.gif)