### PR TITLE
Update style for code tar in `.well`

### DIFF
--- a/notebook/static/notebook/less/notebook.less
+++ b/notebook/static/notebook/less/notebook.less
@@ -115,3 +115,13 @@ kbd {
 .jupyter-keybindings i {
     padding: 6px;
 }
+
+.well code {
+    background-color: lighten(@cell_background, 5%);
+    border-color: @border_color;
+    border-width: @border_width;
+    border-style: solid;
+    padding: 2px;
+    padding-top: 1px;
+    padding-bottom: 1px;
+}


### PR DESCRIPTION
The purpleish is not that great  and unredable and due to us removing
part of bootstrap.

It does not affect the notebook document styling which is already taken care of by `.rendered html`. 


Before/After.

<img width="688" alt="screen shot 2017-02-03 at 13 50 36" src="https://cloud.githubusercontent.com/assets/335567/22609972/249383fc-ea18-11e6-9a41-37c8155481c8.png">

<img width="689" alt="screen shot 2017-02-03 at 13 50 08" src="https://cloud.githubusercontent.com/assets/335567/22609971/2488836c-ea18-11e6-9a56-1778bd618f86.png">

