### PR TITLE
only consider stream output for data rate limit

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -997,7 +997,7 @@ class NotebookApp(JupyterApp):
         limited.""")
 
     iopub_data_rate_limit = Float(1000000, config=True, help="""(bytes/sec)
-        Maximum rate at which messages can be sent on iopub before they are
+        Maximum rate at which stream output can be sent on iopub before they are
         limited.""")
 
     rate_limit_window = Float(3, config=True, help="""(sec) Time window used to 

--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -360,7 +360,12 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
                     The notebook server will temporarily stop sending output
                     to the client in order to avoid crashing it.
                     To change this limit, set the config variable
-                    `--NotebookApp.iopub_msg_rate_limit`."""))
+                    `--NotebookApp.iopub_msg_rate_limit`.
+                    
+                    Current values:
+                    NotebookApp.iopub_msg_rate_limit={} (msgs/sec)
+                    NotebookApp.rate_limit_window={} (secs)
+                    """.format(self.iopub_msg_rate_limit, self.rate_limit_window)))
             else:
                 # resume once we've got some headroom below the limit
                 if self._iopub_msgs_exceeded and msg_rate < (0.8 * self.iopub_msg_rate_limit):
@@ -377,7 +382,12 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
                     The notebook server will temporarily stop sending output
                     to the client in order to avoid crashing it.
                     To change this limit, set the config variable
-                    `--NotebookApp.iopub_data_rate_limit`."""))
+                    `--NotebookApp.iopub_data_rate_limit`.
+                    
+                    Current values:
+                    NotebookApp.iopub_data_rate_limit={} (bytes/sec)
+                    NotebookApp.rate_limit_window={} (secs)
+                    """.format(self.iopub_data_rate_limit, self.rate_limit_window)))
             else:
                 # resume once we've got some headroom below the limit
                 if self._iopub_data_exceeded and data_rate < (0.8 * self.iopub_data_rate_limit):

--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -336,7 +336,10 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
 
             # Increment the bytes and message count
             self._iopub_window_msg_count += 1
-            byte_count = sum([len(x) for x in msg_list])
+            if msg_type == 'stream':
+                byte_count = sum([len(x) for x in msg_list])
+            else:
+                byte_count = 0
             self._iopub_window_byte_count += byte_count
             
             # Queue a removal of the byte and message count for a time in the 


### PR DESCRIPTION
large stream outputs cause much more problems than images or binary widget data, which seem to hit the rate limit more than anything.

this does open us up to large HTML and/or displayed text output potentially causing issues,
but most large outputs that have been hitting this limit do *not* cause issues (#2287).

The main throttle that's important is DOM elements to be added to the page. We can't feasibly distinguish between a massive million-element SVG and HTML with one big image in it.

This does explicitly remove the ability to do throttling based on *bandwith*. If people do want that, I can add the stream limit to a new config value. In that case, I would change the default all-output rate limit to no limit, so the same behavior as this PR, just with an extra knob.

closes #2287