### PR TITLE
fix notebook mime-type on download links

### DIFF
--- a/notebook/files/handlers.py
+++ b/notebook/files/handlers.py
@@ -43,7 +43,7 @@ class FilesHandler(IPythonHandler):
         
         # get mimetype from filename
         if name.endswith('.ipynb'):
-            self.set_header('Content-Type', 'application/json')
+            self.set_header('Content-Type', 'application/x-ipynb+json')
         else:
             cur_mime = mimetypes.guess_type(name)[0]
             if cur_mime is not None:


### PR DESCRIPTION
notebooks are not `application/json`, they are `application/x-ipynb+json`.

This fixes Safari adding the `.json` extension to notebooks on download.