### PR TITLE
Add `Notebook.render_cell_output` method

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1640,6 +1640,17 @@ import {ShortcutEditor} from 'notebook/js/shortcuteditor';
             first_inserted.focus_cell();
         }
     };
+    
+    /**
+     * Re-render the output of a CodeCell.
+     */
+    Notebook.prototype.render_cell_output = function (code_cell) {
+        var cell_data = code_cell.toJSON();
+        var cell_index = this.find_cell_index(code_cell);
+        this.delete_cell(cell_index);
+        var new_cell = this.insert_cell_at_index(cell_data.cell_type, cell_index);
+        new_cell.fromJSON(cell_data);
+    };
 
     // Split/merge
 


### PR DESCRIPTION
Continuation of https://github.com/jupyter/notebook/pull/1866 and https://github.com/gnestor/notebook_json/pull/5 depends on this.

Since extensions are _usually_ loaded after the notebook has loaded and outputs have been rendered, a mime type renderer extension requires an API method for re-rendering the output of a cell after the extension has loaded and registered its mime type using `OutputArea.register_mime_type`. This method allows extensions to do that by replacing a cell with itself which will trigger a re-render.