### PR TITLE
Override mimetype for .css files

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -12,6 +12,7 @@ import importlib
 import io
 import json
 import logging
+import mimetypes
 import os
 import random
 import re
@@ -1115,7 +1116,14 @@ class NotebookApp(JupyterApp):
                         raise
                     self.log.warning("Error loading server extension %s", modulename,
                                   exc_info=True)
-    
+
+    def init_mime_overrides(self):
+        # On some Windows machines, an application has registered an incorrect
+        # mimetype for CSS in the registry. Tornado uses this when serving
+        # .css files, causing browsers to reject the stylesheet. We know the
+        # mimetype always needs to be text/css, so we override it here.
+        mimetypes.add_type('text/css', '.css')
+
     @catch_config_error
     def initialize(self, argv=None):
         super(NotebookApp, self).initialize(argv)
@@ -1128,6 +1136,7 @@ class NotebookApp(JupyterApp):
         self.init_terminals()
         self.init_signal()
         self.init_server_extensions()
+        self.init_mime_overrides()
 
     def cleanup_kernels(self):
         """Shutdown all kernels.


### PR DESCRIPTION
This should avoid the issue several people have had with unstyled pages on misconfigured Windows systems. I think practicality beats purity here.

Closes gh-1350