### PR TITLE
Allow None for post_save_hook

### DIFF
--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -93,7 +93,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
         self.post_save_hook = _post_save_script
 
-    post_save_hook = Any(None, config=True,
+    post_save_hook = Any(None, config=True, allow_none=True,
         help="""Python callable or importstring thereof
 
         to be called on the path of a file just saved.


### PR DESCRIPTION
See gh-1868

We're also discussing changes to traitlets that might avoid the need for this, in ipython/traitlets#342. But this is the simple fix.