### PR TITLE
support routing updating outputs with display_id

### DIFF
--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -219,23 +219,30 @@ define([
         var json = {};
         var msg_type = json.output_type = msg.header.msg_type;
         var content = msg.content;
-        if (msg_type === "stream") {
+        switch(msg_type) {
+        case "stream" :
             json.text = content.text;
             json.name = content.name;
-        } else if (msg_type === "display_data") {
+            break;
+        case "update_display_data":
+            json.output_type = "display_data";
+        case "display_data":
+            json.transient = content.transient;
             json.data = content.data;
             json.metadata = content.metadata;
-            json.transient = content.transient;
-        } else if (msg_type === "execute_result") {
+            break;
+        case "execute_result":
             json.data = content.data;
             json.metadata = content.metadata;
             json.execution_count = content.execution_count;
-        } else if (msg_type === "error") {
+            break;
+        case "error":
             json.ename = content.ename;
             json.evalue = content.evalue;
             json.traceback = content.traceback;
-        } else {
-            console.log("unhandled output message", msg);
+            break;
+        default:
+            console.error("unhandled output message", msg);
             return;
         }
         this.append_output(json);

--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -860,6 +860,7 @@ define([
             var callbacks = this._msg_callbacks[msg_id];
             var kernel = this;
             // clear display_id:msg_id map for display_ids associated with this msg_id
+            if (!callbacks) return;
             callbacks.display_ids.map(function (display_id) {
                 var msg_ids = kernel._display_id_targets[display_id];
                 if (msg_ids) {
@@ -1086,12 +1087,16 @@ define([
                 var target_msg_ids = this._display_id_targets[display_id];
                 if (target_msg_ids) {
                     // we've seen it before, update existing outputs with same id
+                    // by handling display_data as update_display_data
+                    var update_msg = $.extend(true, {}, msg);
+                    update_msg.header.msg_type = 'update_display_data';
+
                     target_msg_ids.map(function (target_msg_id) {
                         var callbacks = that.get_callbacks_for_msg(target_msg_id);
                         if (!callbacks) return;
                         var callback = callbacks.iopub.output;
                         if (callback) {
-                            callback(msg);
+                            callback(update_msg);
                         }
                     });
                 }
@@ -1109,7 +1114,9 @@ define([
                     this._display_id_targets[display_id].push(msg_id);
                 }
                 // and in callbacks for cleanup on clear_callbacks_for_msg
-                callbacks.display_ids.push(display_id);
+                if (callbacks && callbacks.display_ids.indexOf(display_id) === -1) {
+                    callbacks.display_ids.push(display_id);
+                }
             }
         }
 

--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -1067,7 +1067,7 @@ define([
         var callbacks = this.get_callbacks_for_msg(msg_id);
         if (msg.header.msg_type === 'display_data') {
             // display_data messages may re-route based on their display_id
-            var display_id = msg.content.display_id;
+            var display_id = (msg.content.transient || {}).display_id;
             if (display_id) {
                 // it has a display_id
                 var target_msg_id = this._display_id_targets[display_id];

--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -1079,7 +1079,7 @@ define([
         var that = this;
         var msg_id = msg.parent_header.msg_id;
         var callbacks = this.get_callbacks_for_msg(msg_id);
-        if (['display_data', 'update_display_data'].indexOf(msg.header.msg_type) > -1) {
+        if (['display_data', 'update_display_data', 'execute_result'].indexOf(msg.header.msg_type) > -1) {
             // display_data messages may re-route based on their display_id
             var display_id = (msg.content.transient || {}).display_id;
             if (display_id) {

--- a/notebook/tests/notebook/display_id.js
+++ b/notebook/tests/notebook/display_id.js
@@ -1,0 +1,82 @@
+//
+// Various output tests
+//
+
+casper.notebook_test(function () {
+    
+    function get_outputs(cell_idx) {
+        var outputs_json = casper.evaluate(function (cell_idx) {
+            var cell = Jupyter.notebook.get_cell(cell_idx);
+            return JSON.stringify(cell.output_area.outputs);
+        }, {cell_idx: cell_idx});
+        return JSON.parse(outputs_json);
+    }
+    
+    this.thenEvaluate(function () {
+        Jupyter.notebook.insert_cell_at_index("code", 0);
+        var cell = Jupyter.notebook.get_cell(0);
+        cell.set_text([
+            "ip = get_ipython()",
+            "from IPython.display import display",
+            "def display_with_id(obj, display_id, update=False):",
+            "  iopub = ip.kernel.iopub_socket",
+            "  session = get_ipython().kernel.session",
+            "  data, md = ip.display_formatter.format(obj)",
+            "  transient = {'display_id': display_id}",
+            "  content = {'data': data, 'metadata': md, 'transient': transient}",
+            "  msg_type = 'update_display_data' if update else 'display_data'",
+            "  session.send(iopub, msg_type, content, parent=ip.parent_header)",
+            "",
+        ].join('\n'));
+        cell.execute();
+    });
+
+    this.thenEvaluate(function () {
+        Jupyter.notebook.insert_cell_at_index("code", 1);
+        var cell = Jupyter.notebook.get_cell(1);
+        cell.set_text([
+            "display('above')",
+            "display_with_id(1, 'here')",
+            "display('below')",
+        ].join('\n'));
+        cell.execute();
+    });
+
+    this.wait_for_output(1);
+
+    this.then(function () {
+        var outputs = get_outputs(1);
+        this.test.assertEquals(outputs.length, 3, 'cell 1 has the right number of outputs');
+        this.test.assertEquals(outputs[1].transient.display_id, 'here', 'has transient display_id');
+        this.test.assertEquals(outputs[1].data['text/plain'], '1', 'display_with_id produces output');
+    });
+
+
+    this.thenEvaluate(function () {
+        Jupyter.notebook.insert_cell_at_index("code", 2);
+        var cell = Jupyter.notebook.get_cell(2);
+        cell.set_text([
+            "display_with_id(2, 'here')",
+            "display_with_id(3, 'there')",
+            "display_with_id(4, 'here')",
+        ].join('\n'));
+        cell.execute();
+    });
+
+    this.wait_for_output(2);
+
+    this.then(function () {
+        var outputs1 = get_outputs(1);
+        this.test.assertEquals(outputs1[1].data['text/plain'], '4', '');
+        this.test.assertEquals(outputs1.length, 3, 'cell 1 still has the right number of outputs');
+        var outputs2 = get_outputs(2);
+        this.test.assertEquals(outputs2.length, 3, 'cell 2 has the right number of outputs');
+        this.test.assertEquals(outputs2[0].transient.display_id, 'here', 'check display id 0');
+        this.test.assertEquals(outputs2[0].data['text/plain'], '4', 'output[2][0]');
+        this.test.assertEquals(outputs2[1].transient.display_id, 'there', 'display id 1');
+        this.test.assertEquals(outputs2[1].data['text/plain'], '3', 'output[2][1]');
+        this.test.assertEquals(outputs2[2].transient.display_id, 'here', 'display id 2');
+        this.test.assertEquals(outputs2[2].data['text/plain'], '4', 'output[2][2]');
+    });
+
+});


### PR DESCRIPTION
notebook implementation of jupyter/jupyter_client#209

- display(id=...) always adds something to the page
- update(id=...) updates only existing things on page

A single display_id can be used multiple times on the page, and all instances will be updated and kept in sync.

related: https://github.com/ipython/ipykernel/pull/204 , https://github.com/ipython/ipython/pull/10048