### PR TITLE
disable all config in tests

### DIFF
--- a/notebook/bundler/tests/test_bundler_api.py
+++ b/notebook/bundler/tests/test_bundler_api.py
@@ -28,7 +28,7 @@ class BundleAPITest(NotebookTestBase):
         """Make a test notebook. Borrowed from nbconvert test. Assumes the class
         teardown will clean it up in the end."""
         super(BundleAPITest, cls).setup_class()
-        nbdir = cls.notebook_dir.name
+        nbdir = cls.notebook_dir
 
         nb = new_notebook()
 

--- a/notebook/nbconvert/tests/test_nbconvert_handlers.py
+++ b/notebook/nbconvert/tests/test_nbconvert_handlers.py
@@ -55,7 +55,7 @@ b'\x08\xd7c\x90\xfb\xcf\x00\x00\x02\\\x01\x1e.~d\x87\x00\x00\x00\x00IEND\xaeB`\x
 
 class APITest(NotebookTestBase):
     def setUp(self):
-        nbdir = self.notebook_dir.name
+        nbdir = self.notebook_dir
         
         if not os.path.isdir(pjoin(nbdir, 'foo')):
             subdir = pjoin(nbdir, 'foo')

--- a/notebook/services/contents/tests/test_contents_api.py
+++ b/notebook/services/contents/tests/test_contents_api.py
@@ -152,7 +152,7 @@ class APITest(NotebookTestBase):
         return u'%s text file' % name
     
     def to_os_path(self, api_path):
-        return to_os_path(api_path, root=self.notebook_dir.name)
+        return to_os_path(api_path, root=self.notebook_dir)
     
     def make_dir(self, api_path):
         """Create a directory at api_path"""

--- a/notebook/services/kernelspecs/tests/test_kernelspecs_api.py
+++ b/notebook/services/kernelspecs/tests/test_kernelspecs_api.py
@@ -55,7 +55,7 @@ class APITest(NotebookTestBase):
         self.ks_api = KernelSpecAPI(self.request)
 
     def create_spec(self, name):
-        sample_kernel_dir = pjoin(self.data_dir.name, 'kernels', name)
+        sample_kernel_dir = pjoin(self.data_dir, 'kernels', name)
         try:
             os.makedirs(sample_kernel_dir)
         except OSError as e:
@@ -71,7 +71,7 @@ class APITest(NotebookTestBase):
 
     def test_list_kernelspecs_bad(self):
         """Can list kernelspecs when one is invalid"""
-        bad_kernel_dir = pjoin(self.data_dir.name, 'kernels', 'bad')
+        bad_kernel_dir = pjoin(self.data_dir, 'kernels', 'bad')
         try:
             os.makedirs(bad_kernel_dir)
         except OSError as e:

--- a/notebook/services/sessions/tests/test_sessions_api.py
+++ b/notebook/services/sessions/tests/test_sessions_api.py
@@ -80,7 +80,7 @@ class SessionAPI(object):
 class SessionAPITest(NotebookTestBase):
     """Test the sessions web service API"""
     def setUp(self):
-        nbdir = self.notebook_dir.name
+        nbdir = self.notebook_dir
         subdir = pjoin(nbdir, 'foo')
 
         try:

--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -108,6 +108,7 @@ class NotebookTestBase(TestCase):
         data_dir = cls.data_dir = tmp('data')
         config_dir = cls.config_dir = tmp('config')
         runtime_dir = cls.runtime_dir = tmp('runtime')
+        cls.notebook_dir = tmp('notebooks')
         cls.env_patch = patch.dict('os.environ', {
             'HOME': cls.home_dir,
             'PYTHONPATH': os.pathsep.join(sys.path),
@@ -126,7 +127,6 @@ class NotebookTestBase(TestCase):
             ENV_CONFIG_PATH=[tmp('env', 'etc', 'jupyter')],
         )
         cls.path_patch.start()
-        cls.notebook_dir = TemporaryDirectory()
 
         config = cls.config or Config()
         config.NotebookNotary.db_file = ':memory:'
@@ -142,7 +142,7 @@ class NotebookTestBase(TestCase):
                 config_dir=cls.config_dir,
                 data_dir=cls.data_dir,
                 runtime_dir=cls.runtime_dir,
-                notebook_dir=cls.notebook_dir.name,
+                notebook_dir=cls.notebook_dir,
                 base_url=cls.url_prefix,
                 config=config,
                 allow_root=True,
@@ -176,7 +176,6 @@ class NotebookTestBase(TestCase):
         cls.notebook.stop()
         cls.wait_until_dead()
         cls.tmp_dir.cleanup()
-        cls.notebook_dir.cleanup()
         cls.env_patch.stop()
         cls.path_patch.stop()
         # cleanup global zmq Context, to ensure we aren't leaving dangling sockets

--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 from binascii import hexlify
 from contextlib import contextmanager
+import errno
 import os
 import sys
 from threading import Thread, Event
@@ -90,23 +91,41 @@ class NotebookTestBase(TestCase):
             url_path_join(cls.base_url(), path),
             **kwargs)
         return response
-
+    
     @classmethod
     def setup_class(cls):
-        cls.home_dir = TemporaryDirectory()
-        data_dir = TemporaryDirectory()
+        cls.tmp_dir = TemporaryDirectory()
+        def tmp(*parts):
+            path = os.path.join(cls.tmp_dir.name, *parts)
+            try:
+                os.makedirs(path)
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise
+            return path
+        
+        cls.home_dir = tmp('home')
+        data_dir = cls.data_dir = tmp('data')
+        config_dir = cls.config_dir = tmp('config')
+        runtime_dir = cls.runtime_dir = tmp('runtime')
         cls.env_patch = patch.dict('os.environ', {
-            'HOME': cls.home_dir.name,
+            'HOME': cls.home_dir,
             'PYTHONPATH': os.pathsep.join(sys.path),
-            'IPYTHONDIR': pjoin(cls.home_dir.name, '.ipython'),
-            'JUPYTER_DATA_DIR' : data_dir.name
+            'IPYTHONDIR': pjoin(cls.home_dir, '.ipython'),
+            'JUPYTER_NO_CONFIG': '1', # needed in the future
+            'JUPYTER_CONFIG_DIR' : config_dir,
+            'JUPYTER_DATA_DIR' : data_dir,
+            'JUPYTER_RUNTIME_DIR': runtime_dir,
         })
         cls.env_patch.start()
-        cls.path_patch = patch.object(jupyter_core.paths, 'SYSTEM_JUPYTER_PATH', [])
+        cls.path_patch = patch.multiple(
+            jupyter_core.paths,
+            SYSTEM_JUPYTER_PATH=[tmp('share', 'jupyter')],
+            ENV_JUPYTER_PATH=[tmp('env', 'share', 'jupyter')],
+            SYSTEM_CONFIG_PATH=[tmp('etc', 'jupyter')],
+            ENV_CONFIG_PATH=[tmp('env', 'etc', 'jupyter')],
+        )
         cls.path_patch.start()
-        cls.config_dir = TemporaryDirectory()
-        cls.data_dir = data_dir
-        cls.runtime_dir = TemporaryDirectory()
         cls.notebook_dir = TemporaryDirectory()
 
         config = cls.config or Config()
@@ -120,9 +139,9 @@ class NotebookTestBase(TestCase):
                 port=cls.port,
                 port_retries=0,
                 open_browser=False,
-                config_dir=cls.config_dir.name,
-                data_dir=cls.data_dir.name,
-                runtime_dir=cls.runtime_dir.name,
+                config_dir=cls.config_dir,
+                data_dir=cls.data_dir,
+                runtime_dir=cls.runtime_dir,
                 notebook_dir=cls.notebook_dir.name,
                 base_url=cls.url_prefix,
                 config=config,
@@ -156,10 +175,7 @@ class NotebookTestBase(TestCase):
     def teardown_class(cls):
         cls.notebook.stop()
         cls.wait_until_dead()
-        cls.home_dir.cleanup()
-        cls.config_dir.cleanup()
-        cls.data_dir.cleanup()
-        cls.runtime_dir.cleanup()
+        cls.tmp_dir.cleanup()
         cls.notebook_dir.cleanup()
         cls.env_patch.stop()
         cls.path_patch.stop()

--- a/notebook/tests/test_files.py
+++ b/notebook/tests/test_files.py
@@ -32,7 +32,7 @@ class FilesTest(NotebookTestBase):
         ]
         dirs = not_hidden + hidden
         
-        nbdir = self.notebook_dir.name
+        nbdir = self.notebook_dir
         for d in dirs:
             path = pjoin(nbdir, d.replace('/', os.sep))
             if not os.path.exists(path):
@@ -59,7 +59,7 @@ class FilesTest(NotebookTestBase):
     def test_contents_manager(self):
         "make sure ContentsManager returns right files (ipynb, bin, txt)."
 
-        nbdir = self.notebook_dir.name
+        nbdir = self.notebook_dir
 
         nb = new_notebook(
             cells=[
@@ -99,7 +99,7 @@ class FilesTest(NotebookTestBase):
         self.assertEqual(r.text, 'foobar')
     
     def test_download(self):
-        nbdir = self.notebook_dir.name
+        nbdir = self.notebook_dir
         
         text = 'hello'
         with open(pjoin(nbdir, 'test.txt'), 'w') as f:
@@ -115,7 +115,7 @@ class FilesTest(NotebookTestBase):
         self.assertIn('filename="test.txt"', disposition)
         
     def test_view_html(self):
-        nbdir = self.notebook_dir.name
+        nbdir = self.notebook_dir
         
         html = '<div>Test test</div>'
         with open(pjoin(nbdir, 'test.html'), 'w') as f:
@@ -126,7 +126,7 @@ class FilesTest(NotebookTestBase):
 
     def test_old_files_redirect(self):
         """pre-2.0 'files/' prefixed links are properly redirected"""
-        nbdir = self.notebook_dir.name
+        nbdir = self.notebook_dir
         
         os.mkdir(pjoin(nbdir, 'files'))
         os.makedirs(pjoin(nbdir, 'sub', 'files'))

--- a/notebook/tree/tests/test_tree_handler.py
+++ b/notebook/tree/tests/test_tree_handler.py
@@ -11,7 +11,7 @@ from notebook.tests.launchnotebook import NotebookTestBase
 
 class TreeTest(NotebookTestBase):
     def setUp(self):
-        nbdir = self.notebook_dir.name
+        nbdir = self.notebook_dir
         d = os.path.join(nbdir, 'foo')
         os.mkdir(d)
 


### PR DESCRIPTION
avoids in-env config from polluting test environment

disables everything: data files, runtime, config

closes #2101