### PR TITLE
Revert "Isolate directionality of a string from surrounding"

### DIFF
--- a/notebook/static/notebook/less/highlight.less
+++ b/notebook/static/notebook/less/highlight.less
@@ -27,9 +27,6 @@ Adapted from GitHub theme
 
 .highlight-string{
   color: #BA2121;
-  /* isolate strings unicode direction from surrounding text */
-  unicode-bidi: isolate;
-  unicode-bidi: -webkit-isolate;
 }
 
 .highlight-comment{


### PR DESCRIPTION
This, while fixes visual ordering issue, but breaks editing experience of the same case.

For example trying to double click selection of the first word from the case available on #2114 shows the regression:
![screen shot 2017-02-02 at 11 43 50 am](https://cloud.githubusercontent.com/assets/833473/22541501/e6c97982-e93b-11e6-8e1e-a005b6dcd7cd.png)

Can be considered a CM issues but we should come with another solution for this.