### PR TITLE
Support underline and inverse in ANSI escape codes

### DIFF
--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -282,6 +282,8 @@ define([
         var fg = [];
         var bg = [];
         var bold = false;
+        var underline = false;
+        var inverse = false;
         var match;
         var out = [];
         var numbers = [];
@@ -330,6 +332,14 @@ define([
                     classes.push("ansi-bold");
                 }
 
+                if (underline) {
+                    classes.push("ansi-underline");
+                }
+
+                if (inverse) {
+                    classes.push("ansi-inverse");
+                }
+
                 if (classes.length || styles.length) {
                     out.push("<span");
                     if (classes.length) {
@@ -353,10 +363,18 @@ define([
                     case 0:
                         fg = bg = [];
                         bold = false;
+                        underline = false;
+                        inverse = false;
                         break;
                     case 1:
                     case 5:
                         bold = true;
+                        break;
+                    case 4:
+                        underline = true;
+                        break;
+                    case 7:
+                        inverse = true;
                         break;
                     case 21:
                     case 22:

--- a/notebook/static/notebook/less/ansicolors.less
+++ b/notebook/static/notebook/less/ansicolors.less
@@ -21,6 +21,8 @@
 .ansicolors(white, #C5C1B4, #A1A6B2);
 
 .ansi-bold { font-weight: bold; }
+.ansi-underline { text-decoration: underline; }
+.ansi-inverse { outline: 0.5px dotted; }
 
 /* The following styles are deprecated an will be removed in a future version */
 

--- a/tools/tests/ANSI Test.ipynb
+++ b/tools/tests/ANSI Test.ipynb
@@ -48,22 +48,22 @@
      "text": [
       "This is normal text\n",
       "\n",
-      "\u001b[01mThis is bold text\n",
+      "\u001b[01mThis is bold text\u001b[00m\n",
       "\n",
-      "\u001b[04mThis is underlined text\n",
+      "\u001b[04mThis is underlined text\u001b[00m\n",
       "\n",
-      "\u001b[07mThis is inverse text\n"
+      "\u001b[07mThis is inverse text\u001b[00m\n"
      ]
     }
    ],
    "source": [
     "print (\"This is normal text\")\n",
     "print()\n",
-    "print (\"{ESC}01mThis is bold text\".format(**locals()))\n",
+    "print (\"{ESC}01mThis is bold text{RESET}\".format(**locals()))\n",
     "print()\n",
-    "print (\"{ESC}04mThis is underlined text\".format(**locals()))\n",
+    "print (\"{ESC}04mThis is underlined text{RESET}\".format(**locals()))\n",
     "print()\n",
-    "print (\"{ESC}07mThis is inverse text\".format(**locals()))"
+    "print (\"{ESC}07mThis is inverse text{RESET}\".format(**locals()))"
    ]
   },
   {

--- a/tools/tests/ANSI Test.ipynb
+++ b/tools/tests/ANSI Test.ipynb
@@ -34,6 +34,42 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Bold, underline and inverse text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This is normal text\n",
+      "\n",
+      "\u001b[01mThis is bold text\n",
+      "\n",
+      "\u001b[04mThis is underlined text\n",
+      "\n",
+      "\u001b[07mThis is inverse text\n"
+     ]
+    }
+   ],
+   "source": [
+    "print (\"This is normal text\")\n",
+    "print()\n",
+    "print (\"{ESC}01mThis is bold text\".format(**locals()))\n",
+    "print()\n",
+    "print (\"{ESC}04mThis is underlined text\".format(**locals()))\n",
+    "print()\n",
+    "print (\"{ESC}07mThis is inverse text\".format(**locals()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Plain ANSI 16-color"
    ]
   },


### PR DESCRIPTION
I was dumping output from [cdiff](https://github.com/ymattw/cdiff) into a notebook and noticed that its use of underline and inverse escape codes wasn't being reflected in the notebook output.  A couple simple tweaks to the ANSI parsing and some added CSS classes and it now does.