### PR TITLE
Trigger 'cleared' event when output area is cleared

### DIFF
--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -969,6 +969,7 @@ define([
 
             // Notify others of changes.
             this.element.trigger('changed');
+            this.element.trigger('cleared');
             
             this.outputs = [];
             this._display_id_targets = {};


### PR DESCRIPTION
This would be helpful to have for unmounting React-based renderers when outputs are cleared and prevent duplicate instances of the components.

Usage within a renderer:

```js
this.element.on('cleared', () => {
   ReactDOM.unmountComponentAtNode(toinsert[0]);
});
```