### PR TITLE
Add pandoc to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ env:
     - GROUP=js/services
     - GROUP=js/tree
 
+addons:
+    apt_packages:
+        - pandoc
+
 before_install:
     - pip install --upgrade pip
     - pip install --upgrade setuptools wheel nose coverage codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
     - 3.5.1  # Set to 3.5.1 since travis has not yet included as default for 3.5
     - 2.7
 
-sudo: false
+sudo: required
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,6 @@ env:
     - GROUP=js/services
     - GROUP=js/tree
 
-addons:
-    apt_packages:
-        - pandoc
-
 before_install:
     - pip install --upgrade pip
     - pip install --upgrade setuptools wheel nose coverage codecov
@@ -41,6 +37,8 @@ before_install:
 
 install:
     - pip install -f travis-wheels/wheelhouse file://$PWD#egg=notebook[test]
+    - wget https://github.com/jgm/pandoc/releases/download/1.19.1/pandoc-1.19.1-1-amd64.deb && sudo dpkg -i pandoc-1.19.1-1-amd64.deb
+
 
 script:
     - 'if [[ $GROUP == js* ]]; then travis_retry python -m notebook.jstest ${GROUP:3}; fi'


### PR DESCRIPTION
While inspecting the code coverage on Codecov, I saw that some packages had suspiciously low coverage. I checked the Travis build logs and I realized that some tests are skipped because pandoc is missing. I added it as an apt addon to the Travis configuration file.