### PR TITLE
CSS: Clean up list spacing

### DIFF
--- a/notebook/static/notebook/less/renderedhtml.less
+++ b/notebook/static/notebook/less/renderedhtml.less
@@ -26,8 +26,8 @@
     h6:first-child {margin-top: 1em;}
 
     ul:not(.list-inline),
-    ol:not(.list-inline) {margin: 0em 2em; padding-left: 0px;}
-    ul {list-style:disc; padding-top: 16px;}
+    ol:not(.list-inline) {padding-left: 2em;}
+    ul {list-style:disc;}
     ul ul {list-style:square;}
     ul ul ul {list-style:circle;}
     ol {list-style:decimal;}


### PR DESCRIPTION
This is closer to what was intended with `* + ul` etc. (see https://github.com/jupyter/notebook/issues/1392#issuecomment-215022995), but it is still not really good. Especially nested lists look awkward.