### PR TITLE
speed up casperjs tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ env:
   global:
     - PATH=$TRAVIS_BUILD_DIR/pandoc:$PATH
   matrix:
+    - GROUP=js/notebook
     - GROUP=python
     - GROUP=js/base
-    - GROUP=js/notebook
     - GROUP=js/services
     - GROUP=js/tree
 

--- a/notebook/tests/util.js
+++ b/notebook/tests/util.js
@@ -78,15 +78,6 @@ casper.open_new_notebook = function () {
             });
         });
     });
-
-    // Because of the asynchronous nature of SlimerJS (Gecko), we need to make
-    // sure the notebook has actually been loaded into the IPython namespace
-    // before running any tests.
-    this.waitFor(function() {
-        return this.evaluate(function () {
-            return IPython.notebook;
-        });
-    });
 };
 
 casper.page_loaded = function() {


### PR DESCRIPTION
This code claimed to be required for SlimerJS, but our test suite does
not currently pass on SlimerJS (and does no better or worse without this
code).

With PhantomJS, however, this eliminates a ~10s startup cost for each
file which uses notebook_test, and all of the tests continue to pass.
There are ~40 files using this, the bult of them in the js/notebook
section, which should now run 5-6 minutes faster as a result.