### PR TITLE
don't store default editable/deletable metadata

### DIFF
--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -489,6 +489,15 @@ define([
         var data = {};
         // deepcopy the metadata so copied cells don't share the same object
         data.metadata = JSON.parse(JSON.stringify(this.metadata));
+        if (data.metadata.deletable) {
+            delete data.metadata.deletable;
+        }
+        if (data.metadata.editable) {
+            delete data.metadata.editable;
+        }
+        if (data.metadata.collapsed === false) {
+            delete data.metadata.collapsed;
+        }
         data.cell_type = this.cell_type;
         return data;
     };

--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -501,14 +501,6 @@ define([
         if (data.metadata !== undefined) {
             this.metadata = data.metadata;
         }
-        // upgrade cell's editable metadata if not defined
-        if (this.metadata.editable === undefined) {
-          this.metadata.editable = this.is_editable();
-        }
-        // upgrade cell's deletable metadata if not defined
-        if (this.metadata.deletable === undefined) {
-          this.metadata.deletable = this.is_deletable();
-        }
     };
 
 

--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -535,7 +535,11 @@ define([
         var outputs = this.output_area.toJSON();
         data.outputs = outputs;
         data.metadata.trusted = this.output_area.trusted;
-        data.metadata.collapsed = this.output_area.collapsed;
+        if (this.output_area.collapsed) {
+            data.metadata.collapsed = this.output_area.collapsed;
+        } else {
+            delete data.metadata.collapsed;
+        }
         if (this.output_area.scroll_state === 'auto') {
             delete data.metadata.scrolled;
         } else {


### PR DESCRIPTION
it fills notebooks with redundant flags

these should only be stored if defined and not-default

follow-up to #1482