### PR TITLE
minor updates to CONTRIBUTING installation instructions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -48,14 +48,13 @@ Installing the Jupyter Notebook
 Once you have installed the dependencies mentioned above, use the following
 steps::
 
-    pip install setuptools pip --upgrade --user
+    pip install --upgrade setuptools pip
     git clone https://github.com/jupyter/notebook
     cd notebook
-    pip install -e . --user
+    pip install -e .
 
-If you want the development environment to be available for all users of your
-system (assuming you have the necessary rights) or if you are installing in a
-virtual environment, just drop the ``--user`` option.
+If you are using a system-wide Python installation and you only want to install the notebook for you,
+you can add ``--user`` to the install commands.
 
 Once you have done this, you can launch the master branch of Jupyter notebook
 from any directory in your system with::
@@ -106,7 +105,7 @@ Python Tests
 
 Install dependencies::
 
-    pip install -e .[test] --user
+    pip install -e .[test]
 
 To run the Python tests, use::
 
@@ -155,10 +154,9 @@ containing all the necessary packages (except pandoc), use::
 .. _conda environment:
     http://conda.pydata.org/docs/using/envs.html#use-environment-from-file
 
-If you want to install the necessary packages with ``pip`` instead, use
-(omitting --user if working in a virtual environment)::
+If you want to install the necessary packages with ``pip`` instead::
 
-    pip install -r docs/doc-requirements.txt --user
+    pip install -r docs/doc-requirements.txt
 
 Once you have installed the required packages, you can build the docs with::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,22 +24,20 @@ Installing Node.js and npm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Building the Notebook from its GitHub source code requires some tools to
-create and minify JavaScript components and the CSS.
-Namely, that's Node.js and Node's package manager, ``npm``.
+create and minify JavaScript components and the CSS,
+specifically Node.js and Node's package manager, ``npm``.
+It should be node version ≥ 6.0.
 
 If you use ``conda``, you can get them with::
 
-    conda install -c javascript nodejs
+    conda install -c conda-forge nodejs
 
 If you use `Homebrew <http://brew.sh/>`_ on Mac OS X::
 
     brew install node
 
-For Debian/Ubuntu systems, you should use the ``nodejs-legacy`` package instead
-of the ``node`` package::
-
-    sudo apt-get update
-    sudo apt-get install nodejs-legacy npm
+Installation on Linux may vary, but be aware that the `nodejs` or `npm` packages
+included in the system package repository may be too old to work properly.
 
 You can also use the installer from the `Node.js website <https://nodejs.org>`_.
 


### PR DESCRIPTION
- invert `--user` recommendation in CONTRIBUTING, making `--user` the no longer the default option, given the prevalence of conda/virtual envs these days.

- update Linux node installation to remove `apt` recommendation because the system install rarely provides a recent enough release.