### PR TITLE
Remove redundant sort from back-end

### DIFF
--- a/notebook/services/contents/handlers.py
+++ b/notebook/services/contents/handlers.py
@@ -18,17 +18,6 @@ from notebook.base.handlers import (
 )
 
 
-def sort_key(model):
-    """key function for case-insensitive sort by name and type"""
-    iname = model['name'].lower()
-    type_key = {
-        'directory' : '0',
-        'notebook'  : '1',
-        'file'      : '2',
-    }.get(model['type'], '9')
-    return u'%s%s' % (type_key, iname)
-
-
 def validate_model(model, expect_content):
     """
     Validate a model returned by a ContentsManager method.
@@ -123,10 +112,6 @@ class ContentsHandler(APIHandler):
         model = yield gen.maybe_future(self.contents_manager.get(
             path=path, type=type, format=format, content=content,
         ))
-        if model['type'] == 'directory' and content:
-            # group listing by type, then by name (case-insensitive)
-            # FIXME: sorting should be done in the frontends
-            model['content'].sort(key=sort_key)
         validate_model(model, expect_content=content)
         self._finish_model(model, location=False)
 


### PR DESCRIPTION
While I was looking for fixme's in the code I found the following. In the file [notebook/services/contents/handlers.py](https://github.com/jupyter/notebook/blob/master/notebook/services/contents/handlers.py#L126-L129) a fixme comment mentions that the sorting of the contents of a directory should be done in the front-end. I checked the code on the front-end where this is supposed to be done. 

I found out that it is already done [there](https://github.com/jupyter/notebook/blob/420715e3e5685d9216f09c25d644b420d11fe109/notebook/static/tree/js/notebooklist.js#L372-L386). So the sorting is done redundantly on the front-end and the back-end. I removed the sorting from the back-end.