### PR TITLE
Note that pandoc is required to build docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -141,11 +141,11 @@ or to run just ``notebook/tests/notebook/deletecell.js``::
 Building the Documentation
 --------------------------
 
-To build the documentation you'll need `Sphinx <http://www.sphinx-doc.org/>`_
+To build the documentation you'll need `Sphinx <http://www.sphinx-doc.org/>`_, `pandoc <http://pandoc.org/>`_
 and a few other packages.
 
 To install (and activate) a `conda environment`_ named ``notebook_docs``
-containing all the necessary packages, use::
+containing all the necessary packages (except pandoc), use::
 
     conda env create -f docs/environment.yml
     source activate notebook_docs  # Linux and OS X


### PR DESCRIPTION
Need to install pandoc now that some doc is in notebook files:

```
reading sources... [ 21%] examples/Notebook/Connecting with the Qt Console
Exception occurred:
  File "/Users/parente/miniconda3/envs/notebook_docs/lib/python3.5/site-packages/nbconvert/utils/pandoc.py", line 76, in get_pandoc_version
    raise PandocMissing()
nbconvert.utils.pandoc.PandocMissing: Pandoc wasn't found.
Please check that pandoc is installed:
http://pandoc.org/installing.html
The full traceback has been saved in /var/folders/_k/t8hxmmgx7yxdj8cqtnckwx9h0000gn/T/sphinx-err-qwh5lhpl.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [html] Error 1
```