### PR TITLE
don’t clear callbacks for cell output until next execute

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -340,6 +340,7 @@ define([
     CodeCell.prototype.get_callbacks = function () {
         var that = this;
         return {
+            clear_on_done: false,
             shell : {
                 reply : $.proxy(this._handle_execute_reply, this),
                 payload : {
@@ -357,7 +358,7 @@ define([
                     that.output_area.handle_clear_output.apply(that.output_area, arguments);
                 }, 
             },
-            input : $.proxy(this._handle_input_request, this)
+            input : $.proxy(this._handle_input_request, this),
         };
     };
     

--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -726,6 +726,7 @@ define([
          *      @param callbacks.iopub.output {function}
          *      @param callbacks.iopub.clear_output {function}
          *      @param callbacks.input {function}
+         *      @param callbacks.clear_on_done=true {Bolean}
          * @param {object} [options]
          *      @param [options.silent=false] {Boolean}
          *      @param [options.user_expressions=empty_dict] {Dict}
@@ -864,7 +865,7 @@ define([
         var callbacks = this._msg_callbacks[msg_id];
         if (callbacks !== undefined) {
             callbacks.shell_done = true;
-            if (callbacks.iopub_done) {
+            if (callbacks.clear_on_done && callbacks.iopub_done) {
                 this.clear_callbacks_for_msg(msg_id);
             }
         }
@@ -877,7 +878,7 @@ define([
         var callbacks = this._msg_callbacks[msg_id];
         if (callbacks !== undefined) {
             callbacks.iopub_done = true;
-            if (callbacks.shell_done) {
+            if (callbacks.clear_on_done && callbacks.shell_done) {
                 this.clear_callbacks_for_msg(msg_id);
             }
         }
@@ -900,8 +901,13 @@ define([
             cbcopy.shell = callbacks.shell;
             cbcopy.iopub = callbacks.iopub;
             cbcopy.input = callbacks.input;
+            cbcopy.clear_on_done = callbacks.clear_on_done;
             cbcopy.shell_done = (!callbacks.shell);
             cbcopy.iopub_done = (!callbacks.iopub);
+            if (callbacks.clear_on_done === undefined) {
+                // default to clear-on-done
+                cbcopy.clear_on_done = true;
+            }
         } else {
             this.last_msg_callbacks = {};
         }


### PR DESCRIPTION
adds callbacks.clear_on_done bool flag for kernel callbacks.

Default: true (preserve pre-existing behavior)

Setting to false means that the caller is taking responsibility for clearing callbacks.
Use this in cells to only clear callbacks on the next execution, for better handling of async output.