### PR TITLE
Make dialogs draggable

### DIFF
--- a/notebook/static/base/js/dialog.js
+++ b/notebook/static/base/js/dialog.js
@@ -55,6 +55,9 @@ define(function(require) {
         dialog_content.append(
             $("<div/>")
                 .addClass("modal-header")
+                .mousedown(function() {
+                  $(".modal").draggable();
+                })
                 .append($("<button>")
                     .attr("type", "button")
                     .addClass("close")
@@ -67,9 +70,14 @@ define(function(require) {
                         .text(options.title || "")
                 )
         ).append(
-            $("<div/>").addClass("modal-body").append(
-                options.body || $("<p/>")
-            )
+            $("<div/>")
+                .addClass("modal-body")
+                .mousedown(function() {
+                  $(".modal").draggable();
+                })
+                .append(
+                    options.body || $("<p/>")
+                )
         );
         
         var footer = $("<div/>").addClass("modal-footer");

--- a/notebook/static/base/less/page.less
+++ b/notebook/static/base/less/page.less
@@ -129,6 +129,10 @@ span#login_widget > .button,
     }
 }
 
+.modal-header {
+  cursor: move;
+}
+
 @media (min-width: @screen-sm-min) {
     .modal .modal-dialog {
         width: 700px;


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/2035

This simply calls `.draggable()` on `$(".modals")` when a modal receives a mousedown. I tried to add a `draggable` option and that didn't work. I also tried calling `.draggable()` on creation of a modal and that scrolled the page to the bottom.

![screencap](http://g.recordit.co/Xpib4NYe36.gif)