### PR TITLE
MathML support for MathJax and complete configuration through kernel

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -78,7 +78,12 @@ define(function (require) {
         this.keyboard_manager.notebook = this;
         this.save_widget.notebook = this;
         
-        mathjaxutils.init();
+        var notebook = this;
+        this.events.on('kernel_connected.Kernel', function () {
+            notebook.kernel.kernel_info(function (data) {
+                mathjaxutils.init(data);
+            });
+        });
 
         if (marked) {
             marked.setOptions({

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -3,7 +3,7 @@
 {% block stylesheet %}
 
 {% if mathjax_url %}
-<script type="text/javascript" src="{{mathjax_url}}?config=TeX-AMS_HTML-full,Safe&delayStartupUntil=configured" charset="utf-8"></script>
+<script type="text/javascript" src="{{mathjax_url}}?delayStartupUntil=configured" charset="utf-8"></script>
 {% endif %}
 <script type="text/javascript">
 // MathJax disabled, set as null to distingish from *missing* MathJax,

--- a/setupbase.py
+++ b/setupbase.py
@@ -157,6 +157,7 @@ def find_package_data():
     static_data.extend([
         mj('MathJax.js'),
         mj('config', 'TeX-AMS_HTML-full.js'),
+        mj('config', 'MML_HTMLorMML-full.js'),
         mj('config', 'Safe.js'),
     ])
     
@@ -176,6 +177,7 @@ def find_package_data():
         mj('fonts', 'HTML-CSS', 'STIX-Web', 'woff'),
         mj('extensions'),
         mj('jax', 'input', 'TeX'),
+        mj('jax', 'input', 'MathML'),
         mj('jax', 'output', 'HTML-CSS', 'fonts', 'STIX-Web'),
         mj('jax', 'output', 'SVG', 'fonts', 'STIX-Web'),
     ]:


### PR DESCRIPTION
This change adds MathML as an input format option to Jupyter's MathJax and, more importantly, a future proof way for kernels to completely configure MathJax to their specific needs.

MathML as an alternative input to the Jupyter defined default TeX input is necessary for kernels like Mathics (https://github.com/mathics/Mathics) which output everything as MathML and do complex reshuffling of the MathML XML nodes that is not possible on a TeX input layer (like having pictures and svgs in the exponents of a formula). In addition, MathML should really be an input option for kernels which opt for that format.

I recently created a PR for Jupyter 5 trying to solve this MathJax configuration via a config file entry (https://github.com/jupyter/notebook/pull/1409) and it was a start, but this solution now proposed is, I believe, the proper and correct one. @minrk, I'm sorry for starting that former change without trying to fix the problem in the correct way first.

With this new PR, MathJax is not configured until the kernel has been asked which MathJax configuration it really needs. After a kernel has provided that information via kernel_info (see addition of mathjax in kernel_info proposed at https://github.com/jupyter/jupyter_client/pull/161), MathJax is then configured for that kernel. If the kernel does not provide any information, the standard Jupyter configuration is used. 

Since MathJax was already configured to initialize late (though the call of MathJax.Hub.Configured()), the delayed init is not a problem implementation-wise.

The one drawback of this PR for Python and TeX-mode MathJax users will be though that MathJax will only be loaded after the kernel has started up and provided its info. Currently, MathJax is loaded instantly (through the script tag in the notebook html template), thus rendering happens instantly. With the new solution, rendering can be delayed for a couple of seconds until the kernel is up and running.

The configuration happens in a differential way. Jupyter sets a default configuration, then everything the kernel delivers as configuration is merged into this default configuration.

MathML support is provided through changing setupbase.py and adding the necessary files for MathML input.