### PR TITLE
Escape file names in attachment headers

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -22,7 +22,7 @@ except ImportError:
 from jinja2 import TemplateNotFound
 from tornado import web
 
-from tornado import gen
+from tornado import gen, escape
 from tornado.log import app_log
 
 from notebook._sysinfo import get_sys_info
@@ -412,7 +412,7 @@ class AuthenticatedFileHandler(IPythonHandler, web.StaticFileHandler):
         if os.path.splitext(path)[1] == '.ipynb':
             name = path.rsplit('/', 1)[-1]
             self.set_header('Content-Type', 'application/json')
-            self.set_header('Content-Disposition','attachment; filename="%s"' % name)
+            self.set_header('Content-Disposition','attachment; filename="%s"' % escape.url_escape(name))
         
         return web.StaticFileHandler.get(self, path)
     

--- a/notebook/files/handlers.py
+++ b/notebook/files/handlers.py
@@ -12,7 +12,7 @@ except ImportError: #PY2
     from base64 import decodestring as decodebytes
 
 
-from tornado import web
+from tornado import web, escape
 
 from notebook.base.handlers import IPythonHandler
 
@@ -39,7 +39,7 @@ class FilesHandler(IPythonHandler):
         model = cm.get(path, type='file', content=include_body)
         
         if self.get_argument("download", False):
-            self.set_header('Content-Disposition','attachment; filename="%s"' % name)
+            self.set_header('Content-Disposition','attachment; filename="%s"' % escape.urlescape(name))
         
         # get mimetype from filename
         if name.endswith('.ipynb'):

--- a/notebook/files/handlers.py
+++ b/notebook/files/handlers.py
@@ -39,7 +39,7 @@ class FilesHandler(IPythonHandler):
         model = cm.get(path, type='file', content=include_body)
         
         if self.get_argument("download", False):
-            self.set_header('Content-Disposition','attachment; filename="%s"' % escape.urlescape(name))
+            self.set_header('Content-Disposition','attachment; filename="%s"' % escape.url_escape(name))
         
         # get mimetype from filename
         if name.endswith('.ipynb'):


### PR DESCRIPTION
When there are non-ascii characters in notebook file name, i.e., "文件名.ipynb", notebooks cannot be properly downloaded via configurable-http-proxy in JupyterHub. https://github.com/jupyter/notebook/pull/1353 fixed the case under nbconvert but left out other scenarios.