### PR TITLE
Better handeling or RTL prompts

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -465,7 +465,7 @@ define([
         } else {
             ns = encodeURIComponent(prompt_value);
         }
-        return 'In&nbsp;[' + ns + ']:';
+        return '<bdi>In</bdi>&nbsp;[' + ns + ']:';
     };
 
     CodeCell.input_prompt_continuation = function (prompt_value, lines_number) {

--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -455,7 +455,14 @@ define([
         var toinsert = this.create_output_area();
         this._record_display_id(json, toinsert);
         if (this.prompt_area) {
-            toinsert.find('div.prompt').addClass('output_prompt').text('Out[' + n + ']:');
+            toinsert.find('div.prompt')
+                    .addClass('output_prompt')
+                    .empty()
+                    .append(
+                      $('<bdi>').text('Out')
+                    ).append(
+                      '[' + n + ']:'
+                    );
         }
         var inserted = this.append_mime_type(json, toinsert);
         if (inserted) {

--- a/notebook/tests/notebook/prompt_numbers.js
+++ b/notebook/tests/notebook/prompt_numbers.js
@@ -21,16 +21,16 @@ casper.notebook_test(function () {
         var a = 'print("a")';
         var index = this.append_cell(a);
 
-        this.test.assertEquals(get_prompt(index), "In&nbsp;[&nbsp;]:", "prompt number is &nbsp; by default");
+        this.test.assertEquals(get_prompt(index), "<bdi>In</bdi>&nbsp;[&nbsp;]:", "prompt number is &nbsp; by default");
         set_prompt(index, 2);
-        this.test.assertEquals(get_prompt(index), "In&nbsp;[2]:", "prompt number is 2");
+        this.test.assertEquals(get_prompt(index), "<bdi>In</bdi>&nbsp;[2]:", "prompt number is 2");
         set_prompt(index, 0);
-        this.test.assertEquals(get_prompt(index), "In&nbsp;[0]:", "prompt number is 0");
+        this.test.assertEquals(get_prompt(index), "<bdi>In</bdi>&nbsp;[0]:", "prompt number is 0");
         set_prompt(index, "*");
-        this.test.assertEquals(get_prompt(index), "In&nbsp;[*]:", "prompt number is *");
+        this.test.assertEquals(get_prompt(index), "<bdi>In</bdi>&nbsp;[*]:", "prompt number is *");
         set_prompt(index, undefined);
-        this.test.assertEquals(get_prompt(index), "In&nbsp;[&nbsp;]:", "prompt number is &nbsp;");
+        this.test.assertEquals(get_prompt(index), "<bdi>In</bdi>&nbsp;[&nbsp;]:", "prompt number is &nbsp;");
         set_prompt(index, null);
-        this.test.assertEquals(get_prompt(index), "In&nbsp;[&nbsp;]:", "prompt number is &nbsp;");
+        this.test.assertEquals(get_prompt(index), "<bdi>In</bdi>&nbsp;[&nbsp;]:", "prompt number is &nbsp;");
     });
 });


### PR DESCRIPTION
Basically avoid this:

<img width="99" alt="screen shot 2017-02-03 at 14 49 32" src="https://cloud.githubusercontent.com/assets/335567/22611554/1442f6f6-ea20-11e6-84d2-1476d1d1b208.png">

for this:

<img width="86" alt="screen shot 2017-02-03 at 14 51 31" src="https://cloud.githubusercontent.com/assets/335567/22611597/4c6c3d58-ea20-11e6-850d-fb0acadeee55.png">

Which is not great, but it's the only option I found to ave consistent breaking regardless of wether we have space or a number in the prompt.