### PR TITLE
retry js tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
     - pip install -f travis-wheels/wheelhouse file://$PWD#egg=notebook[test]
 
 script:
-    - 'if [[ $GROUP == js* ]]; then python -m notebook.jstest ${GROUP:3}; fi'
+    - 'if [[ $GROUP == js* ]]; then travis_retry python -m notebook.jstest ${GROUP:3}; fi'
     - 'if [[ $GROUP == python ]]; then nosetests -v --with-coverage --cover-package=notebook notebook; fi'
 
 matrix:


### PR DESCRIPTION
This is a lazy thing to do because intermittently failing tests are often actual bugs (usually in the tests themselves). But if we are just going to kick Travis to re-run when this happens, we might as well let Travis do it automatically.