### PR TITLE
Add a `register_mime_type` method to OutputArea

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -526,7 +526,8 @@ import {ShortcutEditor} from 'notebook/js/shortcuteditor';
      * @return {jQuery} A selector of all cell elements
      */
     Notebook.prototype.get_cell_elements = function () {
-        return this.container.find(".cell").not('.cell .cell');
+        var container = this.container || $('#notebook-container')
+        return container.find(".cell").not('.cell .cell');
     };
 
     /**

--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -996,6 +996,15 @@ define([
         [MIME_JAVASCRIPT] : append_javascript,
         [MIME_PDF] : append_pdf
     };
+    
+    OutputArea.prototype.register_mime_type = function (mimetype, append, safe) {
+        if (mimetype && typeof(append) === 'function') {
+            OutputArea.output_types.push(mimetype);
+            if (safe) OutputArea.safe_outputs[mimetype] = true;
+            OutputArea.display_order.unshift(mimetype);
+            OutputArea.append_map[mimetype] = append;
+        }
+    };
 
     return {'OutputArea': OutputArea};
 });


### PR DESCRIPTION
This method will allow nbextensions to easily register a new mime type and a renderer for that mime type.

Usage:

```js
var append_json = function (json, md, element) {
  var type = ‘application/json’;
  var toinsert = this.create_output_subarea(md, 'output_json rendered_html', type);
  this.keyboard_manager.register_events(toinsert);
  ReactDOM.render(React.createElement(JSONTree, {data: json}), toinsert[0]);
  element.append(toinsert);
  return toinsert;
};
Object.getPrototypeOf(OutputArea).register_mime_type(‘application/json’, append_json, true);
```

See https://github.com/gnestor/notebook_json/tree/render-output for a working implementation  using this method.

Some considerations:

* Should this method not allow the replacement over append functions (e.g. registering a new append function for 'text/markdown' 'text/html')?
* We probably needs tests for this...