### PR TITLE
Patch #2234

### DIFF
--- a/notebook/static/notebook/less/modal.less
+++ b/notebook/static/notebook/less/modal.less
@@ -1,0 +1,19 @@
+.modal .modal-body {
+  
+  .rename-message {
+    
+  }
+  .move-path {
+    display: flex;
+    flex-direction: row;
+    justify-content: space;
+    align-items: center;
+    
+    .server-root {
+      padding-right: 20px;
+    }
+    .path-input {
+      flex: 1;
+    }
+  }
+}

--- a/notebook/static/notebook/less/style.less
+++ b/notebook/static/notebook/less/style.less
@@ -10,6 +10,7 @@
 @import "tagbar.less";
 @import "completer.less";
 @import "kernelselector.less";
+@import "modal.less";
 @import "menubar.less";
 @import "notificationarea.less";
 @import "notificationwidget.less";


### PR DESCRIPTION
I added styles to Bootstrap’s `modals.less so they were git ignored in #2234. This adds a new `modal.less`.