### PR TITLE
Set sphinx < 1.4 due to LaTeX build errors

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,5 +8,5 @@ dependencies:
 - jupyter_client
 - ipykernel
 - pip:
-  - sphinx>=1.3.6
+  - sphinx<1.4
   - nbsphinx


### PR DESCRIPTION
Sphinx 1.4 was released yesterday. Build failing on 1.4 due to LaTeX build errors. Drop back to 1.3.