### PR TITLE
Fix viewing HTML in sandboxed iframe

### DIFF
--- a/notebook/templates/view.html
+++ b/notebook/templates/view.html
@@ -23,7 +23,7 @@
     }
   </style>
   <div id="container">
-    <iframe id="iframe" sandbox="allow-scripts" src="{{base_url}}/files/{{file_path}}"></iframe>
+    <iframe id="iframe" sandbox="allow-scripts" src="{{file_url}}"></iframe>
   </div>
 </body>
 

--- a/notebook/view/handlers.py
+++ b/notebook/view/handlers.py
@@ -6,7 +6,7 @@
 
 from tornado import web
 from ..base.handlers import IPythonHandler, path_regex
-from ..utils import url_escape
+from ..utils import url_escape, url_path_join
 
 class ViewHandler(IPythonHandler):
     """Render HTML files within an iframe."""
@@ -17,8 +17,9 @@ class ViewHandler(IPythonHandler):
             raise web.HTTPError(404, u'File does not exist: %s' % path)
 
         basename = path.rsplit('/', 1)[-1]
+        file_url = url_path_join(self.base_url, 'files', path)
         self.write(
-            self.render_template('view.html', file_path=url_escape(path), page_title=basename)
+            self.render_template('view.html', file_url=file_url, page_title=basename)
         )
 
 default_handlers = [


### PR DESCRIPTION
See gh-2203

The URL calculation was going wrong, so it was using a URL starting with `//files`. This uses `url_path_join()` to get the separators right.