### PR TITLE
Updated docs on installed phantomjs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -124,7 +124,7 @@ JavaScript Tests
 To run the JavaScript tests, you will need to have PhantomJS and CasperJS
 installed::
 
-    npm install -g casperjs phantomjs@1.9.18
+    npm install -g casperjs phantomjs-prebuilt
 
 Then, to run the JavaScript tests::
 


### PR DESCRIPTION
I had trouble trying to run the notebook tests on master and realised it was because I had v1.9.8 of PhantomJS installed and that when I updated to a later version it worked fine. Since they changed the npm package name from phantomjs to phantomjs-prebuilt that meant that the contributing doc was outdated. So a quick one-liner fix to help future contributors.