### PR TITLE
Use folder icon vs. home icon for root breadcrumb

### DIFF
--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -97,7 +97,7 @@ data-terminals-available="{{terminals_available}}"
               </div>
               <div id="project_name">
                 <ul class="breadcrumb">
-                  <li><a href="{{breadcrumbs[0][0]}}"><i class="fa fa-home"></i></a></li>
+                  <li><a href="{{breadcrumbs[0][0]}}"><i class="fa fa-folder"></i></a></li>
                 {% for crumb in breadcrumbs[1:] %}
                   <li><a href="{{crumb[0]}}">{{crumb[1]}}</a></li>
                 {% endfor %}


### PR DESCRIPTION
Continuation of https://github.com/jupyter/notebook/pull/1725#issuecomment-246438453

Before: 

![image](https://cloud.githubusercontent.com/assets/512354/18447548/fd48b860-78db-11e6-9452-3df4d0d81da7.png)

After:

![image](https://cloud.githubusercontent.com/assets/512354/18446809/c4f28836-78d8-11e6-8f2a-17719c5bdb68.png)