### PR TITLE
Switch to xterm for the terminal emulator

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,6 @@
     "MathJax": "components/MathJax#~2.6",
     "moment": "~2.8.4",
     "requirejs": "~2.1",
-    "term.js": "chjj/term.js#~0.0.7",
     "text-encoding": "~0.1",
     "underscore": "components/underscore#~1.5",
     "jquery-typeahead": "~2.0.0"

--- a/notebook/static/terminal/js/main.js
+++ b/notebook/static/terminal/js/main.js
@@ -1,8 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 __webpack_public_path__ = window['staticURL'] + 'terminal/js/built/';
+require('xterm/src/xterm.css');
 
-requirejs(['termjs'], function(termjs) {
 require([
     'base/js/utils',
     'base/js/page',
@@ -66,5 +66,4 @@ require([
     // Expose terminal for fiddling with in the browser
     window.terminal = terminal;
 
-});
 });

--- a/notebook/static/terminal/js/terminado.js
+++ b/notebook/static/terminal/js/terminado.js
@@ -1,4 +1,4 @@
-define ([], function() {
+define (["xterm"], function(Terminal) {
     "use strict";
     function make_terminal(element, size, ws_url) {
         var ws = new WebSocket(ws_url);

--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -40,7 +40,6 @@
             backbone : 'components/backbone/backbone-min',
             moment: 'components/moment/moment',
             codemirror: 'components/codemirror',
-            termjs: 'components/term.js/src/term',
 
             // Define aliases for requirejs webpack imports
             notebook: 'built/index',

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "moment": "^2.8.4",
     "preact": "^4.5.1",
-    "preact-compat": "^1.7.0"
+    "preact-compat": "^1.7.0",
+    "xterm": "^0.33.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,12 @@
     "babel-preset-es2015": "^6.6.0",
     "bower": "*",
     "concurrently": "^1.0.0",
+    "css-loader": "^0.23.1",
     "eslint": "^2.8.0",
+    "json-loader": "^0.5.4",
     "less": "~2",
     "requirejs": "^2.1.17",
+    "style-loader": "^0.13.1",
     "underscore": "^1.8.3",
     "webpack": "^1.12.13"
   },

--- a/setupbase.py
+++ b/setupbase.py
@@ -153,7 +153,6 @@ def find_package_data():
         pjoin(components, "underscore", "underscore-min.js"),
         pjoin(components, "moment", "moment.js"),
         pjoin(components, "moment", "min", "moment.min.js"),
-        pjoin(components, "term.js", "src", "term.js"),
         pjoin(components, "text-encoding", "lib", "encoding.js"),
     ])
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ var commonConfig = {
             "node_modules" /* npm */
         ]
     },
+    bail: true,
     module: {
         loaders: [
             { test: /\.js$/, exclude: /node_modules|\/notebook\/static\/component/, loader: "babel-loader"},


### PR DESCRIPTION
Xterm is actively maintained and is being used in Jupyterlab.

cf https://github.com/jupyter/notebook/issues/104#issuecomment-230443710