### PR TITLE
Add cell position when calculating location of cursor for tooltip

### DIFF
--- a/notebook/static/notebook/js/tooltip.js
+++ b/notebook/static/notebook/js/tooltip.js
@@ -274,6 +274,7 @@ define([
         // do some math to have the tooltip arrow on more or less on left or right
         // position of the editor
         var cm_pos = $(this.code_mirror.getWrapperElement()).position();
+        var cell_pos = $(this.code_mirror.getWrapperElement().offsetParent).position();
 
         // anchor and head positions are local within CodeMirror element
         var anchor = this.code_mirror.cursorCoords(false, 'local');
@@ -286,8 +287,8 @@ define([
         var arrow_left = center_left - edge_left - 24;
         
         // locate left, top within container element
-        var left = (cm_pos.left + edge_left) + 'px';
-        var top = (cm_pos.top + head.bottom + 10) + 'px';
+        var left = (cell_pos.left + cm_pos.left + edge_left) + 'px';
+        var top = (cell_pos.top + cm_pos.top + head.bottom + 10) + 'px';
 
         if (this._hidden === false) {
             this.tooltip.animate({


### PR DESCRIPTION
Closes gh-2245, I hope, but I don't know if there's a better way to fix it.

I think we need to calculate the location relative to the 'offset parent' of the tooltip. Adding one extra parent level from CodeMirror seems to work at the moment.