### PR TITLE
Use Markdown image references in example notebook

### DIFF
--- a/docs/source/examples/Notebook/Notebook Basics.ipynb
+++ b/docs/source/examples/Notebook/Notebook Basics.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "When you first start the notebook server, your browser will open to the notebook dashboard. The dashboard serves as a home page for the notebook. Its main purpose is to display the notebooks and files in the current directory. For example, here is a screenshot of the dashboard page for the `examples` directory in the Jupyter repository:\n",
     "\n",
-    "<img src=\"images/dashboard_files_tab.png\" width=\"791px\"/>"
+    "![Jupyter dashboard showing files tab](images/dashboard_files_tab.png)"
    ]
   },
   {
@@ -31,7 +31,7 @@
     "\n",
     "To create a new notebook, click on the \"New\" button at the top of the list and select a kernel from the dropdown (as seen below).  Which kernels are listed depend on what's installed on the server.  Some of the kernels in the screenshot below may not exist as an option to you.\n",
     "\n",
-    "<img src=\"images/dashboard_files_tab_new.png\" width=\"202px\" />"
+    "![Jupyter \"New\" menu](images/dashboard_files_tab_new.png)"
    ]
   },
   {
@@ -42,7 +42,8 @@
     "\n",
     "The notebook list shows green \"Running\" text and a green notebook icon next to running notebooks (as seen below). Notebooks remain running until you explicitly shut them down; closing the notebook's page is not sufficient.\n",
     "\n",
-    "<img src=\"images/dashboard_files_tab_run.png\" width=\"777px\"/>"
+    "\n",
+    "![Jupyter dashboard showing one notebook with a running kernel](images/dashboard_files_tab_run.png)"
    ]
   },
   {
@@ -51,7 +52,7 @@
    "source": [
     "To shutdown, delete, duplicate, or rename a notebook check the checkbox next to it and an array of controls will appear at the top of the notebook list (as seen below).  You can also use the same operations on directories and files when applicable.\n",
     "\n",
-    "<img src=\"images/dashboard_files_tab_btns.png\" width=\"301px\" />"
+    "![Buttons: Duplicate, rename, shutdown, delete, new, refresh](images/dashboard_files_tab_btns.png)"
    ]
   },
   {
@@ -60,7 +61,7 @@
    "source": [
     "To see all of your running notebooks along with their directories, click on the \"Running\" tab:\n",
     "\n",
-    "<img src=\"images/dashboard_running_tab.png\" width=\"786px\" />\n",
+    "![Jupyter dashboard running tab](images/dashboard_running_tab.png)\n",
     "\n",
     "This view provides a convenient way to track notebooks that you start as you navigate the file system in a long running notebook server."
    ]
@@ -112,7 +113,7 @@
    "source": [
     "Edit mode is indicated by a green cell border and a prompt showing in the editor area:\n",
     "\n",
-    "<img src=\"images/edit_mode.png\">\n",
+    "![Jupyter cell with green border](images/edit_mode.png)\n",
     "\n",
     "When a cell is in edit mode, you can type into the cell, like a normal text editor."
    ]
@@ -139,7 +140,7 @@
    "source": [
     "Command mode is indicated by a grey cell border with a blue left margin:\n",
     "\n",
-    "<img src=\"images/command_mode.png\">\n",
+    "![Jupyter cell with blue & grey border](images/command_mode.png)\n",
     "\n",
     "When you are in command mode, you are able to edit the notebook as a whole, but not type into individual cells. Most importantly, in command mode, the keyboard is mapped to a set of shortcuts that let you perform notebook and cell actions efficiently. For example, if you are in command mode and you press `c`, you will copy the current cell - no modifier is needed."
    ]
@@ -175,7 +176,7 @@
    "source": [
     "All navigation and actions in the Notebook are available using the mouse through the menubar and toolbar, which are both above the main Notebook area:\n",
     "\n",
-    "<img src=\"images/menubar_toolbar.png\" width=\"786px\" />"
+    "![Jupyter notebook menus and toolbar](images/menubar_toolbar.png)"
    ]
   },
   {
@@ -245,9 +246,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
This makes the high-res screenshots larger on a lower-res screen, but nbsphinx doesn't currently handle HTML `<img>` tags, so we need to use the Markdown format to show images in our docs.

Closes gh-2304