### PR TITLE
add event for finished execution of cell

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -334,6 +334,12 @@ define([
         CodeCell.msg_cells[this.last_msg_id] = this;
         this.render();
         this.events.trigger('execute.CodeCell', {cell: this});
+        this.events.on('finished_iopub.Kernel', function (evt, data) {
+            if (that.kernel.id === data.kernel.id && that.last_msg_id === data.msg_id) {
+		console.log('finished_execute.CodeCell', {cell: that});
+		this.events.trigger('finished_execute.CodeCell', {cell: that});
+	    }
+        });
     };
     
     /**

--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -334,10 +334,10 @@ define([
         CodeCell.msg_cells[this.last_msg_id] = this;
         this.render();
         this.events.trigger('execute.CodeCell', {cell: this});
+        var that = this;
         this.events.on('finished_iopub.Kernel', function (evt, data) {
             if (that.kernel.id === data.kernel.id && that.last_msg_id === data.msg_id) {
-		console.log('finished_execute.CodeCell', {cell: that});
-		this.events.trigger('finished_execute.CodeCell', {cell: that});
+		that.events.trigger('finished_execute.CodeCell', {cell: that});
 	    }
         });
     };

--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -940,6 +940,7 @@ define([
                 this.clear_callbacks_for_msg(msg_id);
             }
         }
+        this.events.trigger('finished_iopub.Kernel', {kernel: this, msg_id: msg_id});
     };
     
     /**


### PR DESCRIPTION
closes #2060 

At the moment, there are is no event that signals the completion of the evaluation/execution of a code cell (FYI, there is one, if the execution starts). The aim is to implement such an event.