### PR TITLE
Enable older version of ipywidgets on notebook 4.2

### DIFF
--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -162,6 +162,22 @@
               }
           },
       });
+
+      define("bootstrap", function () {
+          return window.$;
+      });
+
+      define("jquery", function () {
+          return window.$;
+      });
+
+      define("jqueryui", function () {
+          return window.$;
+      });
+
+      define("jquery-ui", function () {
+          return window.$;
+      });
     </script>
 
     {% block meta %}


### PR DESCRIPTION
Fixes #1386.

@minrk  This makes it work but I can't believe this is the best way to do this.