### PR TITLE
Adding a split cell style into the notebook

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -448,6 +448,22 @@ define(function(require){
                 }
             }
         },
+        'cell-style-centered' : {
+            help: 'select cell style centered ',
+            icon: 'cell-style',
+            help_index : 'el',
+            handler : function (env) {
+                env.notebook.set_cell_style('center');
+            }
+         },
+        'cell-style-split' : {
+            help: 'select cell style split ',
+            icon: 'cell-style',
+            help_index : 'el',
+            handler : function (env) {
+                env.notebook.set_cell_style('right');
+            }
+        },
         'show-command-palette': {
             help_index : 'aa',
             help: 'open the command palette',

--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -48,6 +48,8 @@ define([
         options = options || {};
         this.keyboard_manager = options.keyboard_manager;
         this.events = options.events;
+        this.cell_style = options.cell_style;
+        
         var config = utils.mergeopt(Cell, options.config);
         // superclass default overwrite our default
         
@@ -56,6 +58,7 @@ define([
         this.anchor = false;
         this.rendered = false;
         this.mode = 'command';
+        
 
         // Metadata property
         var that = this;
@@ -81,6 +84,7 @@ define([
 
         // load this from metadata later ?
         this.user_highlight = 'auto';
+        
 
 
         var _local_cm_config = {};
@@ -179,6 +183,16 @@ define([
             // I'm already part of the selection; contract selection to just me
             this.events.trigger('select.Cell', {'cell': this});
         }
+    };
+
+    Cell.prototype.get_cell_style_html = function(cell_style){
+        if (cell_style == "right") 
+            {return "float:right; width:50%;";}
+        else if (cell_style == "left") 
+            {return "float:left; width:50%;";} 
+        else if (cell_style == "center")
+            {return "width:100%;";}
+        return cell_style
     };
 
     /**
@@ -351,6 +365,16 @@ define([
     };
 
     /**
+     * Garbage collects unused attachments in this cell
+     * @method remove_unused_attachments
+     */
+    Cell.prototype.remove_unused_attachments = function () {
+        // Cell subclasses which support attachments should override this
+        // and keep them when needed
+        this.attachments = {};
+    };
+
+    /**
      * Delegates keyboard shortcut handling to either Jupyter keyboard
      * manager when in command mode, or CodeMirror when in edit mode
      *
@@ -483,6 +507,7 @@ define([
         // deepcopy the metadata so copied cells don't share the same object
         data.metadata = JSON.parse(JSON.stringify(this.metadata));
         data.cell_type = this.cell_type;
+        data.cell_style = this.cell_style || "width=100%;";
         return data;
     };
 
@@ -744,6 +769,11 @@ define([
         );
         cell.append(inner_cell);
         this.element = cell;
+    };
+
+    UnrecognizedCell.prototype.remove_unused_attachments = function () {
+        // Do nothing to avoid removing attachments from a possible future
+        // attachment-supporting cell type
     };
 
     UnrecognizedCell.prototype.bind_events = function () {

--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -95,6 +95,7 @@ define([
         this.events = options.events;
         this.tooltip = options.tooltip;
         this.config = options.config;
+        this.cell_style = options.cell_style;
         this.class_config = new configmod.ConfigWithDefaults(this.config,
                                         CodeCell.config_defaults, 'CodeCell');
 
@@ -110,7 +111,8 @@ define([
         Cell.apply(this,[{
             config: $.extend({}, CodeCell.options_default), 
             keyboard_manager: options.keyboard_manager, 
-            events: this.events}]);
+            events: this.events,
+            cell_style:this.cell_style}]);
 
         // Attributes we want to override in this subclass.
         this.cell_type = "code";
@@ -146,14 +148,16 @@ define([
     CodeCell.msg_cells = {};
 
     CodeCell.prototype = Object.create(Cell.prototype);
-    
+
     /** @method create_element */
     CodeCell.prototype.create_element = function () {
         Cell.prototype.create_element.apply(this, arguments);
         var that = this;
 
         var cell =  $('<div></div>').addClass('cell code_cell');
-        cell.attr('tabindex','2');
+        var cell_style_html = Cell.prototype.get_cell_style_html.apply(this, [this.cell_style]);
+
+        cell.attr({'tabindex':'2', 'style':cell_style_html});
 
         var input = $('<div></div>').addClass('input');
         this.input = input;
@@ -512,16 +516,25 @@ define([
                 this.code_mirror.clearHistory();
                 this.auto_highlight();
             }
+            if (data.cell_style !== undefined){
+                this.cell_style = data.cell_style ;
+                }
+            else {this.cell_style = 'width=100%;';}
+
             this.set_input_prompt(data.execution_count);
             this.output_area.trusted = data.metadata.trusted || false;
+            
             this.output_area.fromJSON(data.outputs, data.metadata);
         }
     };
 
 
+
+
     CodeCell.prototype.toJSON = function () {
         var data = Cell.prototype.toJSON.apply(this);
         data.source = this.get_text();
+
         // is finite protect against undefined and '*' value
         if (isFinite(this.input_prompt_number)) {
             data.execution_count = this.input_prompt_number;
@@ -530,6 +543,7 @@ define([
         }
         var outputs = this.output_area.toJSON();
         data.outputs = outputs;
+
         data.metadata.trusted = this.output_area.trusted;
         data.metadata.collapsed = this.output_area.collapsed;
         if (this.output_area.scroll_state === 'auto') {
@@ -537,10 +551,11 @@ define([
         } else {
             data.metadata.scrolled = this.output_area.scroll_state;
         }
+
         return data;
     };
 
-    /**
+    /** `
      * handle cell level logic when the cell is unselected
      * @method unselect
      * @return is the action being taken

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -232,6 +232,8 @@ define([
             '#copy_cell_attachments': 'copy-cell-attachments',
             '#paste_cell_attachments': 'paste-cell-attachments',
             '#insert_image': 'insert-image',
+            '#cell_style_centered':'cell-style-centered',
+            '#cell_style_split':'cell-style-split',
         };
 
         for(var idx in id_actions_dict){

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -61,10 +61,13 @@ define(function (require) {
         this.keyboard_manager = options.keyboard_manager;
         this.contents = options.contents;
         this.save_widget = options.save_widget;
+        this.cell_style = "center";
+
         this.tooltip = new tooltip.Tooltip(this.events);
         this.ws_url = options.ws_url;
         this._session_starting = false;
         this.last_modified = null;
+        
         // debug 484
         this._last_modified = 'init';
         // Firefox workaround
@@ -170,14 +173,15 @@ define(function (require) {
         // 'above', 'below', or 'selected' to get the value from another cell.
         default_cell_type: 'code'
     };
-
+ 
     /**
      * Create an HTML and CSS representation of the notebook.
      */
     Notebook.prototype.create_elements = function () {
         var that = this;
         this.element.attr('tabindex','-1');
-        this.container = $("<div/>").addClass("container").attr("id", "notebook-container");
+        this.container = $("<div/>").addClass("container").attr({"id":"notebook-container"});
+   
         // We add this end_space div to the end of the notebook div to:
         // i) provide a margin between the last cell and the end of the notebook
         // ii) to prevent the div from scrolling up when the last cell is being
@@ -303,7 +307,7 @@ define(function (require) {
             var new_height = app_height - pager_height - splitter_height;
             that.element.animate({height : new_height + 'px'}, time);
         };
-
+   
         this.element.bind('expand_pager', function (event, extrap) {
             var time = (extrap !== undefined) ? ((extrap.duration !== undefined ) ? extrap.duration : 'fast') : 'fast';
             expand_time(time);
@@ -1115,6 +1119,15 @@ define(function (require) {
         }
     };
 
+    Notebook.prototype.set_cell_style = function(cell_style){     
+        this.cell_style = cell_style
+    };
+
+    Notebook.prototype.cycle_cell_style_side = function(cycle_style){     
+        if (this.cell_style == "right"){this.cell_style = "left";}   
+        else if (this.cell_style == "left"){this.cell_style ="right"}
+    };
+
     /**
      * Insert a cell so that after insertion the cell is at given index.
      *
@@ -1130,6 +1143,7 @@ define(function (require) {
      * @return {Cell|null} created cell or null
      */
     Notebook.prototype.insert_cell_at_index = function(type, index){
+
 
         var ncells = this.ncells();
         index = Math.min(index, ncells);
@@ -1158,7 +1172,8 @@ define(function (require) {
                 config: this.config, 
                 keyboard_manager: this.keyboard_manager, 
                 notebook: this,
-                tooltip: this.tooltip
+                tooltip: this.tooltip,
+                cell_style: this.cell_style,
             };
             switch(type) {
             case 'code':
@@ -1239,6 +1254,9 @@ define(function (require) {
         if (index === null || index === undefined) {
             index = Math.min(this.get_selected_index(index), this.get_anchor_index());
         }
+        
+        this.cycle_cell_style_side()
+
         return this.insert_cell_at_index(type, index);
     };
 
@@ -1254,6 +1272,9 @@ define(function (require) {
         if (index === null || index === undefined) {            
             index = Math.max(this.get_selected_index(index), this.get_anchor_index());
         }
+        
+        this.cycle_cell_style_side()
+
         return this.insert_cell_at_index(type, index+1);
     };
 
@@ -2403,9 +2424,19 @@ define(function (require) {
     };
 
     /**
-     Move the unused attachments garbage collection logic to TextCell.toJSON.
+     * Garbage collects unused attachments in all the cells
+     */
+    Notebook.prototype.remove_unused_attachments = function() {
+      var cells = this.get_cells();
+      for (var i = 0; i < cells.length; i++) {
+          var cell = cells[i];
+          cell.remove_unused_attachments();
+      }
+    };
+
+    /**
      * Load a notebook from JSON (.ipynb).
-     *
+     * 
      * @param {object} data - JSON representation of a notebook
      */
     Notebook.prototype.fromJSON = function (data) {
@@ -2437,6 +2468,7 @@ define(function (require) {
         var new_cell = null;
         for (i=0; i<ncells; i++) {
             cell_data = new_cells[i];
+            this.cell_style = cell_data.cell_style || 'center'
             new_cell = this.insert_cell_at_index(cell_data.cell_type, i);
             new_cell.fromJSON(cell_data);
             if (new_cell.cell_type === 'code' && !new_cell.output_area.trusted) {
@@ -2468,7 +2500,7 @@ define(function (require) {
             if (cell.cell_type === 'code' && !cell.output_area.trusted) {
                 trusted = false;
             }
-            cell_array[i] = cell.toJSON(true);
+            cell_array[i] = cell.toJSON();
         }
         var data = {
             cells: cell_array,
@@ -2517,12 +2549,17 @@ define(function (require) {
      * Save this notebook on the server. This becomes a notebook instance's
      * .save_notebook method *after* the entire notebook has been loaded.
      *
+     * manual_save will be true if the save was manually trigered by the user
      */
-    Notebook.prototype.save_notebook = function (check_last_modified) {
+    Notebook.prototype.save_notebook = function (check_last_modified,
+                                                 manual_save) {
         if (check_last_modified === undefined) {
             check_last_modified = true;
         }
-
+        if (manual_save === undefined) {
+            manual_save = false;
+        }
+        
         var error;
         if (!this._fully_loaded) {
             error = new Error("Load failed, save is disabled");
@@ -2537,6 +2574,13 @@ define(function (require) {
         // Trigger an event before save, which allows listeners to modify
         // the notebook as needed.
         this.events.trigger('before_save.Notebook');
+
+        // Garbage collect unused attachments. Only do this for manual save
+        // to avoid removing unused attachments while the user is editing if
+        // an autosave gets triggered in the midle of an edit
+        if (manual_save) {
+            this.remove_unused_attachments();
+        }
 
         // Create a JSON model to be sent to the server.
         var model = {
@@ -2721,7 +2765,7 @@ define(function (require) {
         var parent = utils.url_path_split(this.notebook_path)[0];
         var p;
         if (this.dirty) {
-            p = this.save_notebook(true);
+            p = this.save_notebook(true, true);
         } else {
             p = Promise.resolve();
         }
@@ -2991,7 +3035,7 @@ define(function (require) {
      */
     Notebook.prototype.save_checkpoint = function () {
         this._checkpoint_after_save = true;
-        this.save_notebook(true);
+        this.save_notebook(true, true);
     };
     
     /**

--- a/notebook/static/notebook/js/textcell.js
+++ b/notebook/static/notebook/js/textcell.js
@@ -52,13 +52,15 @@ define([
         this.events = options.events;
         this.config = options.config;
         this.notebook = options.notebook;
+        this.cell_style = options.cell_style;
         
         // we cannot put this as a class key as it has handle to "this".
         var config = utils.mergeopt(TextCell, this.config);
         Cell.apply(this, [{
                     config: config, 
                     keyboard_manager: options.keyboard_manager, 
-                    events: this.events}]);
+                    events: this.events,
+                    cell_style:this.cell_style}]);
 
         this.cell_type = this.cell_type || 'text';
         mathjaxutils = mathjaxutils;
@@ -85,7 +87,9 @@ define([
         var that = this;
 
         var cell = $("<div>").addClass('cell text_cell');
-        cell.attr('tabindex','2');
+        var cell_style_html = Cell.prototype.get_cell_style_html.apply(this, [this.cell_style]);
+
+        cell.attr({'tabindex':'2', 'style':cell_style_html});
 
         var prompt = $('<div/>').addClass('prompt input_prompt');
         cell.append(prompt);
@@ -196,6 +200,9 @@ define([
             if (data.attachments !== undefined) {
                 this.attachments = data.attachments;
             }
+            if (data.cell_style !== undefined) {
+                this.cell_style = data.cell_style;}
+            else {this.cell_style =  'width=100%;';}
 
             if (data.source !== undefined) {
                 this.set_text(data.source);
@@ -226,6 +233,8 @@ define([
         if (data.source == this.placeholder) {
             data.source = "";
         }
+
+        data.cell_style = this.cell_style;
 
         // We deepcopy the attachments so copied cells don't share the same
         // objects

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -237,6 +237,17 @@ data-notebook-path="{{notebook_path | urlencode}}"
                                 </li>
                             </ul>
                         </li>
+                        <li class="divider"></li>
+                        <li id="change_cell_style" class="dropdown-submenu"
+                            title="Cells can be set to take of full width or split the window.">
+                            <a href="#">Cell Style</a>
+                            <ul class="dropdown-menu">
+                            <li id="cell_style_split" title="Set cell style to split screen">
+                            <a href="#">Split</a></li>     
+                            <li id="cell_style_centered" title="Set cell style to centered">
+                            <a href="#">Centered</a></li>
+                            </ul>
+                        </li>
                     </ul>
                 </li>
                 <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown">Kernel</a>


### PR DESCRIPTION
… menu select item

updated markdown cell to also allow split window
switched order of cell styling
moved cell style down to bottom of the dropdown menu
updated to use metadata of the cell to store the cell position
minor bug fixes
refactor code
updating tojson and from json to add persistence