### PR TITLE
[WIP] Add a trusted notebook indicator

### DIFF
--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -287,6 +287,9 @@ define([
             that.update_nbconvert_script(langinfo);
             that.add_kernel_help_links(data.kernel.info_reply.help_links || []);
         });
+        this.events.on('trust_changed.Notebook', function (event, trusted) {
+            that.set_trusted_indicator(trusted);
+        });
     };
     
     MenuBar.prototype._add_celltoolbar_list = function () {
@@ -415,6 +418,18 @@ define([
         });
         
     };
+
+    MenuBar.prototype.set_trusted_indicator = function (trusted) {
+        // TODO
+        var el = this.element.find('span.trusted-indicator');
+        if (trusted) {
+            el.text('Notebook is trusted.').removeClass("untrusted").addClass("trusted");
+        }
+        else {
+            el.text('Notebook is untrusted.').removeClass("trusted").addClass("untrusted");
+        }
+    };
+
 
     return {'MenuBar': MenuBar};
 });

--- a/notebook/static/notebook/less/menubar.less
+++ b/notebook/static/notebook/less/menubar.less
@@ -17,6 +17,20 @@
   .navbar-collapse {
     clear: left;
   }
+  .trusted-indicator {
+      position: relative;
+      display: block;
+      padding: 10px 15px;
+      padding-top: 6px;
+      padding-bottom: 6px;
+      font-weight: bold;
+  }
+  .trusted-indicator.trusted {
+      color: green;
+  }
+  .trusted-indicator.untrusted {
+      color: red;
+  }
   
 }
 

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -40,6 +40,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
     <span id="notebook_name" class="filename"></span>
     <span class="checkpoint_status"></span>
     <span class="autosave_status"></span>
+    <span class="trusted_indicator"></span>
 </span>
 
 <span id="kernel_logo_widget">
@@ -301,6 +302,9 @@ data-notebook-path="{{notebook_path | urlencode}}"
                         <li title="About Jupyter Notebook"><a id="notebook_about" href="#">About</a></li>
                         {% endblock %}
                     </ul>
+                </li>
+                <li>
+                    <span class="trusted-indicator"></span>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
This pull request adds a "trusted notebook" indicator, as discussed in https://github.com/jupyter/notebook/issues/1146.

Currently, the implementation is to put a "Notebook is trusted" / "Notebook is untrusted" sentence in the menubar on top of the screen. 

Still, UI is not really good at the moment and can be discussed further (hence the "WIP" tag). For instance, displaying a notification explaining what is an untrusted notebook upon opening an untrusted notebook could be a good idea IMO.

Trusted notebook UI:
![2016-04-01-145716](https://cloud.githubusercontent.com/assets/3856586/14207423/57430aca-f81a-11e5-8ee5-351c7619e01b.png)

Untrusted notebook UI:
![2016-04-01-145751](https://cloud.githubusercontent.com/assets/3856586/14207427/5a6380a4-f81a-11e5-8f37-cb74e4fb9946.png)
