### PR TITLE
Escape file names in attachment headers

### DIFF
--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -7,7 +7,7 @@ import io
 import os
 import zipfile
 
-from tornado import web
+from tornado import web, escape
 
 from ..base.handlers import (
     IPythonHandler, FilesRedirectHandler,
@@ -38,7 +38,7 @@ def respond_zip(handler, name, output, resources):
     # Headers
     zip_filename = os.path.splitext(name)[0] + '.zip'
     handler.set_header('Content-Disposition',
-                       'attachment; filename="%s"' % zip_filename)
+                       'attachment; filename="%s"' % escape.url_escape(zip_filename))
     handler.set_header('Content-Type', 'application/zip')
 
     # Prepare the zip file
@@ -112,7 +112,7 @@ class NbconvertFileHandler(IPythonHandler):
         if self.get_argument('download', 'false').lower() == 'true':
             filename = os.path.splitext(name)[0] + resources['output_extension']
             self.set_header('Content-Disposition',
-                               'attachment; filename="%s"' % filename)
+                               'attachment; filename="%s"' % escape.url_escape(filename))
 
         # MIME type
         if exporter.output_mimetype:


### PR DESCRIPTION
When there are non-ascii characters in notebook file name, i.e., "文件名.ipynb", notebooks cannot be properly downloaded via configurable-http-proxy in [JupyterHub](https://github.com/jupyter/jupyterhub) and an HPE_INVALID_HEADER_TOKEN is reported. After I inspect the headers returned by the notebook, I find that the file name in Content-Disposition header is not escaped, which cause the error in [request module](https://github.com/request/request) of node.js. After escaping the file names, the bug is resolved.