### PR TITLE
Add info on how to launch master branch install

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -59,6 +59,11 @@ If you want the development environment to be available for all users of your
 system (assuming you have the necessary rights) or if you are installing in a
 virtual environment, just drop the ``--user`` option.
 
+Once you have done this, you can launch the master branch of Jupyter notebook
+from any directory in your system with::
+
+    jupyter notebook
+
 
 Rebuilding JavaScript and CSS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
It wasn't 100% clear to me that, once I had cloned the master branch and installed everything, I could launch the master branch install by typing "jupyter notebook" from any directory in my system. I have updated the contributing doc to make this explicit.