### PR TITLE
Show server root directory in move dialog

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -202,6 +202,12 @@ class NotebookWebApplication(web.Application):
             warnings.warn("The `ignore_minified_js` flag is deprecated and will be removed in Notebook 6.0", DeprecationWarning)
 
         now = utcnow()
+        
+        root_dir = contents_manager.root_dir
+        home = os.path.expanduser('~')
+        if root_dir.startswith(home + os.path.sep):
+            # collapse $HOME to ~
+            root_dir = '~' + root_dir[len(home):]
 
         settings = dict(
             # basics
@@ -255,7 +261,7 @@ class NotebookWebApplication(web.Application):
             mathjax_config=jupyter_app.mathjax_config,
             config=jupyter_app.config,
             config_dir=jupyter_app.config_dir,
-            server_root_dir=contents_manager.root_dir,
+            server_root_dir=root_dir,
             jinja2_env=env,
             terminals_available=False,  # Set later if terminals are available
         )

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -255,6 +255,7 @@ class NotebookWebApplication(web.Application):
             mathjax_config=jupyter_app.mathjax_config,
             config=jupyter_app.config,
             config_dir=jupyter_app.config_dir,
+            server_root_dir=jupyter_app.notebook_dir,
             jinja2_env=env,
             terminals_available=False,  # Set later if terminals are available
         )

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -255,7 +255,7 @@ class NotebookWebApplication(web.Application):
             mathjax_config=jupyter_app.mathjax_config,
             config=jupyter_app.config,
             config_dir=jupyter_app.config_dir,
-            server_root_dir=jupyter_app.notebook_dir,
+            server_root_dir=contents_manager.root_dir,
             jinja2_env=env,
             terminals_available=False,  # Set later if terminals are available
         )

--- a/notebook/services/contents/manager.py
+++ b/notebook/services/contents/manager.py
@@ -50,6 +50,8 @@ class ContentsManager(LoggingConfigurable):
       indicating the root path.
 
     """
+    
+    root_dir = Unicode('/', config=True)
 
     notary = Instance(sign.NotebookNotary)
     def _notary_default(self):

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -842,7 +842,15 @@ define([
                 .text('Enter new destination directory path for '+ num_items + ' items:')
         ).append(
             $("<br/>")
-        ).append(input);
+        ).append(
+            $("<table/>").append(
+                $("<tr/>").append(
+                    $("<td/>").text(utils.get_body_data('serverRoot'))
+                ).append(
+                    $("<td/>").append(input)
+                )
+            ).css('width', '100%')
+        );
         var d = dialog.modal({
             title : "Move "+ num_items + " Items",
             body : dialog_body,

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -843,13 +843,12 @@ define([
         ).append(
             $("<br/>")
         ).append(
-            $("<table/>").append(
-                $("<tr/>").append(
-                    $("<td/>").text(utils.get_body_data('serverRoot'))
-                ).append(
-                    $("<td/>").append(input)
-                )
-            ).css('width', '100%')
+            $("<div/>").append(
+                // $("<i/>").addClass("fa fa-folder").addClass("server-root")
+                $("<span/>").text(utils.get_body_data("serverRoot")).addClass("server-root")
+            ).append(
+              input.addClass("path-input")
+            ).addClass("move-path")
         );
         var d = dialog.modal({
             title : "Move "+ num_items + " Items",

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -8,6 +8,7 @@
 data-base-url="{{base_url | urlencode}}"
 data-notebook-path="{{notebook_path | urlencode}}"
 data-terminals-available="{{terminals_available}}"
+data-server-root="{{server_root}}"
 {% endblock %}
 
 

--- a/notebook/tree/handlers.py
+++ b/notebook/tree/handlers.py
@@ -4,6 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from tornado import web
+import os
 from ..base.handlers import IPythonHandler, path_regex
 from ..utils import url_path_join, url_escape
 
@@ -49,7 +50,7 @@ class TreeHandler(IPythonHandler):
                 notebook_path=path,
                 breadcrumbs=breadcrumbs,
                 terminals_available=self.settings['terminals_available'],
-                server_root=self.settings['server_root_dir'],
+                server_root=os.path.basename(os.path.normpath(self.settings['server_root_dir'])),
             ))
         elif cm.file_exists(path):
             # it's not a directory, we have redirecting to do

--- a/notebook/tree/handlers.py
+++ b/notebook/tree/handlers.py
@@ -50,7 +50,7 @@ class TreeHandler(IPythonHandler):
                 notebook_path=path,
                 breadcrumbs=breadcrumbs,
                 terminals_available=self.settings['terminals_available'],
-                server_root=os.path.basename(os.path.normpath(self.settings['server_root_dir'])),
+                server_root=self.settings['server_root_dir'],
             ))
         elif cm.file_exists(path):
             # it's not a directory, we have redirecting to do

--- a/notebook/tree/handlers.py
+++ b/notebook/tree/handlers.py
@@ -49,6 +49,7 @@ class TreeHandler(IPythonHandler):
                 notebook_path=path,
                 breadcrumbs=breadcrumbs,
                 terminals_available=self.settings['terminals_available'],
+                server_root=self.settings['server_root_dir'],
             ))
         elif cm.file_exists(path):
             # it's not a directory, we have redirecting to do


### PR DESCRIPTION
Attempt at addressing #2204

![screenshot from 2017-02-27 16-37-58](https://cloud.githubusercontent.com/assets/327925/23370203/e01379a6-fd0b-11e6-8262-0efbf2c0e96a.png)

- I used a table to get them on the same line, but it doesn't fit them to the space neatly. I'm sure there's a better way to lay this out, but I don't know what it is. People who know more CSS than me, feel free to edit the branch directly.
- I think we're using API paths for the editable part, which is going to look weird for Windows users - the fixed part will have backslashes, and the editable part forward slashes.
- Is exposing the path of the server root directory like this at all a concern? I can't see any reason why it would be, but I don't think anything currently exposes it.
- What would this do with non-filesystem-based contents managers?