### PR TITLE
Add test dependencies to `devDependecies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   },
   "devDependencies": {
     "bower": "*",
+    "casperjs": "^1.1.3",
     "less": "~2",
+    "phantomjs": "^2.1.7",
     "requirejs": "^2.1.17"
   },
   "dependencies": {


### PR DESCRIPTION
It’s more conventional within the JS community to include test dependencies in `devDependencies` of `package.json` vs. [requiring developers to install them before runnings tests](https://github.com/jupyter/notebook/blob/master/CONTRIBUTING.rst#javascript-tests). `devDependecies` are only installed on `npm install` inside a project vs. `npm install [package name]`, so it will only be installed by developers.

Thoughts?