### PR TITLE
remove outdated/false docker info from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,34 +41,6 @@ Launch with:
 
     $ jupyter notebook
 
-### Running in a Docker container
-
-If you are using **Linux** and have a
-[Docker daemon running](https://docs.docker.com/installation/),
-e.g. reachable on `localhost`, start a container with:
-
-    $ docker run --rm -it -p 8888:8888 -v "$(pwd):/notebooks" jupyter/notebook
-
-In your browser, open the URL `http://localhost:8888/`.
-All notebooks from your session will be saved in the current directory.
-
-On other platforms, such as **Windows and OS X**, that use
-[`docker-machine`](https://docs.docker.com/machine/install-machine/) with `docker`, a container can be started using
-`docker-machine`. In the browser, open the URL `http://ip:8888/` where `ip` is
-the IP address returned from the command [`docker-machine ip <MACHINE>`](https://docs.docker.com/machine/reference/ip/):
-
-    $ docker-machine ip <MACHINE>
-
-For example,
-
-    $ docker-machine ip myjupytermachine
-    192.168.99.104
-
-In browser, open `http://192.168.99.104:8888`.
-
-NOTE: With the deprecated `boot2docker`, use the command `boot2docker ip` to
-determine the URL.
-
 ## Development Installation
 
 See [`CONTRIBUTING.rst`](CONTRIBUTING.rst) for how to set up a local development installation.


### PR DESCRIPTION
the jupyter/notebok docker image is gone, leaving only various docker-stacks

closes #1539