### PR TITLE
Don't force notebooks to be opened in a new tab

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -689,12 +689,6 @@ define([
 
         item.find(".item_buttons .running-indicator").css('visibility', running ? '' : 'hidden');
 
-        // directory nav doesn't open new tabs
-        // files, notebooks do
-        if (model.type !== "directory") {
-            link.attr('target',IPython._target);
-        }
-
         // Add in the date that the file was last modified
         item.find(".item_modified").text(utils.format_datetime(modified));
         item.find(".item_modified").attr("title", moment(modified).format("YYYY-MM-DD HH:mm"));


### PR DESCRIPTION
New tabs can be convenient, but we shouldn't force users to open their notebooks in a new tab.
If the users would like to open their notebook in a new tab they may use the [Meta]-click shortcut.

As far as I can see, there are no technical limitation prohibiting notebooks from being opened in the same tab.

[When to use target=”_blank”](https://css-tricks.com/use-target_blank/) has more reasoning regarding `target="_blank"`.