### PR TITLE
Upgrade xtermjs to 2.2.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,6 @@
     "requirejs": "~2.1",
     "text-encoding": "~0.1",
     "underscore": "components/underscore#~1.8.3",
-    "xterm.js": "sourcelair/xterm.js#~2.1.0"
+    "xterm.js": "sourcelair/xterm.js#~2.2.3"
   }
 }


### PR DESCRIPTION
I tested very briefly and this seemed to work. 2.2.3 is the latest release at present. Release notes are here:
https://github.com/sourcelair/xterm.js/releases