### PR TITLE
fix carriage return handling

### DIFF
--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -445,11 +445,11 @@ define([
     // carriage return characters
     function fixCarriageReturn(txt) {
         txt = txt.replace(/\r+\n/gm, '\n'); // \r followed by \n --> newline
-        while (txt.search(/\r/g) > -1) {
-            var base = txt.match(/^.*\r+/m)[0].replace(/\r/, '');
-            var insert = txt.match(/\r+.*$/m)[0].replace(/\r/, '');
+        while (txt.search(/\r[^$]/g) > -1) {
+            var base = txt.match(/^(.*)\r+/m)[1];
+            var insert = txt.match(/\r+(.*)$/m)[1];
             insert = insert + base.slice(insert.length, base.length);
-            txt = txt.replace(/\r+.*$/m, '\r').replace(/^.*\r+/m, insert);
+            txt = txt.replace(/\r+.*$/m, '\r').replace(/^.*\r/m, insert);
         }
         return txt;
     }

--- a/notebook/tests/base/utils.js
+++ b/notebook/tests/base/utils.js
@@ -48,7 +48,33 @@ casper.notebook_test(function () {
         that.test.assertEquals(result, testcase.result, "Overwriting characters processed");
     });
 
+    var input = [
+      'hasrn\r\n',
+      'hasn\n',
+      '\n',
+      'abcdef\r',
+      'hello\n',
+      'ab3\r',
+      'x2\r\r',
+      '1\r',
+    ].join('');
+    
+    var output = [
+      'hasrn\n',
+      'hasn\n',
+      '\n',
+      'hellof\n',
+      '123\r'
+    ].join('');
+    
+    var result = this.evaluate(function (input) {
+      return IPython.utils.fixCarriageReturn(input);
+    }, input);
+
+    this.test.assertEquals(result, output, "IPython.utils.fixCarriageReturns works");
+    
     // Test load_extensions
+
     this.thenEvaluate(function() {
         define('nbextensions/a', [], function() { window.a = true; });
         define('nbextensions/c', [], function() { window.c = true; });


### PR DESCRIPTION
The only real fix is an errant `+` on the final replacement, which would end up skipping sequential replacements.

- leaves trailing `\r` on the text, if there is one
- use groups to avoid unnecessary replace calls (no change)
- includes test