### PR TITLE
Remove the `.dockerignore` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,0 @@
-.git
-.git*
-.mailmap
-.travis.yml


### PR DESCRIPTION
We already got rid of the docker image. So we don't need this.