### PR TITLE
Allow requests to POST in OPTIONS requests

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -390,7 +390,7 @@ class APIHandler(IPythonHandler):
     def options(self, *args, **kwargs):
         self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
         self.set_header('Access-Control-Allow-Methods',
-                        'GET, PUT, PATCH, DELETE, OPTIONS')
+                        'GET, PUT, POST, PATCH, DELETE, OPTIONS')
         self.finish()
 
 


### PR DESCRIPTION
Commit 65eb248209b5fdc9d1d430c0403fc6bfee1057f4 introduced a bug by not allowing the POST method in OPTIONS requests (which is wrong since several parts of the API accept POST requests, for example creating a new kernel).