### PR TITLE
don't check origin on token-authenticated requests

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -295,8 +295,8 @@ class IPythonHandler(AuthenticatedHandler):
             # No CORS headers deny the request
             allow = False
         if not allow:
-            self.log.warning("Blocking Cross Origin API request.  Origin: %s, Host: %s",
-                origin, host,
+            self.log.warning("Blocking Cross Origin API request for %s.  Origin: %s, Host: %s",
+                self.request.path, origin, host,
             )
         return allow
     

--- a/notebook/base/zmqhandlers.py
+++ b/notebook/base/zmqhandlers.py
@@ -126,7 +126,9 @@ class WebSocketMixin(object):
         
         Tornado >= 4 calls this method automatically, raising 403 if it returns False.
         """
-        if self.allow_origin == '*':
+
+        if self.allow_origin == '*' or (
+            hasattr(self, 'skip_check_origin') and self.skip_check_origin()):
             return True
 
         host = self.request.headers.get("Host")

--- a/notebook/services/security/handlers.py
+++ b/notebook/services/security/handlers.py
@@ -3,18 +3,22 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from tornado import gen, web
+from tornado import web
 
 from ...base.handlers import APIHandler, json_errors
 from . import csp_report_uri
 
 class CSPReportHandler(APIHandler):
     '''Accepts a content security policy violation report'''
+
+    def skip_origin_check(self):
+        """Don't check origin when reporting origin-check violations!"""
+        return True
+
     @json_errors
     @web.authenticated
     def post(self):
         '''Log a content security policy violation report'''
-        csp_report = self.get_json_body()
         self.log.warning("Content security violation: %s",
                       self.request.body.decode('utf8', 'replace'))
 


### PR DESCRIPTION
adds LoginHandler.should_check_origin classmethod API

While testing, I noticed that we were checking origin and authentication on CSP violation reports, but browsers are sending CSP reports with no Origin, meaning that no CSP report will ever be accepted. That doesn't make sense to me, so I disabled both - a CSP report can now be made from *anywhere* (no auth, no check). @rgbkrk does that sound right to you? Or should it be authenticated but no origin check?