### PR TITLE
Set ws-url data attribute when accessing a notebook terminal

### DIFF
--- a/notebook/static/terminal/js/main.js
+++ b/notebook/static/terminal/js/main.js
@@ -38,8 +38,12 @@ require([
 
     var base_url = utils.get_body_data('baseUrl');
     var ws_path = utils.get_body_data('wsPath');
-    var ws_url = location.protocol.replace('http', 'ws') + "//" + location.host
-                                    + base_url + ws_path;
+    var ws_url = utils.get_body_data('wsUrl');
+    if (!ws_url) {
+        // trailing 's' in https will become wss for secure web sockets
+        ws_url = location.protocol.replace('http', 'ws') + "//" + location.host;
+    }
+    ws_url = ws_url + base_url + ws_path;
     
     var header = $("#header")[0];
 

--- a/notebook/templates/terminal.html
+++ b/notebook/templates/terminal.html
@@ -7,6 +7,7 @@
 {% block params %}
 
 data-base-url="{{base_url | urlencode}}"
+data-ws-url="{{ws_url | urlencode}}"
 data-ws-path="{{ws_path}}"
 
 {% endblock %}


### PR DESCRIPTION
Notebook is not able to launch a terminal when notebook tries to connect to a web socket url specified via [NotebookApp.websocket_url option](http://jupyter-notebook.readthedocs.io/en/latest/config.html#options). 

The problem occurs when notebook/templates/terminal.html does not set 'data-ws-url' attribute in the body. Two files need to change to fix this:

[1] A change needs to be made to notebook/templates/terminal.html [similar to notebook.html](https://github.com/jupyter/notebook/blob/23ca9602c2fdd0cd705ec97c2feee909e7865e67/notebook/templates/notebook.html#L30) to support connecting to a websocket url specified via NotebookApp.websocket_url option when launching a terminal.

[2] terminal/js/main.js needs to be updated to consume wsUrl attribute set by terminal.html. If wsUrl is not set, fallback to location.host.
