### PR TITLE
Add missing pager.append function

### DIFF
--- a/notebook/static/notebook/js/pager.js
+++ b/notebook/static/notebook/js/pager.js
@@ -160,6 +160,14 @@ define([
         this.pager_element.find(".container").append($('<pre/>').html(utils.fixCarriageReturn(utils.fixConsole(text))));
     };
 
+    Pager.prototype.append = function (htm) {
+        /**
+         * The only user content injected with this HTML call is escaped by
+         * the fixConsole() method.
+         */
+        this.pager_element.find(".container").append(htm);
+    };
+
 
     Pager.prototype._resize = function() {
         /**


### PR DESCRIPTION
This adds the missing method of the pager, and for which there is already a call line 96.

This is required for https://github.com/ipython/ipython/pull/9304