### PR TITLE
Fix dependency level of underscore.js in bower.json.  Fixes #1894

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
     "MathJax": "components/MathJax#~2.6",
     "requirejs": "~2.1",
     "text-encoding": "~0.1",
-    "underscore": "components/underscore#~1.5"
+    "underscore": "components/underscore#~1.8.3"
   }
 }


### PR DESCRIPTION
The bower.json and package.json are out of sync wrt underscore.js, which causes Windows based systems to produce a blank screen when running from source. The fix is simple and eliminates the problem. See also #1495, as I'm pretty sure it's the same issue there.