### PR TITLE
[WIP] Toggle all line numbers, &  persist config 

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -456,6 +456,14 @@ define(function(require){
                 env.notebook.show_command_palette();
             }
         },
+        'toggle-all-line-numbers': {
+            help : 'toggles line numbers in all cells',
+            icon: 'fa-list-ol',
+            handler: function(env) {
+                console.log('calling function');
+                env.notebook.toggle_all_line_numbers();
+            }
+        },
         'toggle-toolbar':{
             help: 'hide/show the toolbar',
             handler : function(env){

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -456,12 +456,23 @@ define(function(require){
                 env.notebook.show_command_palette();
             }
         },
+        'show-all-line-numbers': {
+            help : 'show line numbers in all cells, and persist the setting',
+            handler: function(env) {
+                env.notebook.line_numbers = true;
+            }
+        },
+        'hide-all-line-numbers': {
+            help : 'hide line numbers in all cells, and persist the setting',
+            handler: function(env) {
+                env.notebook.line_numbers = false;
+            }
+        },
         'toggle-all-line-numbers': {
-            help : 'toggles line numbers in all cells',
+            help : 'toggles line numbers in all cells, and persist the setting',
             icon: 'fa-list-ol',
             handler: function(env) {
-                console.log('calling function');
-                env.notebook.toggle_all_line_numbers();
+                env.notebook.line_numbers = !env.notebook.line_numbers;
             }
         },
         'toggle-toolbar':{

--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -14,8 +14,9 @@ define([
     'codemirror/lib/codemirror',
     'codemirror/addon/edit/matchbrackets',
     'codemirror/addon/edit/closebrackets',
-    'codemirror/addon/comment/comment'
-], function(utils, CodeMirror, cm_match, cm_closeb, cm_comment) {
+    'codemirror/addon/comment/comment',
+    'services/config',
+], function(utils, CodeMirror, cm_match, cm_closeb, cm_comment, configmod) {
     "use strict";
     
     var overlayHack = CodeMirror.scrollbarModel.native.prototype.overlayHack;
@@ -87,7 +88,12 @@ define([
         if(this.class_config){
             _local_cm_config = this.class_config.get_sync('cm_config');
         }
-        config.cm_config = utils.mergeopt({}, config.cm_config, _local_cm_config);
+        
+        var local = new configmod.ConfigWithDefaults(options.config,
+            {}, 'Cell');
+        var llcm = local.get_sync('cm_config');
+
+        config.cm_config = utils.mergeopt({}, config.cm_config, utils.mergeopt({}, llcm, _local_cm_config));
         this.cell_id = utils.uuid();
         this._options = config;
 

--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -108,7 +108,7 @@ define([
         this.completer = null;
 
         Cell.apply(this,[{
-            config: $.extend({}, CodeCell.options_default), 
+            config: options.config, 
             keyboard_manager: options.keyboard_manager, 
             events: this.events}]);
 

--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -159,6 +159,7 @@ define([
             'o' : 'jupyter-notebook:toggle-cell-output-collapsed',
             's' : 'jupyter-notebook:save-notebook',
             'l' : 'jupyter-notebook:toggle-cell-line-numbers',
+            'shift-l' : 'jupyter-notebook:toggle-all-line-numbers',
             'h' : 'jupyter-notebook:show-keyboard-shortcuts',
             'z' : 'jupyter-notebook:undo-cell-deletion',
             'q' : 'jupyter-notebook:close-pager',

--- a/notebook/static/notebook/js/maintoolbar.js
+++ b/notebook/static/notebook/js/maintoolbar.js
@@ -55,7 +55,6 @@ define([
             'run_int'],
          ['<add_celltype_list>'],
          [['jupyter-notebook:show-command-palette']],
-         [['jupyter-notebook:toggle-all-line-numbers']],
          ['<add_celltoolbar_reminder>']
         ];
         this.construct(grps);

--- a/notebook/static/notebook/js/maintoolbar.js
+++ b/notebook/static/notebook/js/maintoolbar.js
@@ -55,6 +55,7 @@ define([
             'run_int'],
          ['<add_celltype_list>'],
          [['jupyter-notebook:show-command-palette']],
+         [['jupyter-notebook:toggle-all-line-numbers']],
          ['<add_celltoolbar_reminder>']
         ];
         this.construct(grps);

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -210,6 +210,7 @@ define([
             '#move_cell_up': 'move-cell-up',
             '#move_cell_down': 'move-cell-down',
             '#toggle_header': 'toggle-header',
+            '#toggle_all_line_numbers': 'toggle-all-line-numbers',
             '#toggle_toolbar': 'toggle-toolbar',
             '#insert_cell_above': 'insert-cell-above',
             '#insert_cell_below': 'insert-cell-below',

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -65,7 +65,6 @@ define(function (require) {
         this.ws_url = options.ws_url;
         this._session_starting = false;
         this.last_modified = null;
-        this.line_numbers = false;
         // debug 484
         this._last_modified = 'init';
         // Firefox workaround
@@ -161,9 +160,26 @@ define(function (require) {
         slideshow_celltoolbar.register(this);
         attachments_celltoolbar.register(this);
 
+        var that = this;
+
+        Object.defineProperty(this, 'line_numbers', {
+          get: function(){
+            var d = that.config.data||{}
+            var cmc =  (d['Cell']||{})['cm_config']||{}
+            return cmc['lineNumbers'] || false;
+          },
+          set: function(value){
+            this.get_cells().map(function(c) {
+              c.code_mirror.setOption('lineNumbers', value);
+            })
+            that.config.update({'Cell':{'cm_config':{'lineNumbers':value}}})
+          }
+          
+        })
         // prevent assign to miss-typed properties.
         Object.seal(this);
     };
+
 
 
     Notebook.options_default = {
@@ -559,10 +575,6 @@ define(function (require) {
      */
     Notebook.prototype.toggle_all_line_numbers = function () {
         this.line_numbers = !this.line_numbers;
-        var display = this.line_numbers;
-        this.get_cells().map(function(c) {
-            c.code_mirror.setOption('lineNumbers', display);
-        })
     }
 
     /**

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -65,6 +65,7 @@ define(function (require) {
         this.ws_url = options.ws_url;
         this._session_starting = false;
         this.last_modified = null;
+        this.line_numbers = false;
         // debug 484
         this._last_modified = 'init';
         // Firefox workaround
@@ -552,6 +553,17 @@ define(function (require) {
         }
         return result;
     };
+    
+    /**
+     * Toggles the display of line numbers in all cells.
+     */
+    Notebook.prototype.toggle_all_line_numbers = function () {
+        this.line_numbers = !this.line_numbers;
+        var display = this.line_numbers;
+        this.get_cells().map(function(c) {
+            c.code_mirror.setOption('lineNumbers', display);
+        })
+    }
 
     /**
      * Get the cell above a given cell.

--- a/notebook/static/notebook/js/textcell.js
+++ b/notebook/static/notebook/js/textcell.js
@@ -56,7 +56,7 @@ define([
         // we cannot put this as a class key as it has handle to "this".
         var config = utils.mergeopt(TextCell, this.config);
         Cell.apply(this, [{
-                    config: config, 
+                    config: options.config, 
                     keyboard_manager: options.keyboard_manager, 
                     events: this.events}]);
 
@@ -279,7 +279,7 @@ define([
         var config = utils.mergeopt(MarkdownCell, {});
         this.class_config = new configmod.ConfigWithDefaults(options.config,
                                             {}, 'MarkdownCell');
-        TextCell.apply(this, [$.extend({}, options, {config: config})]);
+        TextCell.apply(this, [$.extend({}, options, {config: options.config})]);
 
         this.cell_type = 'markdown';
     };
@@ -492,7 +492,7 @@ define([
          */
         options = options || {};
         var config = utils.mergeopt(RawCell, {});
-        TextCell.apply(this, [$.extend({}, options, {config: config})]);
+        TextCell.apply(this, [$.extend({}, options, {config: options.config})]);
 
         this.class_config = new configmod.ConfigWithDefaults(options.config,
                                             RawCell.config_defaults, 'RawCell');

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -154,13 +154,19 @@ data-notebook-path="{{notebook_path | urlencode}}"
                     <ul id="view_menu" class="dropdown-menu">
                         <li id="toggle_header"
                             title="Show/Hide the logo and notebook title (above menu bar)">
-                            <a href="#">Toggle Header</a></li>
+                            <a href="#">Toggle Header</a>
+                        </li>
                         <li id="toggle_toolbar"
                             title="Show/Hide the action icons (below menu bar)">
-                            <a href="#">Toggle Toolbar</a></li>
+                            <a href="#">Toggle Toolbar</a>
+                        </li>
                         <li id="menu-cell-toolbar" class="dropdown-submenu">
                             <a href="#">Cell Toolbar</a>
                             <ul class="dropdown-menu" id="menu-cell-toolbar-submenu"></ul>
+                        </li>
+                        <li id="toggle_all_line_numbers"
+                            title="Toggle all line numbers">
+                            <a href="#">Toggle Line Numbers</a>
                         </li>
                     </ul>
                 </li>


### PR DESCRIPTION
Add 3 actions `show all`,`hide all`, `toggle`, expose toggle in the menu. 

Persist state to nbconfig. Also improve the config so that config option set on `Cell` apply to MD/Code/Raw unless overwritten. By a more specific config. 

Thus the line-numbering state is stored as:

```
{
  "Cell": { 
    "cm_config": {
      "lineNumbers": false
    }
  }
}
```