### PR TITLE
Allow completion picking by clicking option.

### DIFF
--- a/notebook/static/notebook/js/completer.js
+++ b/notebook/static/notebook/js/completer.js
@@ -255,6 +255,7 @@ define([
             var that = this;
             this.sel.click(function () {
                 that.pick();
+                that.editor.focus();
             });
             this._handle_keydown = function (cm, event) {
                 that.keydown(event);

--- a/notebook/static/notebook/js/completer.js
+++ b/notebook/static/notebook/js/completer.js
@@ -256,9 +256,6 @@ define([
             this.sel.dblclick(function () {
                 that.pick();
             });
-            this.sel.focus(function () {
-                that.editor.focus();
-            });
             this._handle_keydown = function (cm, event) {
                 that.keydown(event);
             };

--- a/notebook/static/notebook/js/completer.js
+++ b/notebook/static/notebook/js/completer.js
@@ -253,7 +253,7 @@ define([
 
             //build the container
             var that = this;
-            this.sel.dblclick(function () {
+            this.sel.click(function () {
                 that.pick();
             });
             this._handle_keydown = function (cm, event) {


### PR DESCRIPTION
Resolve #1512.

The `focus` function was shadowing the `dblclick` function (which, probably at one time, allowed picking completion options by double clicking). I don't think the `focus` function was necessary, as clicking anywhere outside the selection box (i.e. in the editor), still changes focus just fine (at least for me on Chrome).

I also changed `dblclick` to `click`, since I think this is the expected behaviour for select widgets, opinions?

![click-select](https://cloud.githubusercontent.com/assets/1953083/16095331/1d46971e-3312-11e6-8899-9595a8859f31.gif)