### PR TITLE
allow using sqlite from pysqlite2

### DIFF
--- a/notebook/services/sessions/sessionmanager.py
+++ b/notebook/services/sessions/sessionmanager.py
@@ -4,7 +4,12 @@
 # Distributed under the terms of the Modified BSD License.
 
 import uuid
-import sqlite3
+
+try:
+    import sqlite3
+except ImportError:
+    # fallback on pysqlite2 if Python was build without sqlite
+    from pysqlite2 import dbapi2 as sqlite3
 
 from tornado import gen, web
 


### PR DESCRIPTION
in case Python was built with an incomplete standard library (missing sqlite3)

we do the same thing in IPython history, etc.

closes #1307