### PR TITLE
Missing font-awesome css file.

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -142,6 +142,7 @@ def find_package_data():
         pjoin(components, "bootstrap-tour", "build", "css", "bootstrap-tour.min.css"),
         pjoin(components, "bootstrap-tour", "build", "js", "bootstrap-tour.min.js"),
         pjoin(components, "es6-promise", "*.js"),
+        pjoin(components, "font-awesome", "css", "*.css"),
         pjoin(components, "font-awesome", "fonts", "*.*"),
         pjoin(components, "google-caja", "html-css-sanitizer-minified.js"),
         pjoin(components, "jquery", "jquery.min.js"),


### PR DESCRIPTION
I'm not sure if this is the right fix, but the font-awesome*.css files were not copied over to the build/ directory when doing "python setup.py build". Running the notebook from that build/ directory resulted in missing icons everywhere.