### PR TITLE
adding link to actual source file per spatialaudio/nbsphinx#74

### DIFF
--- a/docs/source/examples/Notebook/Distributing Jupyter Extensions as Python Packages.ipynb
+++ b/docs/source/examples/Notebook/Distributing Jupyter Extensions as Python Packages.ipynb
@@ -348,7 +348,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "See [Extending the Notebook](../../extending) for more documentation about writing nbextensions, server extensions, and bundler extensions."
+    "See [Extending the Notebook](../../extending/index.rst) for more documentation about writing nbextensions, server extensions, and bundler extensions."
    ]
   }
  ],


### PR DESCRIPTION
Fixes link for sphinx & LaTeX export