### PR TITLE
add Authorization to allowed CORS headers

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -416,7 +416,7 @@ class APIHandler(IPythonHandler):
         return super(APIHandler, self).finish(*args, **kwargs)
 
     def options(self, *args, **kwargs):
-        self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
+        self.set_header('Access-Control-Allow-Headers', 'accept, content-type, authorization')
         self.set_header('Access-Control-Allow-Methods',
                         'GET, PUT, POST, PATCH, DELETE, OPTIONS')
         self.finish()


### PR DESCRIPTION
so that CORS requests can use token authentication in the Authorization header by default.

cf https://github.com/jupyterlab/jupyterlab/pull/1416