### PR TITLE
Fix markdown highlighting in latex

### DIFF
--- a/notebook/static/notebook/js/codemirror-ipythongfm.js
+++ b/notebook/static/notebook/js/codemirror-ipythongfm.js
@@ -33,14 +33,15 @@
 
         return CodeMirror.multiplexingMode(
             gfm_mode,
+            // By defining the $$ delimiter before the $ delimiter we don't run
+            // into the problem that $$ is interpreted as two consecutive $.
             {
-                open: "$", close: "$",
+                open: "$$", close: "$$",
                 mode: tex_mode,
                 delimStyle: "delimit"
             },
             {
-                // not sure this works as $$ is interpreted at (opening $, closing $, as defined just above)
-                open: "$$", close: "$$",
+                open: "$", close: "$",
                 mode: tex_mode,
                 delimStyle: "delimit"
             },


### PR DESCRIPTION
I wrote a bugfix for issue #1911. Description follows.

### Problem
The issue is relative to the syntax highlight of the the markdown cells containing LaTeX code. The user opening the issue provides this problematic example

````
$ a^* = hello $
$$ a^* = hello $$
````
which results in the following syntax highlighting

![example](http://i.imgur.com/eB2QOk7.png)

The problem is that the LaTeX code delimited with `$$` gets interpreted as markdown and in particular the asterisk is interpreted as the italic delimiter. This does not happen for the LaTeX code delimited by `$`.

### Background
The syntax highlight is provided by CodeMirror. The mode (syntax specification) used for highlighting is a custom one, defined in `notebook/static/notebook/js/codemirror-ipythongfm.js` and named `ipythongfm`.

This mode is defined as a [multiplexing mode](https://codemirror.net/doc/manual.html#addon_multiplex), combining the Github Flavored Markdown (`gfm`) mode with the sTeX (`stex`) mode to highlight both the GFM and the LaTeX code.

The switch between the two modes is decided by the opening delimiters `$`, `$$`, `\(` and `\[` and the corresponding closing delimiters.

The problem is that, as the comment on line 42 of the file defining the mode says, the `$$` delimiter is never interpreted as a opening delimiter because it gets first interpreted as two consecutive `$` delimiters, opening and closing an empty LaTeX block.

### Fix
By simply swapping the order of the definition of the multiplexed modes, and defining `$$` before `$`, the bug is fixed. This is because when the text stream is processed by CodeMirror looking for delimiters, the first defined delimiter that matches the stream is used and the other ones are not considered.

Result after the fix:

![result](http://i.imgur.com/4eVgkzN.png)

### Tests
I'm not sure it's possible to write tests for this functionality.