### PR TITLE
Use casper.open() instead of casper.start() to open the dashboard.

### DIFF
--- a/notebook/tests/util.js
+++ b/notebook/tests/util.js
@@ -694,17 +694,31 @@ casper.wait_for_dashboard = function () {
     casper.waitForSelector('.list_item');
 };
 
-casper.open_dashboard = function () {
+/**
+ * Open the dashboard page
+ * @param {bool} use_start - If true, will use casper.start(), otherwise
+ *      casper.open(). You should only set it to true if the dashboard
+ *      is the first URL to be opened in the test, because calling
+ *      casper.start() multiple times causes casper to skip subsequent then()
+ */
+casper.open_dashboard = function (use_start) {
+    if (use_start === undefined) {
+        use_start = false;
+    }
     // Start casper by opening the dashboard page.
     var baseUrl = this.get_notebook_server();
-    this.start(baseUrl);
+    if (use_start) {
+        this.start(baseUrl);
+    } else {
+        this.open(baseUrl);
+    }
     this.waitFor(this.page_loaded);
     this.wait_for_dashboard();
 };
 
 casper.dashboard_test = function (test) {
     // Open the dashboard page and run a test.
-    this.open_dashboard();
+    this.open_dashboard(true);
     this.then(test);
 
     this.then(function () {


### PR DESCRIPTION
This is a fix for #1204 
Calling ``casper.start()`` multiple times seems to cause casper to skip subsequent then() call, skipping some asserts. Using ``casper.open()`` instead fixes this.

Example test run on save.js with ``python -m notebook.jstest notebook/save.js``

#### Before
```
Test file: notebook/tests/notebook/save.js
PASS Save did not fail
PASS Save OK
PASS Save with complicated name
PASS path OK
PASS checkpoints OK
PASS 5 tests executed in 4.354s, 5 passed, 0 failed, 0 dubious, 0 skipped.
```
#### After
```
Test file: notebook/tests/notebook/save.js
PASS Save did not fail
PASS Save OK
PASS Save with complicated name
PASS path OK
PASS checkpoints OK
PASS Escaped URL in notebook list
PASS Notebook name is correct
PASS 7 tests executed in 5.459s, 7 passed, 0 failed, 0 dubious, 0 skipped.
```