### PR TITLE
Attempted to correct a URL that was a dead link. 

### DIFF
--- a/docs/source/examples/Notebook/JavaScript Notebook Extensions.ipynb
+++ b/docs/source/examples/Notebook/JavaScript Notebook Extensions.ipynb
@@ -523,7 +523,7 @@
     "```\n",
     "\n",
     "\n",
-    "See for example @damianavila [\"ZenMode\" plugin](https://github.com/ipython-contrib/IPython-notebook-extensions/blob/master/custom.example.js#L34) :\n",
+    "See for example @damianavila [\"ZenMode\" plugin](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/blob/b29c698394239a6931fa4911440550df214812cb/src/jupyter_contrib_nbextensions/nbextensions/zenmode/main.js#L32) :\n",
     "\n",
     "```javascript\n",
     "\n",
@@ -595,7 +595,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I was going through a tutorial in the documentation and found a dead (404) link.

I inserted my best guess to the updated version.
	modified:   docs/source/examples/Notebook/JavaScript Notebook Extensions.ipynb