### PR TITLE
Toggle Header in Edit page

### DIFF
--- a/notebook/static/edit/js/menubar.js
+++ b/notebook/static/edit/js/menubar.js
@@ -112,6 +112,11 @@ define([
         });
         
         // View
+
+        this.element.find('#toggle_header').click(function (){
+            $("#header-container").toggle();
+        });
+        
         this.element.find('#menu-line-numbers').click(function () {
             var current = editor.codemirror.getOption('lineNumbers');
             var value = Boolean(1-current);

--- a/notebook/templates/edit.html
+++ b/notebook/templates/edit.html
@@ -65,7 +65,9 @@ data-file-path="{{file_path}}"
             </li>
             <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">View</a>
               <ul id="view-menu" class="dropdown-menu">
-                <li id="menu-line-numbers"><a href="#">Toggle Line Numbers</a></li>
+              <li id="toggle_header" title="Show/Hide the IPython Notebook logo and notebook title (above menu bar)">
+              <a href="#">Toggle Header</a></li>
+              <li id="menu-line-numbers"><a href="#">Toggle Line Numbers</a></li>
               </ul>
             </li>
             <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Language</a>


### PR DESCRIPTION
#1214 

There is no function to hide the header in edit mode. Now I know my syntax is wrong. I couldn't find a way to do this from the edit page javascript file. If I could get some guidance and than I could write it properly. Right now I just put the javascript within the html edit file.

Before:
![headheaderbefore](https://cloud.githubusercontent.com/assets/15676683/13789809/4f036ab6-eaab-11e5-987d-977a74788499.png)
 #After:
![headheaderafter](https://cloud.githubusercontent.com/assets/15676683/13789897/a81af92a-eaab-11e5-9b4a-4e3c70520c28.png)

