### PR TITLE
Separate common classes for server and notebook extensions

### DIFF
--- a/notebook/bundler/bundlerextensions.py
+++ b/notebook/bundler/bundlerextensions.py
@@ -3,8 +3,7 @@
 import sys
 import os
 
-from ..nbextensions import (BaseNBExtensionApp, _get_config_dir, 
-    GREEN_ENABLED, RED_DISABLED)
+from ..extensions import BaseExtensionApp, _get_config_dir, GREEN_ENABLED, RED_DISABLED
 from .._version import __version__
 
 from jupyter_core.paths import jupyter_config_path
@@ -170,7 +169,7 @@ def disable_bundler_python(module, user=True, sys_prefix=False, logger=None):
     return _set_bundler_state_python(False, module, user, sys_prefix,
                                      logger=logger)
 
-class ToggleBundlerExtensionApp(BaseNBExtensionApp):
+class ToggleBundlerExtensionApp(BaseExtensionApp):
     """A base class for apps that enable/disable bundlerextensions"""
     name = "jupyter bundlerextension enable/disable"
     version = __version__
@@ -236,7 +235,7 @@ class DisableBundlerExtensionApp(ToggleBundlerExtensionApp):
     _toggle_value = None
 
 
-class ListBundlerExtensionApp(BaseNBExtensionApp):
+class ListBundlerExtensionApp(BaseExtensionApp):
     """An App that lists and validates nbextensions"""
     name = "jupyter nbextension list"
     version = __version__
@@ -276,7 +275,7 @@ class ListBundlerExtensionApp(BaseNBExtensionApp):
         self.list_nbextensions()
 
 
-class BundlerExtensionApp(BaseNBExtensionApp):
+class BundlerExtensionApp(BaseExtensionApp):
     """Base jupyter bundlerextension command entry point"""
     name = "jupyter bundlerextension"
     version = __version__

--- a/notebook/extensions.py
+++ b/notebook/extensions.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+"""Utilities for installing extensions"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import os
+from tornado.log import LogFormatter
+from traitlets import Bool, Any
+from jupyter_core.application import JupyterApp
+from jupyter_core.paths import (
+    jupyter_config_dir, ENV_CONFIG_PATH, SYSTEM_CONFIG_PATH
+)
+from ._version import __version__
+
+class ArgumentConflict(ValueError):
+    pass
+
+_base_flags = {}
+_base_flags.update(JupyterApp.flags)
+_base_flags.pop("y", None)
+_base_flags.pop("generate-config", None)
+_base_flags.update({
+    "user" : ({
+        "BaseExtensionApp" : {
+            "user" : True,
+        }}, "Apply the operation only for the given user"
+    ),
+    "system" : ({
+        "BaseExtensionApp" : {
+            "user" : False,
+            "sys_prefix": False,
+        }}, "Apply the operation system-wide"
+    ),
+    "sys-prefix" : ({
+        "BaseExtensionApp" : {
+            "sys_prefix" : True,
+        }}, "Use sys.prefix as the prefix for installing nbextensions (for environments, packaging)"
+    ),
+    "py" : ({
+        "BaseExtensionApp" : {
+            "python" : True,
+        }}, "Install from a Python package"
+    )
+})
+_base_flags['python'] = _base_flags['py']
+
+
+class BaseExtensionApp(JupyterApp):
+    """Base nbextension installer app"""
+    _log_formatter_cls = LogFormatter
+    flags = _base_flags
+    version = __version__
+
+    user = Bool(False, config=True, help="Whether to do a user install")
+    sys_prefix = Bool(False, config=True, help="Use the sys.prefix as the prefix")
+    python = Bool(False, config=True, help="Install from a Python package")
+
+    # Remove for 5.0...
+    verbose = Any(None, config=True, help="DEPRECATED: Verbosity level")
+
+    def _verbose_changed(self):
+        """Warn about verbosity changes"""
+        import warnings
+        warnings.warn("`verbose` traits of `{}` has been deprecated, has no effects and will be removed in notebook 5.0.".format(type(self).__name__), DeprecationWarning)
+
+    def _log_format_default(self):
+        """A default format for messages"""
+        return "%(message)s"
+
+def _get_config_dir(user=False, sys_prefix=False):
+    """Get the location of config files for the current context
+
+    Returns the string to the enviornment
+
+    Parameters
+    ----------
+
+    user : bool [default: False]
+        Get the user's .jupyter config directory
+    sys_prefix : bool [default: False]
+        Get sys.prefix, i.e. ~/.envs/my-env/etc/jupyter
+    """
+    user = False if sys_prefix else user
+    if user and sys_prefix:
+        raise ArgumentConflict("Cannot specify more than one of user or sys_prefix")
+    if user:
+        nbext = jupyter_config_dir()
+    elif sys_prefix:
+        nbext = ENV_CONFIG_PATH[0]
+    else:
+        nbext = SYSTEM_CONFIG_PATH[0]
+    return nbext
+
+# Constants for pretty print extension listing function.
+# Window doesn't support coloring in the commandline
+GREEN_ENABLED = '\033[32m enabled \033[0m' if os.name != 'nt' else 'enabled '
+RED_DISABLED = '\033[31mdisabled\033[0m' if os.name != 'nt' else 'disabled'
+GREEN_OK = '\033[32mOK\033[0m' if os.name != 'nt' else 'ok'
+RED_X = '\033[31m X\033[0m' if os.name != 'nt' else ' X'

--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -32,28 +32,14 @@ from ._version import __version__
 from traitlets.config.manager import BaseJSONConfigManager
 from traitlets.utils.importstring import import_item
 
-from tornado.log import LogFormatter
-
-# Constants for pretty print extension listing function.
-# Window doesn't support coloring in the commandline
-GREEN_ENABLED = '\033[32m enabled \033[0m' if os.name != 'nt' else 'enabled '
-RED_DISABLED = '\033[31mdisabled\033[0m' if os.name != 'nt' else 'disabled'
-
 DEPRECATED_ARGUMENT = object()
 
 NBCONFIG_SECTIONS = ['common', 'notebook', 'tree', 'edit', 'terminal']
 
-GREEN_OK = '\033[32mOK\033[0m' if os.name != 'nt' else 'ok'
-RED_X = '\033[31m X\033[0m' if os.name != 'nt' else ' X'
 
 #------------------------------------------------------------------------------
 # Public API
 #------------------------------------------------------------------------------
-
-
-class ArgumentConflict(ValueError):
-    pass
-
 
 def check_nbextension(files, user=False, prefix=None, nbextensions_dir=None, sys_prefix=False):
     """Check whether nbextension files have been installed
@@ -583,60 +569,11 @@ def validate_nbextension_python(spec, full_dest, logger=None):
 # Applications
 #----------------------------------------------------------------------
 
-from traitlets import Bool, Unicode, Any
-from jupyter_core.application import JupyterApp
-
-_base_flags = {}
-_base_flags.update(JupyterApp.flags)
-_base_flags.pop("y", None)
-_base_flags.pop("generate-config", None)
-_base_flags.update({
-    "user" : ({
-        "BaseNBExtensionApp" : {
-            "user" : True,
-        }}, "Apply the operation only for the given user"
-    ),
-    "system" : ({
-        "BaseNBExtensionApp" : {
-            "user" : False,
-            "sys_prefix": False,
-        }}, "Apply the operation system-wide"
-    ),
-    "sys-prefix" : ({
-        "BaseNBExtensionApp" : {
-            "sys_prefix" : True,
-        }}, "Use sys.prefix as the prefix for installing nbextensions (for environments, packaging)"
-    ),
-    "py" : ({
-        "BaseNBExtensionApp" : {
-            "python" : True,
-        }}, "Install from a Python package"
-    )
-})
-_base_flags['python'] = _base_flags['py']
-
-class BaseNBExtensionApp(JupyterApp):
-    """Base nbextension installer app"""
-    _log_formatter_cls = LogFormatter
-    flags = _base_flags
-    version = __version__
-    
-    user = Bool(False, config=True, help="Whether to do a user install")
-    sys_prefix = Bool(False, config=True, help="Use the sys.prefix as the prefix")
-    python = Bool(False, config=True, help="Install from a Python package")
-
-    # Remove for 5.0...
-    verbose = Any(None, config=True, help="DEPRECATED: Verbosity level")
-
-    def _verbose_changed(self):
-        """Warn about verbosity changes"""
-        import warnings
-        warnings.warn("`verbose` traits of `{}` has been deprecated, has no effects and will be removed in notebook 5.0.".format(type(self).__name__), DeprecationWarning)
-
-    def _log_format_default(self):
-        """A default format for messages"""
-        return "%(message)s"
-
+from .extensions import (
+    BaseExtensionApp, _get_config_dir, GREEN_ENABLED, RED_DISABLED, GREEN_OK, RED_X,
+    ArgumentConflict, _base_flags
+)
+from traitlets import Bool, Unicode
 
 flags = {}
 flags.update(_base_flags)
@@ -661,7 +598,7 @@ aliases = {
     "destination" : "InstallNBExtensionApp.destination",
 }
 
-class InstallNBExtensionApp(BaseNBExtensionApp):
+class InstallNBExtensionApp(BaseExtensionApp):
     """Entry point for installing notebook extensions"""
     description = """Install Jupyter notebook extensions
     
@@ -741,7 +678,7 @@ class InstallNBExtensionApp(BaseNBExtensionApp):
                 sys.exit(str(e))
 
 
-class UninstallNBExtensionApp(BaseNBExtensionApp):
+class UninstallNBExtensionApp(BaseExtensionApp):
     """Entry point for uninstalling notebook extensions"""
     version = __version__
     description = """Uninstall Jupyter notebook extensions
@@ -806,7 +743,7 @@ class UninstallNBExtensionApp(BaseNBExtensionApp):
                 sys.exit(str(e))
 
 
-class ToggleNBExtensionApp(BaseNBExtensionApp):
+class ToggleNBExtensionApp(BaseExtensionApp):
     """A base class for apps that enable/disable extensions"""
     name = "jupyter nbextension enable/disable"
     version = __version__
@@ -895,7 +832,7 @@ class DisableNBExtensionApp(ToggleNBExtensionApp):
     _toggle_value = None
 
 
-class ListNBExtensionsApp(BaseNBExtensionApp):
+class ListNBExtensionsApp(BaseExtensionApp):
     """An App that lists and validates nbextensions"""
     name = "jupyter nbextension list"
     version = __version__
@@ -941,7 +878,7 @@ jupyter nbextension disable --py <packagename>    # disable all nbextensions in 
 jupyter nbextension uninstall --py <packagename>  # uninstall an nbextension in a Python package
 """
 
-class NBExtensionApp(BaseNBExtensionApp):
+class NBExtensionApp(BaseExtensionApp):
     """Base jupyter nbextension command entry point"""
     name = "jupyter nbextension"
     version = __version__
@@ -1085,31 +1022,6 @@ def _nbextension_dirs():
         pjoin(ENV_JUPYTER_PATH[0], u'nbextensions'),
         pjoin(SYSTEM_JUPYTER_PATH[0], 'nbextensions')
     ]
-
-
-def _get_config_dir(user=False, sys_prefix=False):
-    """Get the location of config files for the current context
-
-    Returns the string to the enviornment
-
-    Parameters
-    ----------
-
-    user : bool [default: False]
-        Get the user's .jupyter config directory
-    sys_prefix : bool [default: False]
-        Get sys.prefix, i.e. ~/.envs/my-env/etc/jupyter
-    """
-    user = False if sys_prefix else user
-    if user and sys_prefix:
-        raise ArgumentConflict("Cannot specify more than one of user or sys_prefix")
-    if user:
-        nbext = jupyter_config_dir()
-    elif sys_prefix:
-        nbext = ENV_CONFIG_PATH[0]
-    else:
-        nbext = SYSTEM_CONFIG_PATH[0]
-    return nbext
 
 
 def _get_nbextension_metadata(module):

--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -1049,40 +1049,6 @@ def _get_nbextension_metadata(module):
     return m, nbexts
 
 
-def _read_config_data(user=False, sys_prefix=False):
-    """Get the config for the current context
-
-    Returns the string to the enviornment
-
-    Parameters
-    ----------
-
-    user : bool [default: False]
-        Get the user's .jupyter config directory
-    sys_prefix : bool [default: False]
-        Get sys.prefix, i.e. ~/.envs/my-env/etc/jupyter
-    """
-    config_dir = _get_config_dir(user=user, sys_prefix=sys_prefix)
-    config_man = BaseJSONConfigManager(config_dir=config_dir)
-    return config_man.get('jupyter_notebook_config')
-
-
-def _write_config_data(data, user=False, sys_prefix=False):
-    """Update the config for the current context
-
-    Parameters
-    ----------
-    data : object
-        An object which can be accepted by ConfigManager.update
-    user : bool [default: False]
-        Get the user's .jupyter config directory
-    sys_prefix : bool [default: False]
-        Get sys.prefix, i.e. ~/.envs/my-env/etc/jupyter
-    """
-    config_dir = _get_config_dir(user=user, sys_prefix=sys_prefix)
-    config_man = BaseJSONConfigManager(config_dir=config_dir)
-    config_man.update('jupyter_notebook_config', data)
-
 
 if __name__ == '__main__':
     main()

--- a/notebook/serverextensions.py
+++ b/notebook/serverextensions.py
@@ -9,15 +9,11 @@ from __future__ import print_function
 import importlib
 import sys
 
-
 from jupyter_core.paths import jupyter_config_path
 from ._version import __version__
-from .nbextensions import (
-    JupyterApp, BaseNBExtensionApp, _get_config_dir,
-    GREEN_ENABLED, RED_DISABLED,
-    GREEN_OK, RED_X,
+from .extensions import (
+    BaseExtensionApp, _get_config_dir, GREEN_ENABLED, RED_DISABLED, GREEN_OK, RED_X
 )
-
 from traitlets import Bool
 from traitlets.utils.importstring import import_item
 from traitlets.config.manager import BaseJSONConfigManager
@@ -26,9 +22,6 @@ from traitlets.config.manager import BaseJSONConfigManager
 # ------------------------------------------------------------------------------
 # Public API
 # ------------------------------------------------------------------------------
-class ArgumentConflict(ValueError):
-    pass
-
 
 def toggle_serverextension_python(import_name, enabled=None, parent=None,
                                   user=True, sys_prefix=False, logger=None):
@@ -135,7 +128,7 @@ def validate_serverextension(import_name, logger=None):
 # ----------------------------------------------------------------------
 
 flags = {}
-flags.update(JupyterApp.flags)
+flags.update(BaseExtensionApp.flags)
 flags.pop("y", None)
 flags.pop("generate-config", None)
 flags.update({
@@ -164,7 +157,7 @@ flags.update({
 flags['python'] = flags['py']
 
 
-class ToggleServerExtensionApp(BaseNBExtensionApp):
+class ToggleServerExtensionApp(BaseExtensionApp):
     """A base class for enabling/disabling extensions"""
     name = "jupyter serverextension enable/disable"
     description = "Enable/disable a server extension using frontend configuration files."
@@ -244,7 +237,7 @@ class DisableServerExtensionApp(ToggleServerExtensionApp):
     _toggle_value = False
 
 
-class ListServerExtensionsApp(BaseNBExtensionApp):
+class ListServerExtensionsApp(BaseExtensionApp):
     """An App that lists (and validates) Server Extensions"""
     name = "jupyter serverextension list"
     version = __version__
@@ -283,7 +276,7 @@ jupyter serverextension disable --py <packagename>  # disable all server extensi
 """
 
 
-class ServerExtensionApp(BaseNBExtensionApp):
+class ServerExtensionApp(BaseExtensionApp):
     """Root level server extension app"""
     name = "jupyter serverextension"
     version = __version__


### PR DESCRIPTION
This is a small cleanup.

- The  `ArgumentConflict` exception was defined twice.
- `serverextensions` depended on `nbextensions`. If anything, nbextensions it should be the opposite or no dependency (since the legacy notebook will become a serverextension).

So I separated the common parts in a separate file and removed the duplicate exception definition (which could have created awkward bugs with exceptions of seemingly the same type not being caught).