### PR TITLE
Upgrade xterm.js to 2.3.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,6 @@
     "requirejs": "~2.1",
     "text-encoding": "~0.1",
     "underscore": "components/underscore#~1.8.3",
-    "xterm.js": "sourcelair/xterm.js#~2.2.3"
+    "xterm.js": "sourcelair/xterm.js#~2.3.1"
   }
 }


### PR DESCRIPTION
See https://github.com/sourcelair/xterm.js/releases/tag/2.3.0.  The biggest gain is in performance; commands with a ton of output are now properly handled.  Tested on OSX with Firefox, Chrome, and Safari.