### PR TITLE
Fixed issue #980: incorrect LaTeX capturing and MathJax rendering

### DIFF
--- a/notebook/static/notebook/js/mathjaxutils.js
+++ b/notebook/static/notebook/js/mathjaxutils.js
@@ -59,7 +59,7 @@ define([
 
     // MATHSPLIT contains the pattern for math delimiters and special symbols
     // needed for searching for math in the text input.
-    var MATHSPLIT = /(\$\$?|\\(?:begin|end)\{[a-z]*\*?\}|\\[{}$]|[{}]|(?:\n\s*)+|@@\d+@@|\\\\(?:\(|\)))/i;
+    var MATHSPLIT = /(\$\$?|\\(?:begin|end)\{[a-z]*\*?\}|\\[{}$]|[{}]|(?:\n\s*)+|@@\d+@@|\\\\(?:\(|\)|\[|\]))/i;
 
     //  The math is in blocks i through j, so
     //    collect it into one block and clear the others.
@@ -178,10 +178,10 @@ define([
                     end = block;
                     braces = 0;
                 }
-                else if (block === "\\\\\(") {
-                	start = i;
-                	end = "\\\\\)";
-                	braces = 0;
+                else if (block === "\\\\\(" || block === "\\\\\[") {
+                    start = i;
+                    end = block.slice(-1) === "(" ? "\\\\\)" : "\\\\\]";
+                    braces = 0;
                 }
                 else if (block.substr(1, 5) === "begin") {
                     start = i;
@@ -204,11 +204,20 @@ define([
     //    and clear the math array (no need to keep it around).
     //
     var replace_math = function (text, math) {
-        text = text.replace(/@@(\d+)@@/g, function (match, n) {
-            return math[n]
-            	.replace("\\\\\(", "\\\(")
-            	.replace("\\\\\)", "\\\)");
-        });
+        var math_group_process = function (match, n) {
+            var math_group = math[n];
+
+            if (math_group.substr(0, 3) === "\\\\\("  && math_group.substr(math_group.length - 3) === "\\\\\)") {
+                math_group = "\\\(" + math_group.substring(3, math_group.length - 3) + "\\\)";
+            } else if (math_group.substr(0, 3) === "\\\\\[" && math_group.substr(math_group.length - 3) === "\\\\\]") {
+                math_group = "\\\[" + math_group.substring(3, math_group.length - 3) + "\\\]";
+            }
+            
+            return math_group;
+        };
+
+        text = text.replace(/@@(\d+)@@/g, math_group_process);
+        
         return text;
     };
 

--- a/notebook/static/notebook/js/mathjaxutils.js
+++ b/notebook/static/notebook/js/mathjaxutils.js
@@ -204,6 +204,11 @@ define([
     //    and clear the math array (no need to keep it around).
     //
     var replace_math = function (text, math) {
+    	//
+    	//  Replaces a math placeholder with its corresponding group.
+    	//  The math delimiters "\\(", "\\[", "\\)" and "\\]" are replaced
+    	//  removing one backslash in order to be interpreted correctly by MathJax.
+    	//
         var math_group_process = function (match, n) {
             var math_group = math[n];
 
@@ -216,6 +221,8 @@ define([
             return math_group;
         };
 
+        // Replace all the math group placeholders in the text
+        // with the saved strings.
         text = text.replace(/@@(\d+)@@/g, math_group_process);
         
         return text;

--- a/notebook/static/notebook/js/mathjaxutils.js
+++ b/notebook/static/notebook/js/mathjaxutils.js
@@ -55,8 +55,6 @@ define([
     // Other minor modifications are also due to StackExchange and are used with
     // permission.
 
-    var inline = "$"; // the inline math delimiter
-
     // MATHSPLIT contains the pattern for math delimiters and special symbols
     // needed for searching for math in the text input.
     var MATHSPLIT = /(\$\$?|\\(?:begin|end)\{[a-z]*\*?\}|\\[{}$]|[{}]|(?:\n\s*)+|@@\d+@@|\\\\(?:\(|\)|\[|\]))/i;
@@ -173,7 +171,7 @@ define([
                 //  Look for math start delimiters and when
                 //    found, set up the end delimiter.
                 //
-                if (block === inline || block === "$$") {
+                if (block === "$" || block === "$$") {
                     start = i;
                     end = block;
                     braces = 0;

--- a/notebook/tests/notebook/markdown.js
+++ b/notebook/tests/notebook/markdown.js
@@ -128,9 +128,29 @@ casper.notebook_test(function () {
         };
       });
     };
-    var input_string_1 = 'x\\\\(a_{0}+ b_{T}\\\\)y\\\\(a_{0}+  b_{T}\\\\)z';
-    var expected_result_1 = ['x@@0@@y@@1@@z',['\\\\(a_{0}+ b_{T}\\\\)','\\\\(a_{0}+  b_{T}\\\\)']];
-    var message_1 = "multiple inline with underscores";
+    var input_string_1 = 'x \\\\(a_{0}+ b_{T}\\\\) y \\\\(a_{0}+  b_{T}\\\\) z';
+    var expected_result_1 = ['x @@0@@ y @@1@@ z', ['\\\\(a_{0}+ b_{T}\\\\)','\\\\(a_{0}+  b_{T}\\\\)']];
+    var message_1 = "multiple inline(LaTeX style) with underscores";
+    
+    var input_string_2 = 'x \\\\[a_{0}+ b_{T}\\\\] y \\\\[a_{0}+  b_{T}\\\\] z';
+    var expected_result_2 = ['x @@0@@ y @@1@@ z', ['\\\\[a_{0}+ b_{T}\\\\]','\\\\[a_{0}+  b_{T}\\\\]']];
+    var message_2 = "multiple equation (LaTeX style) with underscores";
+
+    var input_string_3 = 'x $a_{0}+ b_{T}$ y $a_{0}+  b_{T}$ z';
+    var expected_result_3 = ['x @@0@@ y @@1@@ z',['$a_{0}+ b_{T}$','$a_{0}+  b_{T}$']];
+    var message_3 = "multiple inline(TeX style) with underscores";
+    
+    var input_string_4 = 'x $$a_{0}+ b_{T}$$ y $$a_{0}+  b_{T}$$ z';
+    var expected_result_4 = ['x @@0@@ y @@1@@ z', ['$$a_{0}+ b_{T}$$','$$a_{0}+  b_{T}$$']];
+    var message_4 = "multiple equation(TeX style) with underscores";
+
+    var input_string_5 = 'x \\begin{equation}a_{0}+ b_{T}\\end{equation} y \\begin{equation}a_{0}+  b_{T}\\end{equation} z';
+    var expected_result_5 = ['x @@0@@ y @@1@@ z',['\\begin{equation}a_{0}+ b_{T}\\end{equation}','\\begin{equation}a_{0}+  b_{T}\\end{equation}']];
+    var message_5 = "multiple equations with underscores";
 
     mathjax_render_test(input_string_1, expected_result_1, message_1);
+    mathjax_render_test(input_string_2, expected_result_2, message_2);
+    mathjax_render_test(input_string_3, expected_result_3, message_3);
+    mathjax_render_test(input_string_4, expected_result_4, message_4);
+    mathjax_render_test(input_string_5, expected_result_5, message_5);
 });

--- a/notebook/tests/notebook/markdown.js
+++ b/notebook/tests/notebook/markdown.js
@@ -102,4 +102,35 @@ casper.notebook_test(function () {
     codeblock = '```aaaa\nx = 1\n```'
     result = '<pre><code class="cm-s-ipython language-aaaa">x = 1\n</code></pre>'
     md_render_test(codeblock, result, 'Markdown code block unknown language');
+
+    function mathjax_render_test(input_string, result, message){
+      casper.thenEvaluate(function (text){
+        window._test_result = null;
+        require(['notebook/js/mathjaxutils'],function(mathjaxutils){
+          window._test_result = mathjaxutils.remove_math(text);
+        });
+      }, {text: input_string});
+      casper.waitFor(function() {
+        return casper.evaluate(function(){
+          return window._test_result!==null;
+        });
+      });
+      casper.then(function(){
+        var return_val = casper.evaluate(function(){
+          var blah = window._test_result;
+          delete window._test_result;
+          return blah;
+        });
+        this.test.assertEquals(return_val[0], result[0], message+" markdown");
+        this.test.assertEquals(return_val[1].length, result[1].length, message+" math instance count");
+        for(var i=0; i<return_val[1].length; i++){
+          this.test.assertEquals(return_val[1][i], result[1][i], message+" math instance "+i);
+        };
+      });
+    };
+    var input_string_1 = 'x\\\\(a_{0}+ b_{T}\\\\)y\\\\(a_{0}+  b_{T}\\\\)z';
+    var expected_result_1 = ['x@@0@@y@@1@@z',['\\\\(a_{0}+ b_{T}\\\\)','\\\\(a_{0}+  b_{T}\\\\)']];
+    var message_1 = "multiple inline with underscores";
+
+    mathjax_render_test(input_string_1, expected_result_1, message_1);
 });


### PR DESCRIPTION
I wrote a bugfix for issue #980.

### Background
The LaTeX code that needs to be rendered inline in the text cells is specified using delimiters. In particular, the following delimiters are supported:

1. `$`
2. `$$`
3. `\begin` and `\end`
4. `\(` and `\)`

(A note on the last one. It's necessary to write `\\(` instead of `\(` because in the latter case the backslash gets interpreted by Markdown as an escaper for the parenthesis.)

There is a mechanism in place in order for the LaTeX code not to get interpreted as Markdown. It works as follows:

- The user enters the Markdown with inline LaTeX in the text cell, for example `*abc* $x_1 = 1, x_2 = 2$ _def_`, and clicks execute cell.
- The function `remove_math` in `notebook/static/notebook/js/mathjaxutils.js` is used to extract the LaTeX groups from the text, put them in a separate array, and replace the groups in the text with placeholders. In this case, for example, the function will return `['*abc* @@0@@ _def_', ['$x_1 = 1, x_2 = 2$']]`.
- The text gets rendered as Markdown.
- The placeholders get replaced with the LaTeX groups that were backed up.
- The rendered Markdown is processed by MathJax to render the LaTeX.

This procedure is necessary since, otherwise, the underscores in the LaTeX group would be interpreted as italic delimiters, in this example.

The **core of the problem** is that the function `remove_math` extracts from the text only the groups delimited by 1, 2 and 3, but not 4.

It's easy in fact to see that in the third line in the example in the issue the underscores are interpreted as italic delimiters by Markdown.

### Fix
The changes are made on the `notebook/static/notebook/js/mathjaxutils.js` file.

The `remove_math` function contains some logic to identify the LaTeX blocks and extract them. The first step in this procedure is to split the text on all the possible group delimiters. This is done using the `MATHSPLIT` regular expression defined on line 62. As the comments in the code say, it's a bit "magical" in the sense that its workings are not crystal clear.

The `\\(` and `\\)` delimiters were missing from the regular expression, so I added them appending `\\\\(?:\(|\))` to it. Moreover, since the regular expression was already matching the text `\\` as a delimiter, I had to remove it (otherwise the block `\\(` would not be grouped together and we would not be able to identify it as a group delimiter). It is not clear to me the purpose of splitting on the `\\`s since we're only looking for LaTeX group delimiters and they are not. I suspect it a result of a copy & paste from somewhere else, since the comments cite different sources for the code.

After being split, the text is processed by running over each of the blocks and looking for start and end LaTeX delimiters. On line 181 I added the missing logic to handle the case in which the text `\\(`is the start delimiter and the text `\\)` is the end delimiter. 

The last change is in the line 208. It is necessary because since the LaTeX code is extracted, backed up, and reinserted in the text after the Markdown is rendered, the `\\(` that was necessary for Markdown is not interpreted by it (resulting in `\(`), so we have to manually replace the instances of `\\(` and `\\)` to `\(` and `\)` respectively, which are the delimiters that are recognized by MathJax.