### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/source/notebook.rst
+++ b/docs/source/notebook.rst
@@ -142,7 +142,7 @@ and communicate back results.  This kernel remains active if the web browser
 window is closed, and reopening the same notebook from the dashboard will
 reconnect the web application to the same kernel. In the dashboard, notebooks
 with an active kernel have a ``Shutdown`` button next to them, whereas
-notebooks without an active kernel have a ``Delete`` button in its place.
+notebooks without an inactive kernel have a ``Delete`` button in its place.
 
 Other clients may connect to the same underlying IPython kernel.
 The notebook server always prints to the terminal the full details of


### PR DESCRIPTION
Active is inverted.