### PR TITLE
Fix sphinx warning about new lines after markup

### DIFF
--- a/docs/source/examples/Notebook/Working With Markdown Cells.ipynb
+++ b/docs/source/examples/Notebook/Working With Markdown Cells.ipynb
@@ -162,12 +162,15 @@
     "$e^{i\\pi} + 1 = 0$  and displayed:\n",
     "\n",
     "$$e^x=\\sum_{i=0}^\\infty \\frac{1}{i!}x^i$$\n",
+    "\n",
     "Inline expressions can be added by surrounding the latex code with `$`:\n",
+    "\n",
     "```\n",
     "$e^{i\\pi} + 1 = 0$\n",
     "```\n",
     "\n",
     "Expressions on their own line are surrounded by `$$`:\n",
+    "\n",
     "```latex\n",
     "$$e^x=\\sum_{i=0}^\\infty \\frac{1}{i!}x^i$$\n",
     "```"
@@ -309,6 +312,7 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -324,9 +328,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Gets rid of the warning when making the docs regarding indentation, newlines and markup.