### PR TITLE
Downgrade to CodeMirror 5.16

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "backbone": "components/backbone#~1.2",
     "bootstrap": "components/bootstrap#~3.3",
     "bootstrap-tour": "0.9.0",
-    "codemirror": "components/codemirror#~5.21",
+    "codemirror": "components/codemirror#~5.16",
     "font-awesome": "components/font-awesome#~4.2.0",
     "google-caja": "5669",
     "jquery": "components/jquery#~2.0",


### PR DESCRIPTION
Temporary fix for https://github.com/jupyter/notebook/issues/1967

I have tested and this resolves the strange space behavior in Safari 10 👌 