### PR TITLE
Cull idle kernels

### DIFF
--- a/notebook/services/kernels/kernelmanager.py
+++ b/notebook/services/kernels/kernelmanager.py
@@ -264,6 +264,10 @@ class MappingKernelManager(MultiKernelManager):
         if not self._initialized_culler and self.cull_kernels_after_minutes > 0:
             if self._culler_callback is None:
                 loop = IOLoop.current()
+                if self.kernel_culling_interval_seconds <= 0: #handle case where user set invalid value
+                    self.log.warn("Invalid value for 'kernel_culling_interval_seconds' detected (%s) - using default value (%s).",
+                        self.kernel_culling_interval_seconds, self.kernel_culling_interval_seconds_default)
+                    self.kernel_culling_interval_seconds = self.kernel_culling_interval_seconds_default
                 self._culler_callback = PeriodicCallback(
                     self.cull_kernels, 1000*self.kernel_culling_interval_seconds, loop)
                 self.log.info("Culling kernels with idle durations > %s minutes at %s second intervals ...",


### PR DESCRIPTION
(Updated to include review recommendations below...)

This change introduces the ability to cull kernels that have been idle for a specified amount of time.  Off by default, it is enabled by setting `--MappingKernelManager.cull_idle_timeout` to a positive value representing the number of seconds a kernel must remain inactive to be culled.  This feature leverages [activity tracking's](https://github.com/jupyter/notebook/pull/1827) `last_activity` value to determine when the last activity for a given kernel occurred.  Typical values for `cull_idle_timeout` will be on the order of 43200 (12 hours) or 86400 (24 hours) seconds as described in this [JKG issue](https://github.com/jupyter/kernel_gateway/issues/96).  These changes originally targeted Jupyter Kernel Gateway per [issue #226](https://github.com/jupyter/kernel_gateway/issues/226) but really belongs in the Notebook server.

An optional property has been introduced to adjust the interval in which idle kernels are culled provided they have exceeded the aforementioned timeout property.  This property is adjusted by setting `--MappingKernelManager.cull_interval` to a positive value.  If not set or non-positive, the default value of 300 (5 minutes) seconds will be used.

JKG [Issue 227](https://github.com/jupyter/kernel_gateway/issues/227) has been opened to remove the activity tracking that was also in place in the JKG.  Prior to that, there could be false reports of active kernels that have been culled by the underlying MappingKernelManager.  If not removed, we should minimally adjust the JKG's activity tracking handler to consult the active kernel manager class on each request.