### PR TITLE
Add MathJax support for AsciiMath and Content MathML

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -161,7 +161,7 @@ class IPythonHandler(AuthenticatedHandler):
     
     @property
     def mathjax_config(self):
-        return self.settings.get('mathjax_config', 'TeX-AMS-MML_HTMLorMML-full,Safe')
+        return self.settings.get('mathjax_config', 'TeX-MML-AM_HTMLorMML-full,Safe')
 
     @property
     def base_url(self):

--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -161,7 +161,7 @@ class IPythonHandler(AuthenticatedHandler):
     
     @property
     def mathjax_config(self):
-        return self.settings.get('mathjax_config', 'TeX-AMS_HTML-full,Safe')
+        return self.settings.get('mathjax_config', 'TeX-AMS-MML_HTMLorMML-full,Safe')
 
     @property
     def base_url(self):

--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -161,7 +161,7 @@ class IPythonHandler(AuthenticatedHandler):
     
     @property
     def mathjax_config(self):
-        return self.settings.get('mathjax_config', 'TeX-MML-AM_HTMLorMML-full,Safe')
+        return self.settings.get('mathjax_config', 'TeX-AMS-MML_HTMLorMML-full,Safe')
 
     @property
     def base_url(self):

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -762,7 +762,7 @@ class NotebookApp(JupyterApp):
         else:
             self.log.info("Using MathJax: %s", new)
 
-    mathjax_config = Unicode("TeX-AMS-MML_HTMLorMML-full,Safe", config=True,
+    mathjax_config = Unicode("TeX-MML-AM_HTMLorMML-full,Safe", config=True,
         help="""The MathJax.js configuration file that is to be used."""
     )
 

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -762,7 +762,7 @@ class NotebookApp(JupyterApp):
         else:
             self.log.info("Using MathJax: %s", new)
 
-    mathjax_config = Unicode("TeX-AMS_HTML-full,Safe", config=True,
+    mathjax_config = Unicode("TeX-AMS-MML_HTMLorMML-full,Safe", config=True,
         help="""The MathJax.js configuration file that is to be used."""
     )
 

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -762,7 +762,7 @@ class NotebookApp(JupyterApp):
         else:
             self.log.info("Using MathJax: %s", new)
 
-    mathjax_config = Unicode("TeX-MML-AM_HTMLorMML-full,Safe", config=True,
+    mathjax_config = Unicode("TeX-AMS-MML_HTMLorMML-full,Safe", config=True,
         help="""The MathJax.js configuration file that is to be used."""
     )
 

--- a/notebook/static/notebook/js/mathjaxutils.js
+++ b/notebook/static/notebook/js/mathjaxutils.js
@@ -17,6 +17,12 @@ define([
                     processEscapes: true,
                     processEnvironments: true
                 },
+                asciimath2jax: {
+                    delimiters: [['...','...']]
+                },
+                MathML: {
+                    extensions: ['content-mathml.js']
+                },
                 // Center justify equations in code and markdown cells. Elsewhere
                 // we use CSS to left justify single line equations in code cells.
                 displayAlign: 'center',

--- a/notebook/static/notebook/js/mathjaxutils.js
+++ b/notebook/static/notebook/js/mathjaxutils.js
@@ -17,9 +17,6 @@ define([
                     processEscapes: true,
                     processEnvironments: true
                 },
-                asciimath2jax: {
-                    delimiters: [['...','...']]
-                },
                 MathML: {
                     extensions: ['content-mathml.js']
                 },

--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -245,6 +245,7 @@ define([
         'text/html',
         'text/markdown',
         'text/latex',
+        'application/mathml+xml',
         'image/svg+xml',
         'image/png',
         'image/jpeg',
@@ -445,7 +446,8 @@ define([
         }
         this._safe_append(toinsert);
         // If we just output latex, typeset it.
-        if ((json.data['text/latex'] !== undefined) ||
+        if ((json.data['application/mathml+xml'] !== undefined) ||
+            (json.data['text/latex'] !== undefined) ||
             (json.data['text/html'] !== undefined) ||
             (json.data['text/markdown'] !== undefined)) {
             this.typeset();
@@ -558,7 +560,8 @@ define([
         if (this.append_mime_type(json, toinsert, handle_inserted)) {
             this._safe_append(toinsert);
             // If we just output latex, typeset it.
-            if ((json.data['text/latex'] !== undefined) ||
+            if ((json.data['application/mathml+xml'] !== undefined) ||
+                (json.data['text/latex'] !== undefined) ||
                 (json.data['text/html'] !== undefined) ||
                 (json.data['text/markdown'] !== undefined)) {
                 this.typeset();
@@ -570,6 +573,7 @@ define([
     OutputArea.safe_outputs = {
         'text/plain' : true,
         'text/latex' : true,
+        'application/mathml+xml' : true,
         'image/png' : true,
         'image/jpeg' : true
     };
@@ -783,6 +787,18 @@ define([
         element.append(toinsert);
         return toinsert;
     };
+    
+    var append_mathml = function (mathml, md, element) {
+        /**
+         * This method cannot do the typesetting because the mathml first has to
+         * be on the page.
+         */
+        var type = 'application/mathml+xml';
+        var toinsert = this.create_output_subarea(md, "output_mathml", type);
+        toinsert.text(mathml);
+        element.append(toinsert);
+        return toinsert;
+    };
 
 
     OutputArea.prototype.append_raw_input = function (msg) {
@@ -968,6 +984,7 @@ define([
         'text/html',
         'text/markdown',
         'text/latex',
+        'application/mathml+xml',
         'image/svg+xml',
         'image/png',
         'image/jpeg',
@@ -983,6 +1000,7 @@ define([
         "image/png" : append_png,
         "image/jpeg" : append_jpeg,
         "text/latex" : append_latex,
+        "application/mathml+xml" : append_mathml,
         "application/javascript" : append_javascript,
         "application/pdf" : append_pdf
     };

--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -586,7 +586,7 @@ define([
                 var value = json.data[type];
                 if (!this.trusted && !OutputArea.safe_outputs[type]) {
                     // not trusted, sanitize HTML
-                    if (type==='text/html' || type==='text/svg') {
+                    if (type==='text/html' || type==='text/svg' || type==='application/mathml+xml') {
                         value = security.sanitize_html(value);
                     } else {
                         // don't display if we don't know how to sanitize it
@@ -795,7 +795,7 @@ define([
          */
         var type = 'application/mathml+xml';
         var toinsert = this.create_output_subarea(md, "output_mathml", type);
-        toinsert.text(mathml);
+        toinsert.append(mathml);
         element.append(toinsert);
         return toinsert;
     };

--- a/setupbase.py
+++ b/setupbase.py
@@ -166,7 +166,7 @@ def find_package_data():
     mj = lambda *path: pjoin(components, 'MathJax', *path)
     static_data.extend([
         mj('MathJax.js'),
-        mj('config', 'TeX-AMS-MML_HTMLorMML-full.js'),
+        mj('config', 'TeX-MML-AM_HTMLorMML-full.js'),
         mj('config', 'Safe.js'),
     ])
     

--- a/setupbase.py
+++ b/setupbase.py
@@ -166,7 +166,7 @@ def find_package_data():
     mj = lambda *path: pjoin(components, 'MathJax', *path)
     static_data.extend([
         mj('MathJax.js'),
-        mj('config', 'TeX-AMS_HTML-full.js'),
+        mj('config', 'TeX-AMS-MML_HTMLorMML-full.js'),
         mj('config', 'Safe.js'),
     ])
     

--- a/setupbase.py
+++ b/setupbase.py
@@ -166,7 +166,7 @@ def find_package_data():
     mj = lambda *path: pjoin(components, 'MathJax', *path)
     static_data.extend([
         mj('MathJax.js'),
-        mj('config', 'TeX-MML-AM_HTMLorMML-full.js'),
+        mj('config', 'TeX-AMS-MML_HTMLorMML-full.js'),
         mj('config', 'Safe.js'),
     ])
     


### PR DESCRIPTION
* Test notebook: https://gist.github.com/gnestor/bbe456b13a0d1d8430d0caa8d8a8fd65
* MathML renders correctly using `IPython.core.display.HTML`
* AsciiMath renders correctly in Markdown cells
* MathML and AsciiMath do not render correct on Github/Gist
* Use `…` delimiters to use AsciiMath in a Markdown cell