### PR TITLE
Fix bug when attempting to remove old nbserver info files

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1330,7 +1330,7 @@ def list_running_servers(runtime_dir=None):
             else:
                 # If the process has died, try to delete its info file
                 try:
-                    os.unlink(file)
+                    os.unlink(os.path.join(runtime_dir, file))
                 except OSError:
                     pass  # TODO: This should warn or log or something
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
When list_running_servers find an old nbserver-xxxx.json info file, it attempts to delete it. It needs to use the full path rather than the filename. An exception was being raised, but the error was suppressed silently.

This fixes issue #1886 