### PR TITLE
Add cmdtrl-shift-f shortcut to show command palette

### DIFF
--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -114,6 +114,7 @@ define([
     KeyboardManager.prototype.get_default_edit_shortcuts = function() {
         return {
             'cmdtrl-shift-p'      : 'jupyter-notebook:show-command-palette',
+            'cmdtrl-shift-f'      : 'jupyter-notebook:show-command-palette',
             'esc'                 : 'jupyter-notebook:enter-command-mode',
             'ctrl-m'              : 'jupyter-notebook:enter-command-mode',
             'up'                  : 'jupyter-notebook:move-cursor-up',
@@ -125,6 +126,7 @@ define([
     KeyboardManager.prototype.get_default_command_shortcuts = function() {
         return {
             'cmdtrl-shift-p': 'jupyter-notebook:show-command-palette',
+            'cmdtrl-shift-f': 'jupyter-notebook:show-command-palette',
             'shift-space': 'jupyter-notebook:scroll-notebook-up',
             'shift-v' : 'jupyter-notebook:paste-cell-above',
             'shift-m' : 'jupyter-notebook:merge-cells',


### PR DESCRIPTION
Closes gh-2121

At least on my system, Ctrl-Shift-F does not seem to be taken in either Chrome or Firefox. My reasoning for F is '**F**ind command'.