### PR TITLE
log exceptions in nbconvert handlers

### DIFF
--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -8,6 +8,7 @@ import os
 import zipfile
 
 from tornado import web, escape
+from tornado.log import app_log
 
 from ..base.handlers import (
     IPythonHandler, FilesRedirectHandler,
@@ -70,6 +71,7 @@ def get_exporter(format, **kwargs):
     try:
         return Exporter(**kwargs)
     except Exception as e:
+        app_log.exception("Could not construct Exporter: %s", Exporter)
         raise web.HTTPError(500, "Could not construct Exporter: %s" % e)
 
 class NbconvertFileHandler(IPythonHandler):
@@ -103,6 +105,7 @@ class NbconvertFileHandler(IPythonHandler):
                 }
             )
         except Exception as e:
+            self.log.exception("nbconvert failed: %s", e)
             raise web.HTTPError(500, "nbconvert failed: %s" % e)
 
         if respond_zip(self, name, output, resources):


### PR DESCRIPTION
when nbconvert fails, log the traceback

cc @janschulz who reported this [on conda-forge](https://github.com/conda-forge/nbconvert-feedstock/issues/3#issuecomment-216256276)