### PR TITLE
Welcome Message for Console and Terminal Output

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, print_function
 
+import notebook
 import binascii
 import datetime
 import errno
@@ -1345,7 +1346,11 @@ class NotebookApp(JupyterApp):
         for line in self.notebook_info().split("\n"):
             info(line)
         info("Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).")
-        info("Welcome to Project Jupyter! Explore the various tools available and their corresponding documentation. If you are interested in contributing to the platform, please visit the community resources section at http://jupyter.org/community.html.")
+        if 'dev' in notebook.__version__:
+            info("Welcome to Project Jupyter! Explore the various tools available"
+                 " and their corresponding documentation. If you are interested"
+                 " in contributing to the platform, please visit the community"
+                 "resources section at http://jupyter.org/community.html.")
 
         self.write_server_info_file()
 

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1345,6 +1345,7 @@ class NotebookApp(JupyterApp):
         for line in self.notebook_info().split("\n"):
             info(line)
         info("Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).")
+        info("Welcome to Project Jupyter! Explore the various tools available and their corresponding documentation. If you are interested in contributing to the platform, please visit the community resources section at http://jupyter.org/community.html.")
 
         self.write_server_info_file()
 

--- a/notebook/static/tree/js/main.js
+++ b/notebook/static/tree/js/main.js
@@ -58,6 +58,9 @@ require([
         console.warn(err);
     }
 
+    console.log('Welcome to Project Jupyter! Explore the various tools available and their corresponding documentation. If you are interested in contributing to the platform, please visit the community resources section at http://jupyter.org/community.html.');
+
+
     // Setup all of the config related things
 
     var common_options = {


### PR DESCRIPTION
This PR is in reference to #1664.

Added a welcome message similar to that implemented at https://github.com/jupyter/jupyter.github.io/pull/181 in two locations:

One message will be logged to the browser console for user's accessing the developer tools.
The second message will be logged to the user's terminal output.