### PR TITLE
fixes problem with disappearing MathJax mglyphs in output areas

### DIFF
--- a/notebook/static/notebook/less/outputarea.less
+++ b/notebook/static/notebook/less/outputarea.less
@@ -74,6 +74,10 @@ div.output_area {
             max-width: none;
         }
     }
+
+    .mglyph>img {
+        max-width: none;
+    }
 }
 
 /* This is needed to protect the pre formating from global settings such


### PR DESCRIPTION
This change allows MathML `mglyphs` with embedded data to be correctly rendered. This is an important feature for some applications using images embedded in math formulas.

To test this PR's change in a Python 3 notebook, use the attached notebook and evaluate all three cells.

Without this PR, the third step's `HTML` will output nothing. With the CSS change in this PR, an arrow svg will be visible as expected.

The second step is necessary to reconfigure MathJax to accept `mglyph' tags with embedded data, which is by default disabled due to Jupyter's safe MathJax mode. I will address this in a separate PR.

[mglyph.ipynb.zip](https://github.com/jupyter/notebook/files/416997/mglyph.ipynb.zip)


