### PR TITLE
Fixes for reconnecting on a flaky network

### DIFF
--- a/notebook/static/notebook/js/notificationarea.js
+++ b/notebook/static/notebook/js/notificationarea.js
@@ -138,8 +138,7 @@ define([
             if (info.attempt === 1) {
 
                 var msg = "A connection to the notebook server could not be established." +
-                        " The notebook will continue trying to reconnect, but" +
-                        " until it does, you will NOT be able to run code. Check your" +
+                        " The notebook will continue trying to reconnect. Check your" +
                         " network connection or notebook server configuration.";
 
                 dialog.kernel_modal({

--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -338,7 +338,7 @@ define([
          * @function reconnect
          */
         if (this.is_connected()) {
-            return;
+            this.stop_channels();
         }
         this._reconnect_attempt = this._reconnect_attempt + 1;
         this.events.trigger('kernel_reconnecting.Kernel', {

--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -534,8 +534,13 @@ define([
 
         this.events.trigger('kernel_disconnected.Kernel', {kernel: this});
         if (error) {
-            console.log('WebSocket connection failed: ', ws_url);
-            this.events.trigger('kernel_connection_failed.Kernel', {kernel: this, ws_url: ws_url, attempt: this._reconnect_attempt});
+            console.log('WebSocket connection failed: ', ws_url, error);
+            this.events.trigger('kernel_connection_failed.Kernel', {
+                kernel: this,
+                ws_url: ws_url,
+                attempt: this._reconnect_attempt,
+                error: error,
+            });
         }
         this._schedule_reconnect();
     };

--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -638,8 +638,8 @@ define([
          */
         var msg = this._get_msg(msg_type, content, metadata, buffers);
         msg.channel = 'shell';
-        this._send(serialize.serialize(msg));
         this.set_callbacks_for_msg(msg.header.msg_id, callbacks);
+        this._send(serialize.serialize(msg));
         return msg.header.msg_id;
     };
 


### PR DESCRIPTION
Problem: When a client loses their websocket connection and then reconnects, this triggers the creation of new, identical zmq sockets with a collision in their routing IDENTITY. This causes messages to be lost, even though the websocket connection is established.

Fix: if a duplicate connection (same session id, same kernel id) is attempted, close the stale one.

My first thought was to refuse colliding connections, but for the most likely case of a flaky network where the earlier session hasn't been closed yet, this experience is quite unpleasant,
even though it *eventually* works itself out.

Smaller fixes along the way while working this out:

- `Kernel.reconnect()` always disconnects and reconnects, instead of being a no-op if it appears the connection is established. This would have been a mitigation for #1379 while we worked out the real fix.
- remove outdated "you will NOT be able to run code" message
  from connection-failed dialog. This is a reference to ignored execute
  requests, which are fixed by the pending-message queue in 4.2

closes #1379

cc @aggFTW, @willingc, @ellisonbg

Thanks for your patience!