### PR TITLE
reverse nbconfig load order

### DIFF
--- a/notebook/services/config/manager.py
+++ b/notebook/services/config/manager.py
@@ -19,11 +19,12 @@ class ConfigManager(LoggingConfigurable):
     def get(self, section_name):
         """Get the config from all config sections."""
         config = {}
-        for p in self.read_config_path:
+        # step through back to front, to ensure front of the list is top priority
+        for p in self.read_config_path[::-1]:
             cm = BaseJSONConfigManager(config_dir=p)
             recursive_update(config, cm.get(section_name))
         return config
-            
+
     def set(self, section_name, data):
         """Set the config only to the user's config."""
         return self.write_config_manager.set(section_name, data)


### PR DESCRIPTION
list is in descending priority, so load should iterate back to front, to ensure user config wins

the easy part of #1508