### PR TITLE
restore `npm run build:watch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "bower": "bower install",
-    "build": "python setup.py js css"
+    "build": "python setup.py js css",
+    "build:watch": "set -e; while true; do npm run build; sleep 3; done"
   },
   "devDependencies": {
     "bower": "*",


### PR DESCRIPTION
it's not real watching, just polling every few seconds.

Help docs still point to this command, and we need something for devs as `ignore_minified_js` is gone.

Unlike the webpack build, the current js build does check dependencies and is quick and inexpensive if it doesn't need updating.

closes #1641