### PR TITLE
Add \[ \] and \( \) as maths delimiters

### DIFF
--- a/notebook/static/notebook/js/mathjaxutils.js
+++ b/notebook/static/notebook/js/mathjaxutils.js
@@ -58,7 +58,7 @@ define([
 
     // MATHSPLIT contains the pattern for math delimiters and special symbols
     // needed for searching for math in the text input.
-    var MATHSPLIT = /(\$\$?|\\(?:begin|end)\{[a-z]*\*?\}|\\[\\{}$]|[{}]|(?:\n\s*)+|@@\d+@@)/i;
+    var MATHSPLIT = /(\$\$?|\\[\[\(\)\]]|\\(?:begin|end)\{[a-z]*\*?\}|\\[\\{}$]|[{}]|(?:\n\s*)+|@@\d+@@)/i
 
     //  The math is in blocks i through j, so
     //    collect it into one block and clear the others.
@@ -95,10 +95,12 @@ define([
     //
     var remove_math = function (text) {
         var math = []; // stores math strings for later
+        var math_delimiters = { "\\[": "\\]", "\\(": "\\)", "$$": "$$", "$": "$" };
         var start;
         var end;
         var last;
         var braces;
+
 
         // Except for extreme edge cases, this should catch precisely those pieces of the markdown
         // source that will later be turned into code spans. While MathJax will not TeXify code spans,
@@ -172,9 +174,9 @@ define([
                 //  Look for math start delimiters and when
                 //    found, set up the end delimiter.
                 //
-                if (block === inline || block === "$$") {
+                if (block in math_delimiters) {
                     start = i;
-                    end = block;
+                    end = math_delimiters[block];
                     braces = 0;
                 }
                 else if (block.substr(1, 5) === "begin") {


### PR DESCRIPTION
As mentioned in [nbconvert/#477](https://github.com/jupyter/nbconvert/issues/477) and earlier in [notebook#759](https://github.com/jupyter/notebook/issues/759), \\[ \\]  and \\( \\) are not recognized as maths delimiters, and the equations not correctly displayed. 
This is not intuitive for LaTeX users (as it is now the recommended way to delimit maths) and causes problems when converting to eg html since the contents of those maths blocks is considered as markdown. 
The PR attempt to solve that by updating `mathjaxutils.js`
- the regex MATHSPLIT is updated to account for these new delimiters
- new start/end delimiters are matched