### PR TITLE
iopub rate limit refinements

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -915,7 +915,7 @@ class NotebookApp(JupyterApp):
         help="Reraise exceptions encountered loading server extensions?",
     )
 
-    iopub_msg_rate_limit = Float(1000, config=True, help="""(msg/sec)
+    iopub_msg_rate_limit = Float(1000, config=True, help="""(msgs/sec)
         Maximum rate at which messages can be sent on iopub before they are
         limited.""")
 


### PR DESCRIPTION
- reset counter on status: idle (avoids Run All running into limits)
- fix rate measurements to exclude messages not sent due to rate limiting
- fix formatting of rate-exceeded messages, tweak text a bit
- after pausing output, don't resume sending until rate has dropped 20% below limit, to avoid rapid back & forth across the limit

cc @haraldschilly who brought up the Run All issue on gitter.
