### PR TITLE
Remove drop shadow from Tag UI for consistency.

### DIFF
--- a/notebook/static/notebook/less/tagbar.less
+++ b/notebook/static/notebook/less/tagbar.less
@@ -45,6 +45,7 @@
     .form-control();
     .input-sm();
     // undo some of the sizing caused by the above mixins
+    box-shadow: none;
     width: inherit;
     font-size: inherit;
     height: 22px;


### PR DESCRIPTION
Likely a side-effect of using `.form-control()`