### PR TITLE
Add PERMITTED_MIMETYPES to mimetype check

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -52,6 +52,10 @@ define([
             'sort-name': 0
         };
         this._max_upload_size_mb = 25;
+        this.PERMITTED_MIMETYPES = [
+          'application/javascipt',
+          'application/x-sh',
+        ];
     };
 
     NotebookList.prototype.style = function () {
@@ -646,9 +650,9 @@ define([
         }
         var uri_prefix = NotebookList.uri_prefixes[model.type];
         if (model.type === 'file' &&
-            model.mimetype && model.mimetype.substr(0,5) !== 'text/'
-            && !model.mimetype.endsWith('javascript')
-        ) {
+            model.mimetype &&
+            (model.mimetype.substr(0, 5) !== 'text/' ||
+            PERMITTED_MIMETYPES.indexOf(model.mimetype) < 0)) {
             // send text/unidentified files to editor, others go to raw viewer
             uri_prefix = 'files';
         }

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -52,7 +52,7 @@ define([
             'sort-name': 0
         };
         this._max_upload_size_mb = 25;
-        this.PERMITTED_MIMETYPES = [
+        this.EDIT_MIMETYPES = [
           'application/javascipt',
           'application/x-sh',
         ];
@@ -652,7 +652,7 @@ define([
         if (model.type === 'file' &&
             model.mimetype &&
             (model.mimetype.substr(0, 5) !== 'text/' ||
-            PERMITTED_MIMETYPES.indexOf(model.mimetype) < 0)) {
+            EDIT_MIMETYPES.indexOf(model.mimetype) < 0)) {
             // send text/unidentified files to editor, others go to raw viewer
             uri_prefix = 'files';
         }


### PR DESCRIPTION
This is a follow up to #1143 and #1408.

I think the easiest and most scalable solution would be to set up a PERMITTED_MIMETYPES array that we can add strange but editable mime types to. We can build the download and edit functionality on top of this.

cc: @takluyver @minrk 