### PR TITLE
remove debug statement about no custom error page template

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -383,15 +383,14 @@ class IPythonHandler(AuthenticatedHandler):
             message=message,
             exception=exception,
         )
-        
+
         self.set_header('Content-Type', 'text/html')
         # render the template
         try:
             html = self.render_template('%s.html' % status_code, **ns)
         except TemplateNotFound:
-            self.log.debug("No template for %d", status_code)
             html = self.render_template('error.html', **ns)
-        
+
         self.write(html)
 
 


### PR DESCRIPTION
We don't need a message when the default error page is used