### PR TITLE
pin casper to 1.1.0-beta5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
     - nvm install 5.6
     - nvm use 5.6
     - npm upgrade -g npm
-    - 'if [[ $GROUP == js* ]]; then  npm install -g casperjs; fi'
+    - 'if [[ $GROUP == js* ]]; then  npm install -g casperjs@1.1.0-beta5; fi'
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 
 install:


### PR DESCRIPTION
to see if this fixes the shutdown test failure

If this works, we can get tests back to passing on master while we figure out what's up with casper in another PR.