### PR TITLE
remove token query parameter from pages on load

### DIFF
--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -156,6 +156,32 @@
 {% block script %}
 {% endblock %}
 
+<script type='text/javascript'>
+  function _remove_token_from_url() {
+    if (window.location.search.length <= 1) {
+      return;
+    }
+    var search_parameters = window.location.search.slice(1).split('&');
+    var found = false;
+    for (var i = 0; i < search_parameters.length; i++) {
+      if (search_parameters[i].split('=')[0] === 'token') {
+        // remote token from search parameters
+        search_parameters.splice(i, 1);
+        var new_search = '';
+        if (search_parameters.length) {
+          new_search = '?' + search_parameters.join('&');
+        }
+        var new_url = window.location.origin + 
+                      window.location.pathname + 
+                      new_search + 
+                      window.location.hash;
+        window.history.replaceState({}, "", new_url);
+        return;
+      }
+    }
+  }
+  _remove_token_from_url();
+</script>
 </body>
 
 </html>


### PR DESCRIPTION
remove token query parameter from pages on load

Once the page has been loaded, the token has done its job and can be discarded. Its presence can lead to confusion, especially copying/pasting URLs with one-time tokens present.

closes #2127