### PR TITLE
simple overload of passwd_check

### DIFF
--- a/notebook/auth/login.py
+++ b/notebook/auth/login.py
@@ -67,7 +67,7 @@ class LoginHandler(IPythonHandler):
     def hashed_password(self):
         return self.password_from_settings(self.settings)
 
-    def self.passwd_check(self, a, b):
+    def passwd_check(self, a, b):
         return passwd_check(a, b)
     
     def post(self):

--- a/notebook/auth/login.py
+++ b/notebook/auth/login.py
@@ -67,10 +67,13 @@ class LoginHandler(IPythonHandler):
     def hashed_password(self):
         return self.password_from_settings(self.settings)
 
+    def self.passwd_check(self, a, b):
+        return passwd_check(a, b)
+    
     def post(self):
         typed_password = self.get_argument('password', default=u'')
         if self.get_login_available(self.settings):
-            if passwd_check(self.hashed_password, typed_password):
+            if self.passwd_check(self.hashed_password, typed_password):
                 self.set_login_cookie(self, uuid.uuid4().hex)
             elif self.token and self.token == typed_password:
                 self.set_login_cookie(self, uuid.uuid4().hex)


### PR DESCRIPTION
part of a solution to use the unix password as the jupyter password involves this change, which allows us to overload 

```python
class SyncLogin(LoginHandler):
    def passwd_check(self, h, t ):
        import crypt
        h = self.get_hashed_password()
        return crypt.crypt(t, h ) == h
```

no other method worked.
I'd be happy to be given an alternative solution.