### PR TITLE
Remove hardcoded widgets check

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -281,24 +281,6 @@ class NotebookWebApplication(web.Application):
         handlers.extend(load_handlers('services.kernelspecs.handlers'))
         handlers.extend(load_handlers('services.security.handlers'))
         
-        # BEGIN HARDCODED WIDGETS HACK
-        # TODO: Remove on notebook 5.0
-        widgets = None
-        try:
-            import widgetsnbextension
-        except:
-            try:
-                import ipywidgets as widgets
-                handlers.append(
-                    (r"/nbextensions/widgets/(.*)", FileFindHandler, {
-                        'path': widgets.find_static_assets(),
-                        'no_cache_paths': ['/'], # don't cache anything in nbextensions
-                    }),
-                )
-            except:
-                app_log.warning('Widgets are unavailable. Please install widgetsnbextension or ipywidgets 4.0')
-        # END HARDCODED WIDGETS HACK
-        
         handlers.append(
             (r"/nbextensions/(.*)", FileFindHandler, {
                 'path': settings['nbextensions_path'],


### PR DESCRIPTION
Once this is merged, the notebook will only support ipywidgets>=5.0. The
minimum supported ipywidgets (5.0.0) was released in April 2016.

Closes gh-1960