### PR TITLE
trigger event change.Cell

### DIFF
--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -203,6 +203,7 @@ define([
         });
         if (this.code_mirror) {
             this.code_mirror.on("change", function(cm, change) {
+                that.events.trigger("change.Cell", {cell: that, change: change});
                 that.events.trigger("set_dirty.Notebook", {value: true});
             });
         }


### PR DESCRIPTION
Trigger an (new) event `change.Cell` when the input of a cell is changed.

At the moment, only a `set_dirty` is triggered; but neither the information, which cell caused the change and nor what exactly changed is missing. However all information is available, it just has to be passed on.