### PR TITLE
Further highlight token info in log output

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1321,7 +1321,15 @@ class NotebookApp(JupyterApp):
                 b = lambda : browser.open(url_path_join(self.connection_url, uri),
                                           new=2)
                 threading.Thread(target=b).start()
-        
+
+        if self.token:
+            self.log.critical('\n'.join([
+                '\n',
+                'Copy/paste this URL into your browser when you connect for the first time,',
+                'to login with a token:',
+                '    %s' % url_concat(self.connection_url, {'token': self.token}),
+            ]))
+
         self.io_loop = ioloop.IOLoop.current()
         if sys.platform.startswith('win'):
             # add no-op to wake every 5s

--- a/notebook/templates/login.html
+++ b/notebook/templates/login.html
@@ -63,6 +63,9 @@ http://localhost:8888/?token=c8de56fa... :: /Users/you/notebooks
       <p>
         Or you can paste just the token value into the password field on this page.
       </p>
+      <p>
+        Cookies are required for authenticated access to notebooks.
+      </p>
     </div>
     {% endblock token_message %}
     {% endif %}

--- a/notebook/templates/login.html
+++ b/notebook/templates/login.html
@@ -20,7 +20,7 @@
       <div class="navbar-inner">
         <div class="container">
           <div class="center-nav">
-            <p class="navbar-text nav">Password or token:</p>
+            <p class="navbar-text nav">Password{% if token_available %} or token{% endif %}:</p>
             <form action="{{base_url}}login?next={{next}}" method="post" class="navbar-form pull-left">
               <input type="password" name="password" id="password_input" class="form-control">
               <button type="submit" id="login_submit">Log in</button>
@@ -42,10 +42,11 @@
       {% endfor %}
       </div>
     {% endif %}
+    {% if token_available %}
     {% block token_message %}
     <div class="col-sm-6 col-sm-offset-3 text-left">
       <p class="warning">
-        If this notebook server has no password set, token authentication is enabled.
+        Token authentication is enabled.
 
         You need to open the notebook server with its first-time login token in the URL,
         or enable a password in order to gain access.
@@ -64,6 +65,7 @@ http://localhost:8888/?token=c8de56fa... :: /Users/you/notebooks
       </p>
     </div>
     {% endblock token_message %}
+    {% endif %}
 </div>
 
 {% endblock %}


### PR DESCRIPTION
add critical-level log statement at the end of startup with token info

closes #1980