### PR TITLE
load minified typeahead.min.js

### DIFF
--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -37,7 +37,7 @@
             moment: 'components/moment/moment',
             codemirror: 'components/codemirror',
             termjs: 'components/xterm.js/dist/xterm',
-            typeahead: 'components/jquery-typeahead/dist/jquery.typeahead'
+            typeahead: 'components/jquery-typeahead/dist/jquery.typeahead.min',
           },
 	  map: { // for backward compatibility
 	    "*": {


### PR DESCRIPTION
not needed on master, which already loads the right thing.

closes #1154