### PR TITLE
Mitigation for POST requests from malicious forms

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -346,7 +346,7 @@ class IPythonHandler(AuthenticatedHandler):
     def get_json_body(self):
         """Return the body of the request as JSON data."""
         if not self.request.body:
-            return None
+            raise web.HTTPError(400, u'No JSON in body of request')
         # Do we need to call body.decode('utf-8') here?
         body = self.request.body.strip().decode(u'utf-8')
         try:

--- a/notebook/services/kernels/tests/test_kernels_api.py
+++ b/notebook/services/kernels/tests/test_kernels_api.py
@@ -61,7 +61,7 @@ class KernelAPITest(NotebookTestBase):
 
     def test_default_kernel(self):
         # POST request
-        r = self.kern_api._req('POST', '')
+        r = self.kern_api._req('POST', '', body='{}')
         kern1 = r.json()
         self.assertEqual(r.headers['location'], url_path_join(self.url_prefix, 'api/kernels', kern1['id']))
         self.assertEqual(r.status_code, 201)

--- a/notebook/services/sessions/tests/test_sessions_api.py
+++ b/notebook/services/sessions/tests/test_sessions_api.py
@@ -154,7 +154,7 @@ class SessionAPITest(NotebookTestBase):
 
     def test_create_with_kernel_id(self):
         # create a new kernel
-        r = requests.post(url_path_join(self.base_url(), 'api/kernels'))
+        r = requests.post(url_path_join(self.base_url(), 'api/kernels'), json={})
         r.raise_for_status()
         kernel = r.json()
 
@@ -232,7 +232,7 @@ class SessionAPITest(NotebookTestBase):
         sid = before['id']
 
         # create a new kernel
-        r = requests.post(url_path_join(self.base_url(), 'api/kernels'))
+        r = requests.post(url_path_join(self.base_url(), 'api/kernels'), json={})
         r.raise_for_status()
         kernel = r.json()
 


### PR DESCRIPTION
In discussion on gh-1830, I found that HTML forms in Firefox do not send an Origin header. You can therefore submit a POST request with an empty body to trigger certain actions, such as starting a kernel, avoiding the origin check we do.

This mitigates that for creating files and starting kernels, by requiring a JSON body, even if there's no data. I cannot currently find a way to create a JSON body in a request sent from a form.

The other cases I've found are interrupting and restarting kernels. This does not affect those cases, but they are only possible if you have a kernel ID.