### PR TITLE
Remove double border in Find and replace UI.

### DIFF
--- a/notebook/static/notebook/less/searchandreplace.less
+++ b/notebook/static/notebook/less/searchandreplace.less
@@ -8,7 +8,16 @@
     border-width: 1px;
     border-radius: 0px;
   }
-    
+
+
+  [dir="ltr"] & .input-group-btn + .form-control {
+    border-left: none;
+  }
+
+  [dir="rtl"] & .input-group-btn + .form-control {
+     border-right: none;
+  }
+
   #replace-preview .replace {
     
     & .match {

--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -107,7 +107,7 @@
     data-jupyter-api-token="{{token | urlencode}}"
   {% endif %}
  {% endblock params %}
->
+dir="ltr">
 
 <noscript>
     <div id='noscript'>


### PR DESCRIPTION
There is a less-than optimal double border between the last button and
the input field.

Remove it by making the right border of the last button be None

---- 

Before/after:
<img width="683" alt="screen shot 2017-02-03 at 13 25 33" src="https://cloud.githubusercontent.com/assets/335567/22609027/4a51baea-ea14-11e6-8a0d-a1e4f9645a11.png">
