### PR TITLE
Simple implementation of cell tags

### DIFF
--- a/notebook/static/notebook/js/celltoolbarpresets/tags.js
+++ b/notebook/static/notebook/js/celltoolbarpresets/tags.js
@@ -8,14 +8,24 @@ define([
 
     var CellToolbar = celltoolbar.CellToolbar;
 
-    var remove_tag = function(cell) {
-        return function(tag_name) {
+    var write_tag = function(cell, name, add) {
+        if (add) {
+            // Add to metadata
+            if (cell.metadata.tags === undefined) {
+                cell.metadata.tags = [];
+            } else if (cell.metadata.tags.indexOf(name) !== -1) {
+                // Tag already exists
+                return;
+            }
+            cell.metadata.tags.push(name);
+        } else {
+            // Remove from metadata
             if (!cell.metadata || !cell.metadata.tags) {
                 // No tags to remove
                 return;
             }
             // Remove tag from tags list
-            var index = cell.metadata.tags.indexOf(tag_name);
+            var index = cell.metadata.tags.indexOf(name);
             if (index !== -1) {
                 cell.metadata.tags.splice(index, 1);
             }
@@ -23,6 +33,13 @@ define([
             if (cell.metadata.tags.length === 0) {
                 delete cell.metadata.tags;
             }
+        }
+        cell.events.trigger('set_dirty.Notebook', {value: true});
+    }
+
+    var remove_tag = function(cell) {
+        return function(tag_name) {
+            return write_tag(cell, tag_name, false);
         };
     };
 
@@ -114,14 +131,8 @@ define([
         button_container.append(tag_container);
 
         add_tag_edit(div, cell, function(name) {
-            // Add to metadata
-            if (cell.metadata.tags === undefined) {
-                cell.metadata.tags = [];
-            } else if (cell.metadata.tags.indexOf(name) !== -1) {
-                // Tag already exists
-                return;
-            }
-            cell.metadata.tags.push(name);
+            // Write tag to metadata
+            write_tag(cell, name, true);
             // Make tag visual
             var tag = make_tag(name, on_remove);
             tag_container.append(tag);

--- a/notebook/static/notebook/js/celltoolbarpresets/tags.js
+++ b/notebook/static/notebook/js/celltoolbarpresets/tags.js
@@ -130,12 +130,21 @@ define([
         }
         button_container.append(tag_container);
 
-        add_tag_edit(div, cell, function(name) {
-            // Write tag to metadata
-            write_tag(cell, name, true);
-            // Make tag visual
-            var tag = make_tag(name, on_remove);
-            tag_container.append(tag);
+        add_tag_edit(div, cell, function(input) {
+            // Split on whitespace:
+            var names = input.split(/\s/);
+            for (var i=0; i < names.length; ++i) {
+                var name = names[i];
+                if (name === '') {
+                    // Skip empty strings
+                    continue;
+                }
+                // Write tag to metadata
+                write_tag(cell, name, true);
+                // Make tag visual
+                var tag = make_tag(name, on_remove);
+                tag_container.append(tag);
+            }
         });
     };
 

--- a/notebook/static/notebook/js/celltoolbarpresets/tags.js
+++ b/notebook/static/notebook/js/celltoolbarpresets/tags.js
@@ -1,0 +1,141 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+define([
+    'notebook/js/celltoolbar'
+], function(celltoolbar) {
+    "use strict";
+
+    var CellToolbar = celltoolbar.CellToolbar;
+
+    var remove_tag = function(cell) {
+        return function(tag_name) {
+            if (!cell.metadata || !cell.metadata.tags) {
+                // No tags to remove
+                return;
+            }
+            // Remove tag from tags list
+            var index = cell.metadata.tags.indexOf(tag_name);
+            if (index !== -1) {
+                cell.metadata.tags.splice(index, 1);
+            }
+            // If tags list is empty, remove it
+            if (cell.metadata.tags.length === 0) {
+                delete cell.metadata.tags;
+            }
+        };
+    };
+
+    var make_tag_container = function(cell, on_remove) {
+
+        var tag_container = $('<span/>').
+            addClass('tag-container');
+        var tag_list = cell.metadata.tags || [];
+        if (!Array.isArray(tag_list)) {
+            // We cannot make tags UI for this cell!
+            // Maybe someone else used "tags" for something?
+            return null;  // Fail gracefully
+        }
+        for (var i=0; i < tag_list.length; ++i) {
+            var tag_name = tag_list[i];
+            if (typeof tag_name !== 'string') {
+                // Unexpected type, disable toolbar for safety
+                return null;
+            }
+            var tag = make_tag(tag_name, on_remove);
+            tag_container.append(tag);
+        }
+        return tag_container;
+    };
+
+    var make_tag = function(name, on_remove) {
+        var tag_container = $('<span/>')
+            .addClass('cell-tag')
+            .text(name);
+
+        var remove_button = $('<a/>')
+            .addClass('remove-tag-btn')
+            .text('X')
+            .click( function(ev) {
+                if (ev.button === 0) {
+                    // Remove tag from container
+                    tag_container.remove();
+                    // Remove tag from cell
+                    if (on_remove) {
+                        on_remove(name);
+                    }
+                    return false;
+                }
+            });
+        tag_container.append(remove_button);
+        return tag_container;
+    };
+
+    // Single edit with button to add tags
+    var add_tag_edit = function(div, cell, on_add) {
+        var button_container = $(div);
+
+        var text = $('<input/>').attr('type', 'text');
+        var button = $('<button />')
+            .addClass('btn btn-default btn-xs')
+            .text('Add tag')
+            .click(function() {
+                on_add(text[0].value);
+                // Clear input after adding:
+                text[0].value = '';
+                return false;
+            });
+        // Wire enter in input to button click
+        text.keyup(function(event){
+            if(event.keyCode == 13){
+                button.click();
+            }
+        });
+        button_container.append(
+            $('<span/>')
+                .append(text)
+                .append(button)
+                .addClass('tags-input')
+            );
+        IPython.keyboard_manager.register_events(text);
+    };
+
+    var add_tags_cellbar = function(div, cell) {
+        var button_container = $(div);
+
+        button_container.addClass('tags_button_container');
+
+        var on_remove = remove_tag(cell);
+
+        var tag_container = make_tag_container(cell, on_remove);
+        if (tag_container === null) {
+            return;
+        }
+        button_container.append(tag_container);
+
+        add_tag_edit(div, cell, function(name) {
+            // Add to metadata
+            if (cell.metadata.tags === undefined) {
+                cell.metadata.tags = [];
+            } else if (cell.metadata.tags.indexOf(name) !== -1) {
+                // Tag already exists
+                return;
+            }
+            cell.metadata.tags.push(name);
+            // Make tag visual
+            var tag = make_tag(name, on_remove);
+            tag_container.append(tag);
+        });
+    };
+
+    var register = function(notebook) {
+      CellToolbar.register_callback('tags.edit', add_tags_cellbar);
+
+      var tags_preset = [];
+      tags_preset.push('tags.edit');
+
+      CellToolbar.register_preset('Tags', tags_preset, notebook);
+
+    };
+    return {'register' : register};
+});

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -28,6 +28,7 @@ define([
     './celltoolbarpresets/rawcell',
     './celltoolbarpresets/slideshow',
     './celltoolbarpresets/attachments',
+    './celltoolbarpresets/tags',
     './scrollmanager',
     './commandpalette',
     './shortcuteditor',
@@ -54,6 +55,7 @@ define([
     rawcell_celltoolbar,
     slideshow_celltoolbar,
     attachments_celltoolbar,
+    tags_celltoolbar,
     scrollmanager,
     commandpalette,
     shortcuteditor
@@ -190,6 +192,7 @@ define([
         rawcell_celltoolbar.register(this);
         slideshow_celltoolbar.register(this);
         attachments_celltoolbar.register(this);
+        tags_celltoolbar.register(this);
 
         var that = this;
 

--- a/notebook/static/notebook/less/style.less
+++ b/notebook/static/notebook/less/style.less
@@ -7,6 +7,7 @@
 */
 @import "notebook.less";
 @import "celltoolbar.less";
+@import "tagbar.less";
 @import "completer.less";
 @import "kernelselector.less";
 @import "menubar.less";

--- a/notebook/static/notebook/less/tagbar.less
+++ b/notebook/static/notebook/less/tagbar.less
@@ -1,0 +1,25 @@
+
+
+.tags_button_container {
+    width: 100%;
+    display: flex;
+}
+
+.tag-container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    flex-grow: 1;
+}
+
+.tag-container > * {
+    margin: 0 4px;
+}
+
+.remove-tag-btn {
+    margin-left: 4px;
+}
+
+.tags-input {
+    display: flex;
+}

--- a/notebook/static/notebook/less/tagbar.less
+++ b/notebook/static/notebook/less/tagbar.less
@@ -8,8 +8,9 @@
 .tag-container {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
     flex-grow: 1;
+    overflow: hidden;
+    position: relative;
 }
 
 .tag-container > * {
@@ -22,6 +23,16 @@
 
 .tags-input {
     display: flex;
+}
+
+.cell-tag:last-child:after {
+    content: "";
+    position: absolute;
+    right: 0;
+    width: 40px;
+    height: 100%;
+    /* Fade to background color of cell toolbar */
+    background: linear-gradient(to right, rgba(0,0,0,0), #EEE);
 }
 
 .tags-dialog-btn {

--- a/notebook/static/notebook/less/tagbar.less
+++ b/notebook/static/notebook/less/tagbar.less
@@ -23,3 +23,7 @@
 .tags-input {
     display: flex;
 }
+
+.tags-dialog-btn {
+    margin-right: 4px;
+}


### PR DESCRIPTION
This is a basic implementation of a UI for adding cell tags, c.f. #601. The styling, in particular, has a lot of room for improvement (not sure if it hits all the browser targets of the project), but it should at least be functional.

Screenshot:

![tags](https://cloud.githubusercontent.com/assets/510760/22072087/1318cdca-dd99-11e6-8cd4-afecf731f552.png)

