### PR TITLE
Mimetype tpl

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -53,7 +53,7 @@ define([
         };
         this._max_upload_size_mb = 25;
         this.EDIT_MIMETYPES = [
-          'application/javascipt',
+          'application/javascript',
           'application/x-sh',
           'application/vnd.groove-tool-template'
         ];

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -55,6 +55,7 @@ define([
         this.EDIT_MIMETYPES = [
           'application/javascipt',
           'application/x-sh',
+          'application/vnd.groove-tool-template'
         ];
     };
 


### PR DESCRIPTION
Currently if you try to write nbconvert templates in the browser (which have a `.tpl` extension) it will attempt to download it rather than allow you to open it in the browser. This makes it possible to create but not edit template files entirely within the browser. 

This is because the `.tpl` extension is [mapped to `application/vnd.groove-tool-template`][mimetype] is adhered to by Mac OS/OS X and Linux (as tested by @takluyver and I). Testing on an Azure notebook instead, it seems that Windows does not need this special casing. 

If you want to test this for yourself you can use the following code snippet (using ipython magics)

```python
! touch test.tpl test.tplx
from notebook.services.contents.filemanager import FileContentsManager
a = FileContentsManager()
print(a._file_model('/test.tpl')["mimetype"])
print(a._file_model('/test.tplx')["mimetype"])
```

It also fixes what appears to be a typo to the exception mimetype `application/javascript` which was originally typed `application/javascipt`.

There should be no security issues with this as it only is allowing these to be edited not executed or "viewed" even if another file has the .tpl mimetype.

[mimetype]: https://www.iana.org/assignments/media-types/application/vnd.groove-tool-template