### PR TITLE
Adding toggle line numbers for all cells

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -456,6 +456,14 @@ define(function(require){
                 env.notebook.show_command_palette();
             }
         },
+        'toggle-all-line-numbers': {
+            help : 'toggles line numbers in all cells',
+            icon: 'fa-list-ol',
+            handler: function(env) {
+                console.log('calling function');
+                env.notebook.toggle_all_line_numbers();
+            }
+        },
         'toggle-toolbar':{
             help: 'hide/show the toolbar',
             handler : function(env){

--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -159,6 +159,7 @@ define([
             'o' : 'jupyter-notebook:toggle-cell-output-collapsed',
             's' : 'jupyter-notebook:save-notebook',
             'l' : 'jupyter-notebook:toggle-cell-line-numbers',
+            'shift-l' : 'jupyter-notebook:toggle-all-line-numbers',
             'h' : 'jupyter-notebook:show-keyboard-shortcuts',
             'z' : 'jupyter-notebook:undo-cell-deletion',
             'q' : 'jupyter-notebook:close-pager',

--- a/notebook/static/notebook/js/maintoolbar.js
+++ b/notebook/static/notebook/js/maintoolbar.js
@@ -55,6 +55,7 @@ define([
             'run_int'],
          ['<add_celltype_list>'],
          [['jupyter-notebook:show-command-palette']],
+         [['jupyter-notebook:toggle-all-line-numbers']],
          ['<add_celltoolbar_reminder>']
         ];
         this.construct(grps);

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -65,6 +65,7 @@ define(function (require) {
         this.ws_url = options.ws_url;
         this._session_starting = false;
         this.last_modified = null;
+        this.line_numbers = false;
         // debug 484
         this._last_modified = 'init';
         // Firefox workaround
@@ -552,6 +553,17 @@ define(function (require) {
         }
         return result;
     };
+    
+    /**
+     * Toggles the display of line numbers in all cells.
+     */
+    Notebook.prototype.toggle_all_line_numbers = function () {
+        this.line_numbers = !this.line_numbers;
+        var display = this.line_numbers;
+        this.get_cells().map(function(c) {
+            c.code_mirror.setOption('lineNumbers', display);
+        })
+    }
 
     /**
      * Get the cell above a given cell.


### PR DESCRIPTION
Hi! I'm a research apprentice at BIDS with Matthias (@ Carreau). This is for #1244.

Creates a button in the main toolbar that will toggle the line numbers on/off in all code cells. Future PR will have line numbering persist (i.e. new code cells will have line numbers turned on, if the user turned on line numbers for all cells).

![toggle-button](http://i.imgur.com/Ljqn55f.gif)
