### PR TITLE
Add `cookie_options` to make cookie args configurable

### DIFF
--- a/notebook/auth/login.py
+++ b/notebook/auth/login.py
@@ -40,6 +40,7 @@ class LoginHandler(IPythonHandler):
     def post(self):
         typed_password = self.get_argument('password', default=u'')
         cookie_options = self.settings.get('cookie_options', {})
+        cookie_options.setdefault('httponly', True)
         if self.login_available(self.settings):
             if passwd_check(self.hashed_password, typed_password):
                 # tornado <4.2 has a bug that considers secure==True as soon as

--- a/notebook/auth/login.py
+++ b/notebook/auth/login.py
@@ -39,15 +39,14 @@ class LoginHandler(IPythonHandler):
 
     def post(self):
         typed_password = self.get_argument('password', default=u'')
+        cookie_options = self.settings.get('cookie_options', {})
         if self.login_available(self.settings):
             if passwd_check(self.hashed_password, typed_password):
-                # tornado <4.2 have a bug that consider secure==True as soon as
+                # tornado <4.2 has a bug that considers secure==True as soon as
                 # 'secure' kwarg is passed to set_secure_cookie
                 if self.settings.get('secure_cookie', self.request.protocol == 'https'):
-                    kwargs = {'secure': True}
-                else:
-                    kwargs = {}
-                self.set_secure_cookie(self.cookie_name, str(uuid.uuid4()), **kwargs)
+                    cookie_options.setdefault('secure', True)
+                self.set_secure_cookie(self.cookie_name, str(uuid.uuid4()), **cookie_options)
             else:
                 self.set_status(401)
                 self._render(message={'error': 'Invalid password'})

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -617,6 +617,10 @@ class NotebookApp(JupyterApp):
             help="Supply overrides for the tornado.web.Application that the "
                  "Jupyter notebook uses.")
     
+    cookie_options = Dict(config=True,
+        help="Extra keyword arguments to pass to `set_secure_cookie`."
+             " See tornado's set_secure_cookie docs for details."
+    )
     ssl_options = Dict(config=True,
             help="""Supply SSL options for the tornado HTTPServer.
             See the tornado docs for details.""")
@@ -934,6 +938,7 @@ class NotebookApp(JupyterApp):
         if self.allow_origin_pat:
             self.tornado_settings['allow_origin_pat'] = re.compile(self.allow_origin_pat)
         self.tornado_settings['allow_credentials'] = self.allow_credentials
+        self.tornado_settings['cookie_options'] = self.cookie_options
         # ensure default_url starts with base_url
         if not self.default_url.startswith(self.base_url):
             self.default_url = url_path_join(self.base_url, self.default_url)


### PR DESCRIPTION
also make cookies httponly by default, since we do not need or want access to cookies in js