### PR TITLE
add `jupyter notebook password` entrypoint

### DIFF
--- a/docs/source/public_server.rst
+++ b/docs/source/public_server.rst
@@ -53,6 +53,7 @@ configuring the :attr:`NotebookApp.password` setting in
 
 Prerequisite: A notebook configuration file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Check to see if you have a notebook configuration file,
 :file:`jupyter_notebook_config.py`. The default location for this file
 is your Jupyter folder in your home directory, ``~/.jupyter``.
@@ -66,7 +67,20 @@ using the following command::
 
 Preparing a hashed password
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-You can prepare a hashed password using the function
+
+As of notebook version 5.0, you can enter and store a password for your
+notebook server with a single command.
+:command:`jupyter notebook password` will prompt you for your password
+and record the hashed password in your :file:`jupyter_notebook_config.json`.
+
+.. code-block:: bash
+
+    $ jupyter notebook password
+    Enter password:  ****
+    Verify password: ****
+    [NotebookPasswordApp] Wrote hashed password to /Users/you/.jupyter/jupyter_notebook_config.json
+
+You can prepare a hashed password manually, using the function
 :func:`notebook.auth.security.passwd`:
 
 .. code-block:: ipython

--- a/docs/source/security.rst
+++ b/docs/source/security.rst
@@ -58,8 +58,20 @@ Once you have visited this URL,
 a cookie will be set in your browser and you won't need to use the token again,
 unless you switch browsers, clear your cookies, or start a notebook server on a new port.
 
+Alternatives to token authentication
+------------------------------------
 
-You can disable authentication altogether by setting the token and password to empty strings,
+If a generated token doesn't work well for you,
+you can set a password for your notebook.
+:command:`jupyter notebook password` will prompt you for a password,
+and store the hashed password in your :file:`jupyter_notebook_config.json`.
+
+.. versionadded:: 5.0
+
+    :command:`jupyter notebook password` command is added.
+
+
+It is possible disable authentication altogether by setting the token and password to empty strings,
 but this is **NOT RECOMMENDED**, unless authentication or access restrictions are handled at a different layer in your web application:
 
 .. sourcecode:: python

--- a/notebook/auth/security.py
+++ b/notebook/auth/security.py
@@ -9,8 +9,8 @@ import io
 import json
 import os
 import random
-import sys
 import traceback
+import warnings
 
 from ipython_genutils.py3compat import cast_bytes, str_to_bytes, cast_unicode
 from traitlets.config import Config, ConfigFileNotFound, JSONFileConfigLoader
@@ -133,9 +133,10 @@ def persist_config(config_file=None, mode=0o600):
 
     try:
         os.chmod(config_file, mode)
-    except Exception:
-        print("Failed to set permissions on %s:" % config_file, file=sys.stderr)
-        traceback.print_exc(file=sys.stderr)
+    except Exception as e:
+        tb = traceback.format_exc()
+        warnings.warn("Failed to set permissions on %s:\n%s" % (config_file, tb),
+            RuntimeWarning)
 
 
 def set_password(password=None, config_file=None):

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -331,9 +331,11 @@ class NotebookPasswordApp(JupyterApp):
     and removes the need for token-based authentication.
     """
     
+    description = __doc__
+
     def _config_file_default(self):
         return os.path.join(self.config_dir, 'jupyter_notebook_config.json')
-    description = __doc__
+
     def start(self):
         from .auth.security import set_password
         set_password(config_file=self.config_file)

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -106,6 +106,7 @@ from .utils import url_path_join, check_pid, url_escape
 _examples = """
 jupyter notebook                       # start the notebook
 jupyter notebook --certfile=mycert.pem # use SSL/TLS certificate
+jupyter notebook password              # enter a password to protect the server
 """
 
 DEV_NOTE_NPM = """It looks like you're running the notebook from source.
@@ -323,6 +324,22 @@ class NotebookWebApplication(web.Application):
         return new_handlers
 
 
+class NotebookPasswordApp(JupyterApp):
+    """Set a password for the notebook server.
+
+    Setting a password secures the notebook server
+    and removes the need for token-based authentication.
+    """
+    
+    def _config_file_default(self):
+        return os.path.join(self.config_dir, 'jupyter_notebook_config.json')
+    description = __doc__
+    def start(self):
+        from .auth.security import set_password
+        set_password(config_file=self.config_file)
+        self.log.info("Wrote hashed password to %s" % self.config_file)
+
+
 class NbserverListApp(JupyterApp):
     version = __version__
     description="List currently running notebook servers."
@@ -426,6 +443,7 @@ class NotebookApp(JupyterApp):
     
     subcommands = dict(
         list=(NbserverListApp, NbserverListApp.description.splitlines()[0]),
+        password=(NotebookPasswordApp, NotebookPasswordApp.description.splitlines()[0]),
     )
 
     _log_formatter_cls = LogFormatter


### PR DESCRIPTION
now that we are securing notebooks by default, increasing the convenience of defining a password is more important.

Mostly copied from the `tools/secure_notebook` script. I omitted the ssl-cert-generation from that script, since I think it's less portable to platforms like Windows, and there are many more ways to do it.

TODO:

- [x] update 'securing the notebook' docs with reference to this command
- [x] exercise with tests

cc @fperez

records, hashes, and stores password in json config