### PR TITLE
Add base aliases for nbextensions apps

### DIFF
--- a/notebook/extensions.py
+++ b/notebook/extensions.py
@@ -45,11 +45,15 @@ _base_flags.update({
 })
 _base_flags['python'] = _base_flags['py']
 
+_base_aliases = {}
+_base_aliases.update(JupyterApp.aliases)
+
 
 class BaseExtensionApp(JupyterApp):
     """Base nbextension installer app"""
     _log_formatter_cls = LogFormatter
     flags = _base_flags
+    aliases = _base_aliases
     version = __version__
 
     user = Bool(False, config=True, help="Whether to do a user install")

--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -571,7 +571,7 @@ def validate_nbextension_python(spec, full_dest, logger=None):
 
 from .extensions import (
     BaseExtensionApp, _get_config_dir, GREEN_ENABLED, RED_DISABLED, GREEN_OK, RED_X,
-    ArgumentConflict, _base_flags
+    ArgumentConflict, _base_aliases, _base_flags,
 )
 from traitlets import Bool, Unicode
 
@@ -592,11 +592,13 @@ flags.update({
 
 flags['s'] = flags['symlink']
 
-aliases = {
+aliases = {}
+aliases.update(_base_aliases)
+aliases.update({
     "prefix" : "InstallNBExtensionApp.prefix",
     "nbextensions" : "InstallNBExtensionApp.nbextensions_dir",
     "destination" : "InstallNBExtensionApp.destination",
-}
+})
 
 class InstallNBExtensionApp(BaseExtensionApp):
     """Entry point for installing notebook extensions"""

--- a/notebook/serverextensions.py
+++ b/notebook/serverextensions.py
@@ -162,7 +162,6 @@ class ToggleServerExtensionApp(BaseExtensionApp):
     name = "jupyter serverextension enable/disable"
     description = "Enable/disable a server extension using frontend configuration files."
     
-    aliases = {}
     flags = flags
 
     user = Bool(True, config=True, help="Whether to do a user install")


### PR DESCRIPTION
Includes `--log-level` alias that was missing from install/enable applications