### PR TITLE
Isolate directionality of a string from surrounding

### DIFF
--- a/notebook/static/notebook/less/highlight.less
+++ b/notebook/static/notebook/less/highlight.less
@@ -27,6 +27,9 @@ Adapted from GitHub theme
 
 .highlight-string{
   color: #BA2121;
+  /* isolate strings unicode direction from surrounding text */
+  unicode-bidi: isolate;
+  unicode-bidi: -webkit-isolate;
 }
 
 .highlight-comment{


### PR DESCRIPTION
Hey guys, this little patch will make life of people dealing with text containing RTL text easier. It simply turns this:
`print('\n'.join(['متن متن', '123']))`

![before](https://cloud.githubusercontent.com/assets/833473/22522486/f0be56a8-e8d0-11e6-9d2a-61005619d78b.png)

Into this:
![after](https://cloud.githubusercontent.com/assets/833473/22522888/8d206e68-e8d2-11e6-85f6-c0d9e3b0dea8.png)

To understand the difference, look carefully at the strings sequence on the image. On the first one, which is broken, an Arabic string which logically should be first (as it is printed first on the output the code) came after the number visually. After the change however, highlighting changed in a way that strings visual order actually matches its logical order (the printed text)

This type of workaround is somehow common on other projects, for example have a look at these patches on Chrome browser DevTools:
* http://crbug.com/178635 https://codereview.chromium.org/212653002
* http://crbug.com/330387 https://codereview.chromium.org/109053003