### PR TITLE
typeahead.min.js (not typeahead.js)

### DIFF
--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -20,7 +20,7 @@
     <script src="{{static_url("components/jquery-ui/ui/minified/jquery-ui.min.js") }}" type="text/javascript" charset="utf-8"></script> <!-- extends window.$ -->
     <script src="{{static_url("components/bootstrap/js/bootstrap.min.js") }}" type="text/javascript" charset="utf-8"></script> <!-- extends window.$ -->
     <script src="{{static_url("components/bootstrap-tour/build/js/bootstrap-tour.min.js") }}" type="text/javascript" charset="utf-8"></script> <!-- window.Tour -->
-    <script src="{{static_url("components/jquery-typeahead/dist/jquery.typeahead.js") }}" type="text/javascript" charset="utf-8"></script> <!-- extends window.$ -->
+    <script src="{{static_url("components/jquery-typeahead/dist/jquery.typeahead.min.js") }}" type="text/javascript" charset="utf-8"></script> <!-- extends window.$ -->
     <script src="{{static_url("components/requirejs/require.js") }}" type="text/javascript" charset="utf-8"></script>
     <script>
       window['staticURL'] = "{{static_url("", include_version=False)}}";


### PR DESCRIPTION
page.html was referring to typeahead.js, which does not exist in the dist build.