### PR TITLE
Allow modifying kernel associated with a session via PATCH

### DIFF
--- a/notebook/services/sessions/handlers.py
+++ b/notebook/services/sessions/handlers.py
@@ -103,15 +103,15 @@ class SessionHandler(APIHandler):
         changes = {}
         if 'notebook' in model:
             notebook = model['notebook']
-            if 'path' in notebook:
+            if notebook.get('path') is not None:
                 changes['path'] = notebook['path']
         if 'kernel' in model:
-            if 'name' in model['kernel']:
+            if model['kernel'].get('name') is not None:
                 kernel_name = model['kernel']['name']
                 kernel_id = yield sm.start_kernel_for_session(
                     session_id, kernel_name=kernel_name, path=before['notebook']['path'])
                 changes['kernel_id'] = kernel_id
-            if 'id' in model['kernel']:
+            if model['kernel'].get('id') is not None:
                 kernel_id = model['kernel']['id']
                 if kernel_id not in km:
                     raise web.HTTPError(400, "No such kernel: %s" % kernel_id)

--- a/notebook/services/sessions/sessionmanager.py
+++ b/notebook/services/sessions/sessionmanager.py
@@ -62,22 +62,29 @@ class SessionManager(LoggingConfigurable):
     def new_session_id(self):
         "Create a uuid for a new session"
         return unicode_type(uuid.uuid4())
-    
+
     @gen.coroutine
     def create_session(self, path=None, kernel_name=None):
         """Creates a session and returns its model"""
         session_id = self.new_session_id()
-        # allow nbm to specify kernels cwd
-        kernel_path = self.contents_manager.get_kernel_path(path=path)
-        kernel_id = yield gen.maybe_future(
-            self.kernel_manager.start_kernel(path=kernel_path, kernel_name=kernel_name)
-        )
+        kernel_id = yield self.start_kernel_for_session(session_id, path, kernel_name)
         result = yield gen.maybe_future(
             self.save_session(session_id, path=path, kernel_id=kernel_id)
         )
         # py2-compat
         raise gen.Return(result)
-    
+
+    @gen.coroutine
+    def start_kernel_for_session(self, session_id, path, kernel_name):
+        """Start a new kernel for a given session."""
+        # allow contents manager to specify kernels cwd
+        kernel_path = self.contents_manager.get_kernel_path(path=path)
+        kernel_id = yield gen.maybe_future(
+            self.kernel_manager.start_kernel(path=kernel_path, kernel_name=kernel_name)
+        )
+        # py2-compat
+        raise gen.Return(kernel_id)
+
     def save_session(self, session_id, path=None, kernel_id=None):
         """Saves the items for the session with the given session_id
         
@@ -211,9 +218,9 @@ class SessionManager(LoggingConfigurable):
                 pass
         return result
 
+    @gen.coroutine
     def delete_session(self, session_id):
         """Deletes the row in the session database with given session_id"""
-        # Check that session exists before deleting
         session = self.get_session(session_id=session_id)
-        self.kernel_manager.shutdown_kernel(session['kernel']['id'])
+        yield gen.maybe_future(self.kernel_manager.shutdown_kernel(session['kernel']['id']))
         self.cursor.execute("DELETE FROM session WHERE session_id=?", (session_id,))

--- a/notebook/services/sessions/tests/test_sessionmanager.py
+++ b/notebook/services/sessions/tests/test_sessionmanager.py
@@ -175,6 +175,8 @@ class TestSessionManager(TestCase):
         # try to delete a session that doesn't exist ~ raise error
         sm = self.sm
         self.create_session(path='/path/to/test.ipynb', kernel_name='python')
-        self.assertRaises(TypeError, sm.delete_session, bad_kwarg='23424') # Bad keyword
-        self.assertRaises(web.HTTPError, sm.delete_session, session_id='23424') # nonexistant
+        with self.assertRaises(TypeError):
+            self.loop.run_sync(lambda : sm.delete_session(bad_kwarg='23424')) # Bad keyword
+        with self.assertRaises(web.HTTPError):
+            self.loop.run_sync(lambda : sm.delete_session(session_id='23424')) # nonexistent
 


### PR DESCRIPTION
- PATCH to kernel.id attaches to other kernel
- PATCH to kernel.name starts new kernel with given name

Previous kernel is shutdown after the change

cc @blink1073