### PR TITLE
Set mimerender index in `OutputArea.display_order`

### DIFF
--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -1079,8 +1079,8 @@ define([
     OutputArea.prototype.register_mime_type = function (mimetype, append, options) {
         if (mimetype && typeof(append) === 'function') {
             OutputArea.output_types.push(mimetype);
-            if (safe) OutputArea.safe_outputs[mimetype] = true;
-            OutputArea.display_order.unshift(mimetype);
+            if (options.safe) OutputArea.safe_outputs[mimetype] = true;
+            OutputArea.display_order.splice(options.index || 0, 0, mimetype);
             OutputArea.append_map[mimetype] = append;
         }
     };

--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -1072,7 +1072,11 @@ define([
         [MIME_PDF] : append_pdf
     };
     
-    OutputArea.prototype.register_mime_type = function (mimetype, append, safe) {
+    OutputArea.prototype.mime_types = function () {
+        return OutputArea.display_order;
+    };
+    
+    OutputArea.prototype.register_mime_type = function (mimetype, append, options) {
         if (mimetype && typeof(append) === 'function') {
             OutputArea.output_types.push(mimetype);
             if (safe) OutputArea.safe_outputs[mimetype] = true;


### PR DESCRIPTION
Usage:

```js
OutputArea.register_mime_type(MIME_TYPE, append_json, {
    safe: true,
    index: 1
});
```

Reference implementation: https://github.com/jupyterlab/mimerender-cookiecutter/pull/9