### PR TITLE
Dockerfile: Added --no-browser argument to CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,4 +109,4 @@ WORKDIR /notebooks
 EXPOSE 8888
 
 ENTRYPOINT ["tini", "--"]
-CMD ["jupyter", "notebook"]
+CMD ["jupyter", "notebook", "--no-browser"]


### PR DESCRIPTION
The docker images doesn't contain any browsers, therefore there is no need for trying to launch a browser within the docker container.