### PR TITLE
Catch and log handler exceptions in events.trigger

### DIFF
--- a/notebook/static/base/js/events.js
+++ b/notebook/static/base/js/events.js
@@ -22,5 +22,16 @@ define(['base/js/namespace'], function(Jupyter) {
     Jupyter.Events = window._Events;
     Jupyter.events = window._events;
     
-    return $([window._events]);
+    var events = $([window._events]);
+
+    // catch and log errors in triggered events
+    events._original_trigger = events.trigger;
+    events.trigger = function (name, data) {
+        try {
+            this._original_trigger.apply(this, arguments);
+        } catch (e) {
+            console.error("Exception in event handler for " + name, e, arguments);
+        }
+    }
+    return events;
 });


### PR DESCRIPTION
rather than throwing handler errors in the call to `.trigger()`,
which I think we don't expect to happen (at least our code suggest we don't).

Extensions can register buggy event handlers. These should not be able to cause failures in the event-triggering code paths.

This should fix several avenues by which extensions (or other bugs) could prevent a notebook from loading.

This closes #1602 in that the bug doesn't prevent notebook loading, but it doesn't fix the original error @parente is seeing. I don't fully understand the cause there, because notebook loading doesn't start before the page has finished loading.