### PR TITLE
avoid clobbering ssl_options.ssl_version

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1020,10 +1020,10 @@ class NotebookApp(JupyterApp):
         else:
             # SSL may be missing, so only import it if it's to be used
             import ssl
-            # Disable SSLv3, since its use is discouraged.
-            ssl_options['ssl_version'] = ssl.PROTOCOL_TLSv1
+            # Disable SSLv3 by default, since its use is discouraged.
+            ssl_options.setdefault('ssl_version', ssl.PROTOCOL_TLSv1)
             if ssl_options.get('ca_certs', False):
-                ssl_options['cert_reqs'] = ssl.CERT_REQUIRED
+                ssl_options.setdefault('cert_reqs', ssl.CERT_REQUIRED)
         
         self.login_handler_class.validate_security(self, ssl_options=ssl_options)
         self.http_server = httpserver.HTTPServer(self.web_app, ssl_options=ssl_options,


### PR DESCRIPTION
use setdefault instead of setting directly, so that the user can override these values.

closes #1028