### PR TITLE
Don't require patch coverage for CI

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,5 +6,4 @@ coverage:
         threshold: 10
     patch:
       default:
-        target: auto
-        threshold: 10
+        target: 0%


### PR DESCRIPTION
Keep it running so the number is visible, but don't use it as a CI criterion.