### PR TITLE
merge nbserver_extensions

### DIFF
--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -21,8 +21,8 @@ except ImportError:
     from urllib import urlretrieve
 
 from jupyter_core.paths import (
-    jupyter_data_dir, jupyter_config_dir, jupyter_config_path,
-    SYSTEM_JUPYTER_PATH, ENV_JUPYTER_PATH, ENV_CONFIG_PATH, SYSTEM_CONFIG_PATH
+    jupyter_data_dir, jupyter_config_path, jupyter_path,
+    SYSTEM_JUPYTER_PATH, ENV_JUPYTER_PATH,
 )
 from ipython_genutils.path import ensure_dir_exists
 from ipython_genutils.py3compat import string_types, cast_unicode_py2
@@ -484,7 +484,7 @@ def validate_nbextension(require, logger=None):
     infos = []
 
     js_exists = False
-    for exts in _nbextension_dirs():
+    for exts in jupyter_path('nbextensions'):
         # Does the Javascript entrypoint actually exist on disk?
         js = u"{}.js".format(os.path.join(exts, *require.split("/")))
         js_exists = os.path.exists(js)
@@ -1012,18 +1012,6 @@ def _get_nbextension_dir(user=False, sys_prefix=False, prefix=None, nbextensions
     else:
         nbext = pjoin(SYSTEM_JUPYTER_PATH[0], 'nbextensions')
     return nbext
-
-
-def _nbextension_dirs():
-    """The possible locations of nbextensions.
-
-    Returns a list of known base extension locations
-    """
-    return [
-        pjoin(jupyter_data_dir(), u'nbextensions'),
-        pjoin(ENV_JUPYTER_PATH[0], u'nbextensions'),
-        pjoin(SYSTEM_JUPYTER_PATH[0], 'nbextensions')
-    ]
 
 
 def _get_nbextension_metadata(module):

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -86,6 +86,7 @@ from traitlets.config.application import catch_config_error, boolean_flag
 from jupyter_core.application import (
     JupyterApp, base_flags, base_aliases,
 )
+from jupyter_core.paths import jupyter_config_path
 from jupyter_client import KernelManager
 from jupyter_client.kernelspec import KernelSpecManager, NoSuchKernel, NATIVE_KERNEL_NAME
 from jupyter_client.session import Session
@@ -1232,9 +1233,24 @@ class NotebookApp(JupyterApp):
             # in the new traitlet
             if not modulename in self.nbserver_extensions:
                 self.nbserver_extensions[modulename] = True
-        
-        for modulename in sorted(self.nbserver_extensions):
-            if self.nbserver_extensions[modulename]:
+
+        # Load server extensions with ConfigManager.
+        # This enables merging on keys, which we want for extension enabling,.
+        # Regular config loading only merges at the class level,
+        # so each level (use > env > system) clobbers the previous.
+        manager = ConfigManager(read_config_path=jupyter_config_path())
+        section = manager.get('jupyter_notebook_config')
+        extensions = section.get('NotebookApp', {}).get('nbserver_extensions', {})
+
+        for modulename, enabled in self.nbserver_extensions.items():
+            if modulename not in extensions:
+                # not present in `extensions` means it comes from Python config,
+                # so we need to add it.
+                # Otherwise, trust ConfigManager to have loaded it.
+                extensions[modulename] = enabled
+
+        for modulename, enabled in sorted(extensions.items()):
+            if enabled:
                 try:
                     mod = importlib.import_module(modulename)
                     func = getattr(mod, 'load_jupyter_server_extension', None)

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1235,9 +1235,9 @@ class NotebookApp(JupyterApp):
                 self.nbserver_extensions[modulename] = True
 
         # Load server extensions with ConfigManager.
-        # This enables merging on keys, which we want for extension enabling,.
+        # This enables merging on keys, which we want for extension enabling.
         # Regular config loading only merges at the class level,
-        # so each level (use > env > system) clobbers the previous.
+        # so each level (user > env > system) clobbers the previous.
         config_path = jupyter_config_path()
         if self.config_dir not in config_path:
             # add self.config_dir to the front, if set manually

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1238,8 +1238,12 @@ class NotebookApp(JupyterApp):
         # This enables merging on keys, which we want for extension enabling,.
         # Regular config loading only merges at the class level,
         # so each level (use > env > system) clobbers the previous.
-        manager = ConfigManager(read_config_path=jupyter_config_path())
-        section = manager.get('jupyter_notebook_config')
+        config_path = jupyter_config_path()
+        if self.config_dir not in config_path:
+            # add self.config_dir to the front, if set manually
+            config_path.insert(0, self.config_dir)
+        manager = ConfigManager(read_config_path=config_path)
+        section = manager.get(self.config_file_name)
         extensions = section.get('NotebookApp', {}).get('nbserver_extensions', {})
 
         for modulename, enabled in self.nbserver_extensions.items():


### PR DESCRIPTION
- [x] test
- [x] handle config_file_name and config_dir Application settings

Load with ConfigManager so that merge happens recursively, unlike normal config values.

Makes loading more consistent with frontend extensions, which is good.

It is a bit icky because the same files are loaded and read twice, and one key in a traitlets-defined config file is loaded differently than all others.

This does behave more like we intend and people expect for extensions, though.

closes #2063