### PR TITLE
remove what's new from index

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,12 @@ Jupyter notebook changelog
 A summary of changes in the Jupyter notebook.
 For more detailed information, see `GitHub <https://github.com/jupyter/notebook>`__.
 
+.. tip::
+
+     Use ``pip install notebook --upgrade`` or ``conda upgrade notebook`` to
+     upgrade to the latest release.
+
+
 .. _release-4.2.0:
 
 4.2.0

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,22 +2,6 @@
 The Jupyter notebook
 ====================
 
-.. sidebar:: What's New in Jupyter Notebook
-   :subtitle: Release :ref:`release-4.1.0`
-
-   `Release Announcement <https://blog.jupyter.org/2016/01/08/notebook-4-1-release/>`_
-
-   - Cell toolbar selector moved to View menu
-   - Restart & Run All Cells added to Kernel menu
-   - Multiple-cell selection and actions including cut, copy, paste and execute
-   - Command palette added for executing Jupyter actions
-   - Find and replace added to Edit menu
-
-   To upgrade to the release:
-   ``pip install notebook --upgrade``
-   or
-   ``conda upgrade notebook``
-
 .. toctree::
    :maxdepth: 1
    :caption: User Documentation


### PR DESCRIPTION
use |release| variable to ensure correct value.

move 4.1 release announcement link to 4.1 changelog, away from index.