### PR TITLE
Add a clear_output code cell event

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -510,6 +510,7 @@ define([
     CodeCell.prototype.clear_output = function (wait) {
         this.output_area.clear_output(wait);
         this.set_input_prompt();
+        this.events.trigger('clearOutput.CodeCell', {cell: this});
     };
 
 

--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -510,7 +510,7 @@ define([
     CodeCell.prototype.clear_output = function (wait) {
         this.output_area.clear_output(wait);
         this.set_input_prompt();
-        this.events.trigger('clearOutput.CodeCell', {cell: this});
+        this.events.trigger('clear_output.CodeCell', {cell: this});
     };
 
 


### PR DESCRIPTION
This is triggered when a code cell clears its output. It is needed for the widgets to be able to clear themselves when the cell output is cleared, fixing https://github.com/ipython/ipywidgets/issues/637