### PR TITLE
Don't use max-width on tables in rendered markdown

### DIFF
--- a/notebook/static/notebook/less/textcell.less
+++ b/notebook/static/notebook/less/textcell.less
@@ -44,6 +44,12 @@ h1,h2,h3,h4,h5,h6 {
     overflow-y: hidden;
 }
 
+.text_cell.rendered .rendered_html {
+	tr, th, td {
+		max-width: none;
+	}
+}
+
 .text_cell.unrendered .text_cell_render {
     display:none;
 }


### PR DESCRIPTION
Fixes #2008 