### PR TITLE
Ignore resize events that bubbled up and didn't come from window.

### DIFF
--- a/notebook/static/base/js/page.js
+++ b/notebook/static/base/js/page.js
@@ -52,9 +52,13 @@ define([
         this._resize_site();
     };
 
-    Page.prototype._resize_site = function() {
+    Page.prototype._resize_site = function(e) {
         // Update the site's size.
-        $('div#site').height($(window).height() - $('#header').height());
+        // only trigger if the event actually is the window's, not bubbling up.
+        // See https://bugs.jquery.com/ticket/9841#comment:8
+        if (!e.target.tagName) {
+            $('div#site').height($(window).height() - $('#header').height());
+        }
     };
 
     return {'Page': Page};

--- a/notebook/static/base/js/page.js
+++ b/notebook/static/base/js/page.js
@@ -52,11 +52,17 @@ define([
         this._resize_site();
     };
 
+
+
     Page.prototype._resize_site = function(e) {
-        // Update the site's size.
-        // only trigger if the event actually is the window's, not bubbling up.
-        // See https://bugs.jquery.com/ticket/9841#comment:8
-        if (!e.target.tagName) {
+        /**
+         * Update the site's size.
+         */
+
+        // In the case an event is passed in, only trigger if the event does
+        // *not* have a target DOM node (i.e., it is not bubbling up). See
+        // https://bugs.jquery.com/ticket/9841#comment:8
+        if (!(e && e.target && e.target.tagName)) {
             $('div#site').height($(window).height() - $('#header').height());
         }
     };


### PR DESCRIPTION
See https://bugs.jquery.com/ticket/9841 - we were having a major slowdown in interact widgets because the output areas were triggering a 'resize' event, which was bubbling up to the window object and running a function which required a DOM read.