### PR TITLE
Add debug log for static file paths

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -40,6 +40,12 @@ non_alphanum = re.compile(r'[^A-Za-z0-9]')
 
 sys_info = json.dumps(get_sys_info())
 
+def log():
+    if Application.initialized():
+        return Application.instance().log
+    else:
+        return app_log
+
 class AuthenticatedHandler(web.RequestHandler):
     """A RequestHandler with an authenticated user."""
     
@@ -141,10 +147,7 @@ class IPythonHandler(AuthenticatedHandler):
     @property
     def log(self):
         """use the IPython log by default, falling back on tornado's logger"""
-        if Application.initialized():
-            return Application.instance().log
-        else:
-            return app_log
+        return log()
 
     @property
     def jinja_template_vars(self):
@@ -538,6 +541,9 @@ class FileFindHandler(IPythonHandler, web.StaticFileHandler):
                 return ''
             
             cls._static_paths[path] = abspath
+            
+
+            log().debug("Path %s served from %s"%(path, abspath))
             return abspath
     
     def validate_absolute_path(self, root, absolute_path):


### PR DESCRIPTION
Too often I'm trying to track down an errant extra static file path (like some javascript installed in some obscure place). This makes it easy to see exactly what is being served.