### PR TITLE
Configurable MathJax config

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -160,6 +160,10 @@ class IPythonHandler(AuthenticatedHandler):
         return url_path_join(self.base_url, url)
     
     @property
+    def mathjax_config(self):
+        return self.settings.get('mathjax_config', 'TeX-AMS_HTML-full,Safe')
+
+    @property
     def base_url(self):
         return self.settings.get('base_url', '/')
 

--- a/notebook/lab/handlers.py
+++ b/notebook/lab/handlers.py
@@ -17,7 +17,8 @@ class LabHandler(IPythonHandler):
         self.write(self.render_template('lab.html',
             page_title='Jupyter Lab',
             terminals_available=self.settings['terminals_available'],
-            mathjax_url=self.mathjax_url))
+            mathjax_url=self.mathjax_url,
+            mathjax_config=self.mathjax_config))
 
 #-----------------------------------------------------------------------------
 # URL to handler mappings

--- a/notebook/notebook/handlers.py
+++ b/notebook/notebook/handlers.py
@@ -40,6 +40,7 @@ class NotebookHandler(IPythonHandler):
             notebook_name=name,
             kill_kernel=False,
             mathjax_url=self.mathjax_url,
+            mathjax_config=self.mathjax_config
             )
         )
 

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -238,6 +238,7 @@ class NotebookWebApplication(web.Application):
             nbextensions_path=ipython_app.nbextensions_path,
             websocket_url=ipython_app.websocket_url,
             mathjax_url=ipython_app.mathjax_url,
+            mathjax_config=ipython_app.mathjax_config,
             config=ipython_app.config,
             config_dir=ipython_app.config_dir,
             jinja2_env=env,
@@ -727,6 +728,15 @@ class NotebookApp(JupyterApp):
             self.mathjax_url = u''
         else:
             self.log.info("Using MathJax: %s", new)
+
+    mathjax_config = Unicode("", config=True,
+        help="""The MathJax.js configuration file that is to be used."""
+    )
+    def _mathjax_config_default(self):
+        return 'TeX-AMS_HTML-full,Safe'
+
+    def _mathjax_config_changed(self, name, old, new):
+        self.log.info("Using MathJax configuration file: %s", new)
 
     contents_manager_class = Type(
         default_value=FileContentsManager,

--- a/notebook/templates/lab.html
+++ b/notebook/templates/lab.html
@@ -79,7 +79,7 @@
     {% endblock %}
 
     {% if mathjax_url %}
-    <script type="text/javascript" src="{{mathjax_url}}?config=TeX-AMS_HTML-full,Safe&amp;delayStartupUntil=configured" charset="utf-8"></script>
+    <script type="text/javascript" src="{{mathjax_url}}?config={{mathjax_config}}&amp;delayStartupUntil=configured" charset="utf-8"></script>
     {% endif %}
 
 </head>

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -3,7 +3,7 @@
 {% block stylesheet %}
 
 {% if mathjax_url %}
-<script type="text/javascript" src="{{mathjax_url}}?config=TeX-AMS_HTML-full,Safe&delayStartupUntil=configured" charset="utf-8"></script>
+<script type="text/javascript" src="{{mathjax_url}}?config={{mathjax_config}}&delayStartupUntil=configured" charset="utf-8"></script>
 {% endif %}
 <script type="text/javascript">
 // MathJax disabled, set as null to distingish from *missing* MathJax,


### PR DESCRIPTION
MathJax supports different combined configuration modes, like TeX-MML-AM_HTMLorMML or TeX-MML-AM_SVG (http://docs.mathjax.org/en/latest/config-files.html). Currently, Jupyter hard codes "TeX-AMS_HTML-full" in its notebook.html template. This makes it difficult for experimental Jupyter kernels which need or are designed around other modes (like MML, i.e. MathML).

In the long run, it would be great if Jupyter had a kernel specific MathJax setting in this regard. This, however, is beyond my capabilities and I guess it would be a rather big change, since MathJax config need to be stored statically on the server side.

What I'm suggesting in this pull request therefore is to make the MathJax config mode configurable via the Jupyter config file, so developers can easily work with their experimental kernels in the needed MathJax mode without having to patch the Jupyter source code. They still need to provide their custom MathJax config files in notebook/static/components/MathJax/config, but this is easier, and so the change would still be of great utility.

