### PR TITLE
yet another error-catching custom.js loader

### DIFF
--- a/notebook/static/edit/js/main.js
+++ b/notebook/static/edit/js/main.js
@@ -13,6 +13,7 @@ require([
     'edit/js/menubar',
     'edit/js/savewidget',
     'edit/js/notificationarea',
+    'custom',
 ], function(
     $,
     IPython,
@@ -28,13 +29,6 @@ require([
     ){
     "use strict";
 
-    try {
-        requirejs(['custom/custom'], function() {});
-    } catch(err) {
-        console.log("Error loading custom.js from edition service. Continuing and logging");
-        console.warn(err);
-    }
-    
     page = new page.Page();
 
     var base_url = utils.get_body_data('baseUrl');

--- a/notebook/static/notebook/js/main.js
+++ b/notebook/static/notebook/js/main.js
@@ -24,6 +24,7 @@ require([
     'notebook/js/about',
     'typeahead',
     'notebook/js/searchandreplace',
+    'custom',
 ], function(
     IPython, 
     $,
@@ -50,13 +51,6 @@ require([
     ) {
     "use strict";
 
-    try{
-        requirejs(['custom/custom'], function() {});
-    } catch(err) {
-        console.log("Error processing custom.js. Logging and continuing")
-        console.warn(err);
-    }
-
     // compat with old IPython, remove for IPython > 3.0
     window.CodeMirror = CodeMirror;
 
@@ -82,7 +76,7 @@ require([
     var save_widget = new savewidget.SaveWidget('span#save_widget', {
         events: events, 
         keyboard_manager: keyboard_manager});
-    acts.extend_env({save_widget:save_widget})
+    acts.extend_env({save_widget:save_widget});
     var contents = new contents.Contents({
           base_url: common_options.base_url,
           common_config: common_config

--- a/notebook/static/terminal/js/main.js
+++ b/notebook/static/terminal/js/main.js
@@ -8,7 +8,7 @@ require([
     'base/js/page',
     'services/config',
     'terminal/js/terminado',
-    'custom/custom',
+    'custom',
 ], function(
     $, 
     termjs,

--- a/notebook/static/tree/js/main.js
+++ b/notebook/static/tree/js/main.js
@@ -19,6 +19,7 @@ require([
     // only loaded, not used:
     'jquery-ui',
     'bootstrap',
+    'custom',
 ], function(
     $,
     IPython,
@@ -35,13 +36,6 @@ require([
     newnotebook,
     loginwidget){
     "use strict";
-
-    try{
-        requirejs(['custom/custom'], function() {});
-    } catch(err) {
-        console.log("Error loading custom.js from tree service. Continuing and logging");
-        console.warn(err);
-    }
 
     IPython.NotebookList = notebooklist.NotebookList;
 

--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -95,6 +95,17 @@
       define("jquery-ui", function () {
           return window.$;
       });
+      // error-catching custom.js shim.
+      define("custom", function (require, exports, module) {
+          try {
+              var custom = require('custom/custom');
+              console.debug('loaded custom.js');
+              return custom;
+          } catch (e) {
+              console.error("error loading custom.js", e);
+              return {};
+          }
+      })
     </script>
 
     {% block meta %}

--- a/tools/build-main.js
+++ b/tools/build-main.js
@@ -23,7 +23,8 @@ var rjs_config = {
     codemirror: 'components/codemirror',
     termjs: 'components/xterm.js/src/xterm',
     typeahead: 'components/jquery-typeahead/dist/jquery.typeahead',
-    contents: 'empty:'
+    contents: 'empty:',
+    custom: 'empty:',
   },
   map: { // for backward compatibility
     "*": {


### PR DESCRIPTION
Previous fix (#1378) ended up delaying custom.js loading time until after main.js had completed executing due to async loads. This switches it up a bit to add a 'custom' shim that tries to load 'custom/custom', which should ensure the right loading order.

closes #1730.

This should go into 4.2.3, since this is a regression in 4.2.2