### PR TITLE
Fix deprecated decodestring warning

### DIFF
--- a/notebook/services/contents/largefilemanager.py
+++ b/notebook/services/contents/largefilemanager.py
@@ -57,7 +57,7 @@ class LargeFileManager(FileContentsManager):
                 bcontent = content.encode('utf8')
             else:
                 b64_bytes = content.encode('ascii')
-                bcontent = base64.decodestring(b64_bytes)
+                bcontent = base64.decodebytes(b64_bytes)
         except Exception as e:
             raise web.HTTPError(
                 400, u'Encoding error saving %s: %s' % (os_path, e)

--- a/notebook/services/contents/largefilemanager.py
+++ b/notebook/services/contents/largefilemanager.py
@@ -57,7 +57,7 @@ class LargeFileManager(FileContentsManager):
                 bcontent = content.encode('utf8')
             else:
                 b64_bytes = content.encode('ascii')
-                bcontent = base64.decodebytes(b64_bytes)
+                bcontent = base64.b64decode(b64_bytes)
         except Exception as e:
             raise web.HTTPError(
                 400, u'Encoding error saving %s: %s' % (os_path, e)

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@ warningfilters=module   |.*            |DeprecationWarning |notebook.*
                ignore   |.*schema.*    |UserWarning        |nbfor.*
                ignore   |The 'warn' method is deprecated, use 'warning' instead     | DeprecationWarning |notebook.*
                error    |encodestring\(\) is a deprecated alias, use encodebytes\(\)| DeprecationWarning | notebook.*
-
+               error    |decodestring\(\) is a .*| DeprecationWarning | notebook.*


### PR DESCRIPTION
While running the nose tests a warning was thrown saying that 
`notebook/services/contents/largefilemanager.py:60: DeprecationWarning: decodestring() is a deprecated alias, use decodebytes()
 bcontent = base64.decodestring(b64_bytes)` 

As per the documentation of [base64.decodestring](https://docs.python.org/3/library/base64.html#base64.decodestring) this is deprecated since version 3.1 and the new function to use is decodebytes().

Thus, the changes were made in the source code in file:
`notebook/services/contents/largefilemanager.py`

