### PR TITLE
Add "Shutdown" item to Kernel menu

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -75,18 +75,18 @@ define(function(require){
                 env.notebook.show_shortcuts_editor();
             }
         },
-        'halt-kernel': {
-            help: 'Halt the kernel (no confirmation dialog)',
+        'shutdown-kernel': {
+            help: 'Shutdownthe kernel (no confirmation dialog)',
             handler: function (env) {
-                env.notebook.halt_kernel({confirm: false});
+                env.notebook.shutdown_kernel({confirm: false});
             }
         },
-        'confirm-halt-kernel':{
+        'confirm-shutdown-kernel':{
             icon: 'fa-repeat',
             help_index : 'hb',
             help: 'Shutdown the kernel (with confirmation dialog)',
             handler : function (env) {
-                env.notebook.halt_kernel();
+                env.notebook.shutdown_kernel();
             }
         },
         'restart-kernel': {

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -76,7 +76,7 @@ define(function(require){
             }
         },
         'shutdown-kernel': {
-            help: 'Shutdownthe kernel (no confirmation dialog)',
+            help: 'Shutdown the kernel (no confirmation dialog)',
             handler: function (env) {
                 env.notebook.shutdown_kernel({confirm: false});
             }

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -75,6 +75,20 @@ define(function(require){
                 env.notebook.show_shortcuts_editor();
             }
         },
+        'halt-kernel': {
+            help: 'Halt the kernel (no confirmation dialog)',
+            handler: function (env) {
+                env.notebook.halt_kernel({confirm: false});
+            }
+        },
+        'confirm-halt-kernel':{
+            icon: 'fa-repeat',
+            help_index : 'hb',
+            help: 'Shutdown the kernel (with confirmation dialog)',
+            handler : function (env) {
+                env.notebook.halt_kernel();
+            }
+        },
         'restart-kernel': {
             help: 'restart the kernel (no confirmation dialog)',
             handler: function (env) {

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -250,6 +250,7 @@ define([
             '#rename_notebook' : 'rename-notebook',
             '#find_and_replace' : 'find-and-replace',
             '#save_checkpoint': 'save-notebook',
+            '#halt_kernel': 'confirm-halt-kernel',
             '#restart_kernel': 'confirm-restart-kernel',
             '#restart_clear_output': 'confirm-restart-kernel-and-clear-output',
             '#restart_run_all': 'confirm-restart-kernel-and-run-all-cells',

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -250,7 +250,7 @@ define([
             '#rename_notebook' : 'rename-notebook',
             '#find_and_replace' : 'find-and-replace',
             '#save_checkpoint': 'save-notebook',
-            '#halt_kernel': 'confirm-halt-kernel',
+            '#shutdown_kernel': 'confirm-shutdown-kernel',
             '#restart_kernel': 'confirm-restart-kernel',
             '#restart_clear_output': 'confirm-restart-kernel-and-clear-output',
             '#restart_run_all': 'confirm-restart-kernel-and-run-all-cells',

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -2262,26 +2262,26 @@ define([
      * Prompt the user to restart the kernel.
      * if options.confirm === false, no confirmation dialog is shown.
      */
-    Notebook.prototype.halt_kernel = function (options) {
+    Notebook.prototype.shutdown_kernel = function (options) {
         var that = this;
-        var halt_options = {};
-        halt_options.confirm = (options || {}).confirm;
-        halt_options.dialog = {
-            title : "Halt kernel?",
+        var shutdown_options = {};
+        shutdown_options.confirm = (options || {}).confirm;
+        shutdown_options.dialog = {
+            title : "Shutdown kernel?",
             body : $("<p/>").text(
-                'Do you want to halt the current kernel?  All variables will be lost.'
+                'Do you want to shutdown the current kernel?  All variables will be lost.'
             ),
             buttons : {
-                "Halt" : {
+                "Shutdown" : {
                     "class" : "btn-danger",
                     "click" : function () {},
                 },
             }
         };
-        halt_options.kernel_action = function() {
+        shutdown_options.kernel_action = function() {
             that.session.delete();
         };
-        return this._restart_kernel(halt_options);
+        return this._restart_kernel(shutdown_options);
     };
 
     Notebook.prototype.restart_kernel = function (options) {

--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -318,6 +318,7 @@ define([
 
         var on_error = function (xhr, status, err) {
             that.events.trigger('kernel_failed_restart.Kernel', {kernel: that});
+            that._kernel_dead();
             if (error) {
                 error(xhr, status, err);
             }

--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -317,8 +317,7 @@ define([
         };
 
         var on_error = function (xhr, status, err) {
-            that.events.trigger('kernel_dead.Kernel', {kernel: that});
-            that._kernel_dead();
+            that.events.trigger('kernel_failed_restart.Kernel', {kernel: that});
             if (error) {
                 error(xhr, status, err);
             }

--- a/notebook/static/services/sessions/session.js
+++ b/notebook/static/services/sessions/session.js
@@ -62,6 +62,9 @@ define([
         this.events.on('kernel_dead.Kernel', function () {
             that.delete();
         });
+        this.events.on('kernel_failed_restart.Kernel', function () {
+            that.notebook.start_session();
+        });
     };
 
 
@@ -188,7 +191,7 @@ define([
      * @param {function} [error] - functon executed on ajax error
      */
     Session.prototype.delete = function (success, error) {
-        if (this.kernel) {
+        if (this.kernel && this.kernel.is_connected()) {
             this.events.trigger('kernel_killed.Session', {session: this, kernel: this.kernel});
             this.kernel._kernel_dead();
         }

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -254,7 +254,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
                             title="Send KeyboardInterrupt (CTRL-C) to the Kernel">
                             <a href="#">Interrupt</a>
                         </li>
-                        <li id="restart_kernel"
+                       <li id="restart_kernel"
                             title="Restart the Kernel">
                             <a href="#">Restart</a>
                         </li>
@@ -269,6 +269,10 @@ data-notebook-path="{{notebook_path | urlencode}}"
                         <li id="reconnect_kernel"
                             title="Reconnect to the Kernel">
                             <a href="#">Reconnect</a>
+                        </li>
+                        <li id="halt_kernel"
+                            title="Shutdown the Kernel">
+                            <a href="#">Shutdown</a>
                         </li>
                         <li class="divider"></li>
                         <li id="menu-change-kernel" class="dropdown-submenu">

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -270,7 +270,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
                             title="Reconnect to the Kernel">
                             <a href="#">Reconnect</a>
                         </li>
-                        <li id="halt_kernel"
+                        <li id="shutdown_kernel"
                             title="Shutdown the Kernel">
                             <a href="#">Shutdown</a>
                         </li>

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -254,7 +254,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
                             title="Send KeyboardInterrupt (CTRL-C) to the Kernel">
                             <a href="#">Interrupt</a>
                         </li>
-                       <li id="restart_kernel"
+                        <li id="restart_kernel"
                             title="Restart the Kernel">
                             <a href="#">Restart</a>
                         </li>

--- a/notebook/tests/notebook/kernel_menu.js
+++ b/notebook/tests/notebook/kernel_menu.js
@@ -2,7 +2,7 @@
 casper.notebook_test(function () {
     var that = this;
 
-    var menuItems = ['#restart_kernel', '#restart_clear_output', '#restart_run_all', '#halt_kernel']
+    var menuItems = ['#restart_kernel', '#restart_clear_output', '#restart_run_all', '#shutdown_kernel']
     var cancelSelector = ".modal-footer button:first-of-type"
 
     menuItems.forEach( function(selector) {
@@ -15,11 +15,11 @@ casper.notebook_test(function () {
         });
     });
 
-    var haltSelector = menuItems.pop();
+    var shutdownSelector = menuItems.pop();
     var confirmSelector = ".modal-footer .btn-danger"
 
     menuItems.forEach( function(selector) {
-        that.thenClick(haltSelector);
+        that.thenClick(shutdownSelector);
         that.waitForSelector(confirmSelector);
         that.thenClick(confirmSelector);
 
@@ -36,7 +36,7 @@ casper.notebook_test(function () {
                 return IPython.notebook.kernel.is_connected() === true;
         })});
         that.then(function() {
-            that.test.assert(true, "no confirmation for " + selector + " after session halted")
+            that.test.assert(true, "no confirmation for " + selector + " after session shutdown")
         })
     });
 

--- a/notebook/tests/notebook/kernel_menu.js
+++ b/notebook/tests/notebook/kernel_menu.js
@@ -1,0 +1,44 @@
+
+casper.notebook_test(function () {
+    var that = this;
+
+    var menuItems = ['#restart_kernel', '#restart_clear_output', '#restart_run_all', '#halt_kernel']
+    var cancelSelector = ".modal-footer button:first-of-type"
+
+    menuItems.forEach( function(selector) {
+        that.thenClick(selector);
+        that.waitForSelector(cancelSelector);
+        that.thenClick(cancelSelector);
+
+        that.waitWhileSelector(".modal-content", function() {
+            that.test.assert(true, selector + " confirmation modal pops up and is cancelable");
+        });
+    });
+
+    var haltSelector = menuItems.pop();
+    var confirmSelector = ".modal-footer .btn-danger"
+
+    menuItems.forEach( function(selector) {
+        that.thenClick(haltSelector);
+        that.waitForSelector(confirmSelector);
+        that.thenClick(confirmSelector);
+
+        // wait for shutdown to go through
+        that.waitFor(function() { return this.evaluate(function() {
+            return IPython.notebook.kernel.is_connected() === false;
+        })});
+
+        // Click on one of the restarts
+        that.thenClick(selector);
+
+        //  Kernel should get connected, no need for confirmation.
+        that.waitFor(function() { return this.evaluate(function() {
+                return IPython.notebook.kernel.is_connected() === true;
+        })});
+        that.then(function() {
+            that.test.assert(true, "no confirmation for " + selector + " after session halted")
+        })
+    });
+
+});
+

--- a/notebook/tests/services/session.js
+++ b/notebook/tests/services/session.js
@@ -121,6 +121,9 @@ casper.notebook_test(function () {
         }
     );
 
+    this.thenEvaluate( function() {IPython.notebook.session.start()});
+    this.wait_for_kernel_ready();
+
     // check for events when restarting the session
     this.event_test(
         'restart_session',
@@ -163,6 +166,9 @@ casper.notebook_test(function () {
         // restarting the kernel 5 times!
         20000
     );
+
+    this.thenEvaluate( function() {IPython.notebook.session.start()});
+    this.wait_for_kernel_ready();
 
     // check for events when starting a nonexistant kernel
     this.event_test(


### PR DESCRIPTION
Right now, the only way to work on a notebook without a running kernel is to open it, and then shut down the session from the tree view.

This PR adds a Shutdown item to the Kernel menu. On top of that, it removes the confirmation dialog from the Restart menu item variants in cases where the kernel has already been shutdown. It also adds test cases for both the presence of a confirmation dialog when there is a live session, and the absence of confirmation when there is not a live session.  

![shutdown demo1](https://cloud.githubusercontent.com/assets/118211/22273830/da959dc0-e257-11e6-97f6-82c4166e20fd.gif)
