### PR TITLE
Allow root user to run tests.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Another Docker container should inherit with `FROM jupyter/notebook`
 # to run actual services.
 #
-# For opinionated stacks of ready-to-run Jupyter applications in Docker, 
+# For opinionated stacks of ready-to-run Jupyter applications in Docker,
 # check out docker-stacks <https://github.com/jupyter/docker-stacks>
 
 FROM jupyter/ubuntu_14_04_locale_fix
@@ -109,4 +109,4 @@ WORKDIR /notebooks
 EXPOSE 8888
 
 ENTRYPOINT ["tini", "--"]
-CMD ["jupyter", "notebook", "--no-browser"]
+CMD ["jupyter", "notebook", "--no-browser", "--allow-root"]

--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -34,7 +34,7 @@ class TimeoutError(Exception):
 
 class NotebookTestBase(TestCase):
     """A base class for tests that need a running notebook.
-    
+
     This create some empty config and runtime directories
     and then starts the notebook server with them.
     """
@@ -60,7 +60,7 @@ class NotebookTestBase(TestCase):
                 return
 
         raise TimeoutError("The notebook server didn't start up correctly.")
-    
+
     @classmethod
     def wait_until_dead(cls):
         """Wait for the server process to terminate after shutdown"""
@@ -85,7 +85,7 @@ class NotebookTestBase(TestCase):
         cls.data_dir = data_dir
         cls.runtime_dir = TemporaryDirectory()
         cls.notebook_dir = TemporaryDirectory()
-        
+
         started = Event()
         def start_thread():
             app = cls.notebook = NotebookApp(
@@ -98,6 +98,7 @@ class NotebookTestBase(TestCase):
                 notebook_dir=cls.notebook_dir.name,
                 base_url=cls.url_prefix,
                 config=cls.config,
+                allow_root=True,
             )
             # don't register signal handler during tests
             app.init_signal = lambda : None

--- a/notebook/tests/test_notebookapp.py
+++ b/notebook/tests/test_notebookapp.py
@@ -77,7 +77,7 @@ def test_nb_dir_root():
 def test_generate_config():
     with TemporaryDirectory() as td:
         app = NotebookApp(config_dir=td)
-        app.initialize(['--generate-config'])
+        app.initialize(['--generate-config', '--allow-root'])
         with nt.assert_raises(NoStart):
             app.start()
         assert os.path.exists(os.path.join(td, 'jupyter_notebook_config.py'))


### PR DESCRIPTION
There was a change to disallow root user to run the notebook server, which is all good, but it broke the Docker image build.  These changes enable the Docker image to build again.

FWIW, I'm not convinced that these changes should go in, or if the Dockerfile should get more love and run as a different user, like all the [docker-stacks](http://github.com/jupyter/docker-stacks) do.

Fixes #1056 