### PR TITLE
Allow websocket connections from scripts

### DIFF
--- a/notebook/base/zmqhandlers.py
+++ b/notebook/base/zmqhandlers.py
@@ -133,13 +133,9 @@ class WebSocketMixin(object):
         if origin is None:
             origin = self.get_origin()
         
-        # If no header is provided, assume we can't verify origin
-        if origin is None:
-            self.log.warning("Missing Origin header, rejecting WebSocket connection.")
-            return False
-        if host is None:
-            self.log.warning("Missing Host header, rejecting WebSocket connection.")
-            return False
+        # If no origin or host header is provided, assume from script
+        if origin is None or host is None:
+            return True
         
         origin = origin.lower()
         origin_host = urlparse(origin).netloc


### PR DESCRIPTION
scripts don't set origin on connection

we allow these on API requests, websockets should match.

cc @rgbkrk: is there a reason we block 'missing origin' websockets when we allow the same for API requests? Is it possible for a request from a sensible browser to be missing Host and/or Origin?