### PR TITLE
add edit button to shortcuts dialog

### DIFF
--- a/notebook/static/notebook/js/quickhelp.js
+++ b/notebook/static/notebook/js/quickhelp.js
@@ -188,10 +188,6 @@ define([
             $(this.shortcut_dialog).modal("toggle");
             return;
         }
-        var command_shortcuts = this.keyboard_manager.command_shortcuts.help();
-        var edit_shortcuts = this.keyboard_manager.edit_shortcuts.help();
-        var help, shortcut;
-        var i, half, n;
         var element = $('<div/>');
 
         // The documentation
@@ -261,8 +257,23 @@ define([
 
 
     QuickHelp.prototype.build_command_help = function () {
+        var that = this;
         var command_shortcuts = this.keyboard_manager.command_shortcuts.help();
-        return build_div('<h4>Command Mode (press <kbd>Esc</kbd> to enable)</h4>', command_shortcuts);
+        var div = build_div('<h4>Command Mode (press <kbd>Esc</kbd> to enable)</h4>', command_shortcuts);
+        var edit_button = $('<button/>')
+            .text("Edit Shortcuts")
+            .addClass('btn btn-xs btn-default pull-right')
+            .attr('href', '#')
+            .attr('title', 'edit command-mode keyboard shortcuts')
+            .click(function () {
+                // close this dialog
+                $(that.shortcut_dialog).modal("toggle");
+                // and open the next one
+                that.keyboard_manager.actions.call(
+                    'jupyter-notebook:edit-command-mode-keyboard-shortcuts');
+            });
+        div.find('h4').append(edit_button);
+        return div;
     };
 
     


### PR DESCRIPTION
opens edit-shortcuts dialog

<img width="833" alt="screen shot 2017-01-31 at 15 40 36" src="https://cloud.githubusercontent.com/assets/151929/22469339/f2107884-e7cb-11e6-8359-a75f35c1d7b1.png">


closes #1445

I haven't added the menu entry, since I couldn't figure out the best place for it to go. I think editing preferences generally goes in the Edit menu, but that's already very long, and there don't appear to be any similar options there yet.