### PR TITLE
Include bundler test files in package_data

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -198,6 +198,7 @@ def find_package_data():
     package_data = {
         'notebook' : ['templates/*'] + static_data,
         'notebook.tests' : js_tests,
+        'notebook.bundler.tests': ['resources/*', 'resources/*/*', 'resources/*/*/.*'],
     }
     
     return package_data


### PR DESCRIPTION
This was causing a test failure on Jenkins. It only shows up if you install the package (not a dev install) and test against the installed version.

Ping @parente 