### PR TITLE
Accept JSON output data with mime type "application/*+json"

### DIFF
--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -275,7 +275,7 @@ define([
         }
         var data = bundle.data;
         $.map(OutputArea.output_types, function(key){
-            if (key !== 'application/json' &&
+            if ((key.indexOf('application/') === -1 || key.indexOf('json') === -1) &&
                 data[key] !== undefined &&
                 typeof data[key] !== 'string'
             ) {


### PR DESCRIPTION
Currently, output data must be a string unless the mime type equals “application/json”. This doesn’t allow JSON output data to be rendered by mime types such as “application/vnd.plotly.v1+json” or “application/vnd.vega+json”. This change simply allows JSON output data to be rendered by a custom mime renderer if the mime type includes “application/“ and “json”. 