### PR TITLE
Fix handling of preflight requests

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -387,7 +387,6 @@ class APIHandler(IPythonHandler):
         self.set_header('Content-Type', 'application/json')
         return super(APIHandler, self).finish(*args, **kwargs)
 
-    @web.authenticated
     def options(self, *args, **kwargs):
         self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
         self.set_header('Access-Control-Allow-Methods',


### PR DESCRIPTION
Hi,

I believe I've found a bug in the way that OPTIONS requests are handled by the notebook server. Pre-flighted OPTIONS requests do not include authentication information, which means that we should not expect these to be authenticated and so should not be using the @web.authenticated decorator. Authentication will be validated when the real PUT/POST etc request is issued after the preflight.

FWIW this behaviour is documented by others in different contexts (see for example: http://giix.nl/2015/03/10/cross-origin-resource-sharing-cors-and-kerberos-webserver-auth/).

Thanks,

Carl

P.S. to provide some context, in our environment, we use Kerberos for authenticating against the notebook server to provide single sign-on, and we're working on developing a tool that uses jupyter-js-services to programatically launch kernels via the notebook server and run commands on them. This mostly works great except when the js-services API initiates a POST request with content-type of application/json. The CORS specification dictates that these requests must be pre-flighted, and because the pre-flighted OPTIONS request does not include authenticating material it gets rejected.