### PR TITLE
Fix: Carriage symbol should behave like in console

### DIFF
--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -444,12 +444,13 @@ define([
     // Remove chunks that should be overridden by the effect of
     // carriage return characters
     function fixCarriageReturn(txt) {
-        var tmp = txt;
-        do {
-            txt = tmp;
-            tmp = txt.replace(/\r+\n/gm, '\n'); // \r followed by \n --> newline
-            tmp = tmp.replace(/^.*\r+/gm, '');  // Other \r --> clear line
-        } while (tmp.length < txt.length);
+        txt = txt.replace(/\r+\n/gm, '\n'); // \r followed by \n --> newline
+        while (txt.search(/\r/g) > -1) {
+            var base = txt.match(/^.*\r+/m)[0].replace(/\r/, '');
+            var insert = txt.match(/\r+.*$/m)[0].replace(/\r/, '');
+            insert = insert + base.slice(insert.length, base.length);
+            txt = txt.replace(/\r+.*$/m, '\r').replace(/^.*\r+/m, insert);
+        }
         return txt;
     }
 


### PR DESCRIPTION
Continuation of https://github.com/jupyter/notebook/pull/1833

This PR makes carriage return symbols behave like in `jupyter console`. It uses [this function](https://github.com/lgeiger/escape-carriage/blob/master/index.js) to escape the carriage return.

Here's a example:
```python
print('this sentence\rthat\nwill make you pause')
```

`jupyter notebook` master prints:
```
that
will make you pause
```

`jupyter console` prints:

 ```
that sentence
will make you pause
```