### PR TITLE
set dirty flag when output arrives

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -349,9 +349,11 @@ define([
             },
             iopub : {
                 output : function() { 
+                    that.events.trigger('set_dirty.Notebook', {value: true});
                     that.output_area.handle_output.apply(that.output_area, arguments);
                 }, 
                 clear_output : function() { 
+                    that.events.trigger('set_dirty.Notebook', {value: true});
                     that.output_area.handle_clear_output.apply(that.output_area, arguments);
                 }, 
             },
@@ -476,6 +478,7 @@ define([
         var prompt_html = CodeCell.input_prompt_function(this.input_prompt_number, nline);
         // This HTML call is okay because the user contents are escaped.
         this.element.find('div.input_prompt').html(prompt_html);
+        this.events.trigger('set_dirty.Notebook', {value: true});
     };
 
 


### PR DESCRIPTION
and when the prompt changes

we were previously only setting dirty when execution finishes, leaving the notebook incorrectly clean during many changes before the output is complete.