### PR TITLE
Update release docs for PEP 527

### DIFF
--- a/docs/source/development_release.rst
+++ b/docs/source/development_release.rst
@@ -50,7 +50,7 @@ Create the release
 
     .. code:: bash
 
-        python setup.py sdist --formats=zip,gztar
+        python setup.py sdist
         python setup.py bdist_wheel
 
 #.  You can now test the ``wheel`` and the ``sdist`` locally before uploading


### PR DESCRIPTION
This assumes we're likely to continue doing releases on POSIX systems - on Windows the default is zip until Python 3.6.