### PR TITLE
Make JupyterLab more self contained

### DIFF
--- a/notebook/lab/index.js
+++ b/notebook/lab/index.js
@@ -2,6 +2,8 @@
 // Distributed under the terms of the Modified BSD License.
 'use strict';
 
+// Load CSS.
+require('font-awesome/css/font-awesome.min.css');
 require('jupyter-js-plugins/lib/default-theme/index.css');
 
 // ES6 Promise polyfill

--- a/notebook/lab/index.js
+++ b/notebook/lab/index.js
@@ -4,7 +4,8 @@
 
 require('jupyter-js-plugins/lib/default-theme/index.css');
 
-require('es6-promise');  // Polyfill for IE11
+// ES6 Promise polyfill
+require('es6-promise').polyfill();
 
 var phosphide = require('phosphide/lib/core/application');
 

--- a/notebook/lab/index.js
+++ b/notebook/lab/index.js
@@ -4,6 +4,8 @@
 
 require('jupyter-js-plugins/lib/default-theme/index.css');
 
+require('es6-promise');  // Polyfill for IE11
+
 var phosphide = require('phosphide/lib/core/application');
 
 var app = new phosphide.Application({

--- a/notebook/lab/package.json
+++ b/notebook/lab/package.json
@@ -6,12 +6,12 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "dependencies": {
+    "es6-promise": "^3.1.2",
     "jupyter-js-plugins": "^0.11.8",
     "phosphide": "^0.9.0"
   },
   "devDependencies": {
     "css-loader": "^0.23.1",
-    "es6-promise": "^3.1.2",
     "file-loader": "^0.8.5",
     "json-loader": "^0.5.4",
     "rimraf": "^2.5.0",

--- a/notebook/lab/package.json
+++ b/notebook/lab/package.json
@@ -7,6 +7,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "es6-promise": "^3.1.2",
+    "font-awesome": "^4.6.1",
     "jupyter-js-plugins": "^0.11.8",
     "phosphide": "^0.9.0"
   },

--- a/notebook/lab/package.json
+++ b/notebook/lab/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "css-loader": "^0.23.1",
-    "es6-promise": "^3.0.2",
+    "es6-promise": "^3.1.2",
     "file-loader": "^0.8.5",
     "json-loader": "^0.5.4",
     "rimraf": "^2.5.0",

--- a/notebook/templates/lab.html
+++ b/notebook/templates/lab.html
@@ -6,8 +6,6 @@
 
     <title>{{page_title}}</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <link rel="stylesheet" type="text/css" href="{{static_url("components/font-awesome/css/font-awesome.css")}}"></link>
-    <script src="{{static_url("components/es6-promise/promise.min.js")}}" type="text/javascript" charset="utf-8"></script>
     <script src="{{static_url("components/requirejs/require.js") }}" type="text/javascript" charset="utf-8"></script>
     <script>
       require.config({


### PR DESCRIPTION
Moves the ES6 promise polyfill, and font-awesome from the template to the webpack bundle.

We are still using MathJax and requirejs from bower.  It makes sense to only have one copy of MathJax in the repository since it is so big, and we'd might as well keep the known path to requirejs. 