### PR TITLE
fix and tests for the issue related with the trailing slash using 'nbextension install'

### DIFF
--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -165,7 +165,7 @@ def install_nbextension(path, overwrite=False, symlink=False,
         full_dest = None
     else:
         if not destination:
-            destination = basename(path)
+            destination = basename(normpath(path))
         destination = cast_unicode_py2(destination)
         full_dest = normpath(pjoin(nbext, destination))
         if overwrite and os.path.lexists(full_dest):

--- a/notebook/tests/test_nbextensions.py
+++ b/notebook/tests/test_nbextensions.py
@@ -179,10 +179,13 @@ class TestInstallNBExtension(TestCase):
         self.assert_installed(self.files[-1])
     
     def test_single_dir_trailing_slash(self):
-        d = [u'∂ir/', u'∂ir\\']
-        for dest in d:
-            install_nbextension(pjoin(self.src, dest))
-            self.assert_installed(self.files[-1])    
+        d = u'∂ir/'
+        install_nbextension(pjoin(self.src, d))
+        self.assert_installed(self.files[-1])
+        if os.name == 'nt':
+            d = u'∂ir\\'
+            install_nbextension(pjoin(self.src, d))
+            self.assert_installed(self.files[-1])
 
     def test_destination_file(self):
         file = self.files[0]

--- a/notebook/tests/test_nbextensions.py
+++ b/notebook/tests/test_nbextensions.py
@@ -178,6 +178,11 @@ class TestInstallNBExtension(TestCase):
         install_nbextension(pjoin(self.src, d))
         self.assert_installed(self.files[-1])
     
+    def test_single_dir_trailing_slash(self):
+        d = [u'∂ir/', u'∂ir\\']
+        for dest in d:
+            install_nbextension(pjoin(self.src, dest))
+            self.assert_installed(self.files[-1])    
 
     def test_destination_file(self):
         file = self.files[0]


### PR DESCRIPTION
closes #2069


It seems there is a problem when one wants to install a nbextension contained in a folder. This:

`jupyter nbextension install my_extension/ --sys-prefix`

Installs the content of the `my_extension/` folder but not the folder itself. It is prone to overwrite other files already present in the `nbextensions` folders.

With this PR, the next two lines would be similar:

`jupyter nbextension install my_extension/ --sys-prefix`
`jupyter nbextension install my_extension --sys-prefix`

And the instructions [here](https://jupyter-notebook.readthedocs.io/en/latest/extending/frontend_extensions.html#installing-and-enabling-extensions) would behave correctly.