### PR TITLE
Fix extending range selection down to markdown cell

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ platform:
 build: off
 
 install:
-  - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
+  - appveyor DownloadFile "https://raw.githubusercontent.com/conda-forge/conda-smithy/master/bootstrap-obvious-ci-and-miniconda.py"
   - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %platform% %CONDA_PY:~0,1% --without-obvci
 
   # Add a hack to switch to `conda` version `4.1.12` before activating.

--- a/notebook/static/notebook/js/textcell.js
+++ b/notebook/static/notebook/js/textcell.js
@@ -315,7 +315,7 @@ define([
     };
 
     MarkdownCell.prototype.select = function () {
-        var cont = TextCell.prototype.select.apply(this);
+        var cont = TextCell.prototype.select.apply(this, arguments);
         if (cont) {
             this.notebook.set_insert_image_enabled(!this.rendered);
         }


### PR DESCRIPTION
The 'moveanchor' argument was not getting passed down to the parent class' `select()` method.

Closes gh-1589