### PR TITLE
avoid writing nbextension config to user dir during tests

### DIFF
--- a/notebook/tests/test_nbextensions.py
+++ b/notebook/tests/test_nbextensions.py
@@ -76,19 +76,24 @@ class TestInstallNBExtension(TestCase):
                 os.makedirs(parent)
             touch(fullpath)
         
-        self.data_dir = self.tempdir()
-        self.patch_data = patch.object(nbextensions,
-            'jupyter_data_dir', lambda : self.data_dir)
-        self.patch_data.start()
-        self.system_path = [self.tempdir()]
-        self.system_nbext = pjoin(self.system_path[0], 'nbextensions')
-        self.patch_system_data = patch.object(nbextensions,
+        self.test_dir = self.tempdir()
+        self.data_dir = os.path.join(self.test_dir, 'data')
+        self.config_dir = os.path.join(self.test_dir, 'config')
+        self.system_data_dir = os.path.join(self.test_dir, 'system_data')
+        self.system_path = [self.system_data_dir]
+        self.system_nbext = os.path.join(self.system_data_dir, 'nbextensions')
+        self.patch_env = patch.dict('os.environ', {
+            'JUPYTER_CONFIG_DIR': self.config_dir,
+            'JUPYTER_DATA_DIR': self.data_dir,
+        })
+        self.patch_env.start()
+        self.patch_system_path = patch.object(nbextensions,
             'SYSTEM_JUPYTER_PATH', self.system_path)
-        self.patch_system_data.start()
+        self.patch_system_path.start()
     
     def tearDown(self):
-        self.patch_data.stop()
-        self.patch_system_data.stop()
+        self.patch_env.stop()
+        self.patch_system_path.stop()
 
     def assert_dir_exists(self, path):
         if not os.path.exists(path):
@@ -120,18 +125,20 @@ class TestInstallNBExtension(TestCase):
     def test_create_data_dir(self):
         """install_nbextension when data_dir doesn't exist"""
         with TemporaryDirectory() as td:
-            self.data_dir = pjoin(td, u'jupyter_data')
-            install_nbextension(self.src, user=True)
-            self.assert_dir_exists(self.data_dir)
-            for file in self.files:
-                self.assert_installed(
-                    pjoin(basename(self.src), file),
-                    user=True,
-                )
+            data_dir = os.path.join(td, self.data_dir)
+            with patch.dict('os.environ', {
+                'JUPYTER_DATA_DIR': data_dir,
+            }):
+                install_nbextension(self.src, user=True)
+                self.assert_dir_exists(data_dir)
+                for file in self.files:
+                    self.assert_installed(
+                        pjoin(basename(self.src), file),
+                        user=True,
+                    )
     
     def test_create_nbextensions_user(self):
         with TemporaryDirectory() as td:
-            self.data_dir = pjoin(td, u'jupyter_data')
             install_nbextension(self.src, user=True)
             self.assert_installed(
                 pjoin(basename(self.src), u'ƒile'),

--- a/notebook/tests/test_serverextensions.py
+++ b/notebook/tests/test_serverextensions.py
@@ -1,9 +1,18 @@
+import os
 from unittest import TestCase
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch # py2
+
+from ipython_genutils.tempdir import TemporaryDirectory
+from ipython_genutils import py3compat
 
 from traitlets.config.manager import BaseJSONConfigManager
 from traitlets.tests.utils import check_help_all_output
 
 from notebook.serverextensions import toggle_serverextension_python
+from notebook import nbextensions
 from notebook.nbextensions import _get_config_dir
 
 
@@ -16,6 +25,34 @@ def test_help_output():
 
 
 class TestInstallServerExtension(TestCase):
+    
+    def tempdir(self):
+        td = TemporaryDirectory()
+        self.tempdirs.append(td)
+        return py3compat.cast_unicode(td.name)
+
+    def setUp(self):
+        self.tempdirs = []
+
+        self.test_dir = self.tempdir()
+        self.data_dir = os.path.join(self.test_dir, 'data')
+        self.config_dir = os.path.join(self.test_dir, 'config')
+        self.system_data_dir = os.path.join(self.test_dir, 'system_data')
+        self.system_path = [self.system_data_dir]
+        
+        self.patch_env = patch.dict('os.environ', {
+            'JUPYTER_CONFIG_DIR': self.config_dir,
+            'JUPYTER_DATA_DIR': self.data_dir,
+        })
+        self.patch_env.start()
+        self.patch_system_path = patch.object(nbextensions,
+            'SYSTEM_JUPYTER_PATH', self.system_path)
+        self.patch_system_path.start()
+    
+    def tearDown(self):
+        self.patch_env.stop()
+        self.patch_system_path.stop()
+
     def _inject_mock_extension(self):
         outer_file = __file__
 


### PR DESCRIPTION
mock jupyter environment variables during nb/server-extension tests