### PR TITLE
Fix JS error on running notebooks tab

### DIFF
--- a/notebook/static/tree/js/kernellist.js
+++ b/notebook/static/tree/js/kernellist.js
@@ -49,7 +49,7 @@ define([
             return; // wait for kernelspecs before first load
         }
         this.clear_list();
-        var item, path, session;
+        var item, path, session, info;
         for (path in d) {
             if (!d.hasOwnProperty(path)) {
                 // nothing is safe in javascript
@@ -57,11 +57,12 @@ define([
             }
             session = d[path];
             item = this.new_item(-1);
+            info = this.kernelspecs[session.kernel.name];
             this.add_link({
                 name: path,
                 path: path,
                 type: 'notebook',
-                kernel_display_name: this.kernelspecs[session.kernel.name].spec.display_name
+                kernel_display_name: (info && info.spec) ? info.spec.display_name : session.kernel.name
             }, item);
         }
         $('#running_list_placeholder').toggle($.isEmptyObject(d));


### PR DESCRIPTION
When a kernelspec is removed while a kernel spawned from it is in use,
the Running tab on the dashboards page errors and no longer shows
any results. Fall back on using the kernel name from the session
in this case so that users can see and terminate kernels.