### PR TITLE
terminal: Bump xterm.js to 2.0.1

### DIFF
--- a/notebook/static/terminal/js/terminado.js
+++ b/notebook/static/terminal/js/terminado.js
@@ -2,12 +2,9 @@ define (["xterm"], function(Terminal) {
     "use strict";
     function make_terminal(element, size, ws_url) {
         var ws = new WebSocket(ws_url);
-        Terminal.brokenBold = true;
         var term = new Terminal({
           cols: size.cols,
-          rows: size.rows,
-          screenKeys: false,
-          useStyle: false
+          rows: size.rows
         });
         ws.onopen = function(event) {
             ws.send(JSON.stringify(["set_size", size.rows, size.cols,

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "moment": "^2.8.4",
     "preact": "^4.5.1",
     "preact-compat": "^1.7.0",
-    "xterm": "^1.1.3"
+    "xterm": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "moment": "^2.8.4",
     "preact": "^4.5.1",
     "preact-compat": "^1.7.0",
-    "xterm": "^2.0.1"
+    "xterm": "^2.1.0"
   }
 }


### PR DESCRIPTION
Primary fix is better copy / paste support

Release notes in https://github.com/sourcelair/xterm.js/releases/tag/2.0.1

Doesn't seem to break any styling, unlike the last update I made :)
