### PR TITLE
'include how to build frontend extensions'

### DIFF
--- a/docs/source/extending/index.rst
+++ b/docs/source/extending/index.rst
@@ -12,3 +12,4 @@ override the notebook's defaults with your own custom behavior.
     contents
     savehooks
     handlers
+    frontend_extensions


### PR DESCRIPTION
Otherwise it's not included on RTD. 