### PR TITLE
Move the unused attachments garbage collection logic to TextCell.toJSON.

### DIFF
--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -351,16 +351,6 @@ define([
     };
 
     /**
-     * Garbage collects unused attachments in this cell
-     * @method remove_unused_attachments
-     */
-    Cell.prototype.remove_unused_attachments = function () {
-        // Cell subclasses which support attachments should override this
-        // and keep them when needed
-        this.attachments = {};
-    };
-
-    /**
      * Delegates keyboard shortcut handling to either Jupyter keyboard
      * manager when in command mode, or CodeMirror when in edit mode
      *
@@ -754,11 +744,6 @@ define([
         );
         cell.append(inner_cell);
         this.element = cell;
-    };
-
-    UnrecognizedCell.prototype.remove_unused_attachments = function () {
-        // Do nothing to avoid removing attachments from a possible future
-        // attachment-supporting cell type
     };
 
     UnrecognizedCell.prototype.bind_events = function () {


### PR DESCRIPTION
This allows to keep all attachments in memory and only garbage collect on the JSON that is saved to disk. This is based on @Carreau suggestion of sending a cleaned copy of the JSON when saving.

This fixes #1185 .