### PR TITLE
Defer to default copy implementation when text is selected

### DIFF
--- a/notebook/static/notebook/js/clipboard.js
+++ b/notebook/static/notebook/js/clipboard.js
@@ -33,7 +33,9 @@ function load_json(clipboard) {
 }
 
 function copy(event) {
-  if (Jupyter.notebook.mode !== 'command') {
+  if ((Jupyter.notebook.mode !== 'command') ||
+        // window.getSelection checks if text is selected, e.g. in output
+        !window.getSelection().isCollapsed) {
     return;
   }
   var selecn = Jupyter.notebook.get_selected_cells().map(


### PR DESCRIPTION
Closes gh-1316

We already checked that the notebook is in command mode before copying cells, but if there is text selected in output, we should let the browser copy that rather than copying the cells.