### PR TITLE
Add 'new_browser_window' config option

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -678,11 +678,18 @@ class NotebookApp(JupyterApp):
                       standard library module, which allows setting of the
                       BROWSER environment variable to override it.
                       """)
-    new_browser_window = Bool(False, config=True,
-                              help="""Whether to open the notebook in a new
-                              browser window. The default is to use a new tab.
-                              """)
-    
+
+    webbrowser_open_new = Integer(2, config=True,
+        help="""Specify Where to open the notebook on startup. This is the
+        `new` argument passed to the standard library method `webbrowser.open`.
+        The behaviour is not guaranteed, but depends on browser support. Valid
+        values are:
+            2 opens a new tab,
+            1 opens a new window,
+            0 opens in an existing window.
+        See the `webbrowser.open` documentation for details.
+        """)
+
     webapp_settings = Dict(config=True,
         help="DEPRECATED, use tornado_settings"
     )
@@ -1391,7 +1398,7 @@ class NotebookApp(JupyterApp):
                 uri = url_concat(uri, {'token': self.one_time_token})
             if browser:
                 b = lambda : browser.open(url_path_join(self.connection_url, uri),
-                                          new=1 if self.new_browser_window else 2)
+                                          new=self.webbrowser_open_new)
                 threading.Thread(target=b).start()
 
         if self.token and self._token_generated:

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -678,6 +678,10 @@ class NotebookApp(JupyterApp):
                       standard library module, which allows setting of the
                       BROWSER environment variable to override it.
                       """)
+    new_browser_window = Bool(False, config=True,
+                              help="""Whether to open the notebook in a new
+                              browser window. The default is to use a new tab.
+                              """)
     
     webapp_settings = Dict(config=True,
         help="DEPRECATED, use tornado_settings"
@@ -1387,7 +1391,7 @@ class NotebookApp(JupyterApp):
                 uri = url_concat(uri, {'token': self.one_time_token})
             if browser:
                 b = lambda : browser.open(url_path_join(self.connection_url, uri),
-                                          new=2)
+                                          new=1 if self.new_browser_window else 2)
                 threading.Thread(target=b).start()
 
         if self.token and self._token_generated:


### PR DESCRIPTION
On startup, this optionally opens the notebook in a new browser window instead of a new tab.

Closes #2248

A quick test shows that this works at least for an up-to-date Firefox on Arch. Motivation, copied from the issue:
> As the title says, i'd like to be able to open notebooks in a new window by default. I frequently have several browser windows opened on different workspaces, and the current behaviour will open
the notebook in whatever window I last used (I think). This turns out to be somewhere where I don't want it to be quite often.

I grepped the repository for existing related config options, and found no additional mentions of them in the docs. Did I miss some place where this should be added?

Thanks for considering this request!