### PR TITLE
Fix metadata causing error with docs build

### DIFF
--- a/docs/source/examples/Notebook/JavaScript Notebook Extensions.ipynb
+++ b/docs/source/examples/Notebook/JavaScript Notebook Extensions.ipynb
@@ -595,7 +595,6 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
    "version": "3.5.2"
   }
  },

--- a/docs/source/examples/Notebook/JavaScript Notebook Extensions.ipynb
+++ b/docs/source/examples/Notebook/JavaScript Notebook Extensions.ipynb
@@ -580,7 +580,6 @@
   }
  ],
  "metadata": {
-  "anaconda-cloud": {},
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
Closes #1746 

Removes "anaconda-cloud" and second Python version from the metadata.