### PR TITLE
MathJax MML support

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -161,7 +161,7 @@ class IPythonHandler(AuthenticatedHandler):
     
     @property
     def mathjax_config(self):
-        return self.settings.get('mathjax_config', 'TeX-AMS_HTML-full,Safe')
+        return self.settings.get('mathjax_config', 'TeX-AMS-MML_HTMLorMML-full,Safe')
 
     @property
     def base_url(self):

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -762,7 +762,7 @@ class NotebookApp(JupyterApp):
         else:
             self.log.info("Using MathJax: %s", new)
 
-    mathjax_config = Unicode("TeX-AMS_HTML-full,Safe", config=True,
+    mathjax_config = Unicode("TeX-AMS-MML_HTMLorMML-full,Safe", config=True,
         help="""The MathJax.js configuration file that is to be used."""
     )
 

--- a/setupbase.py
+++ b/setupbase.py
@@ -167,7 +167,7 @@ def find_package_data():
     mj = lambda *path: pjoin(components, 'MathJax', *path)
     static_data.extend([
         mj('MathJax.js'),
-        mj('config', 'TeX-AMS_HTML-full.js'),
+        mj('config', 'TeX-AMS-MML_HTMLorMML-full.js'),
         mj('config', 'Safe.js'),
     ])
     


### PR DESCRIPTION
Allows kernels to provide math output as MathML (MML) in addition to TeX by changing the default MathJax configuration from `TeX-AMS_HTML-full` to `TeX-AMS-MML_HTMLorMML-full`.

This allows the MathML-bound https://github.com/mathics/IMathics kernel to render its math output properly.

Details of the new and old MathJax configurations are available at http://docs.mathjax.org/en/latest/config-files.html.

This is a follow-up of #1456.
