### PR TITLE
Add latex button to dropdown

### DIFF
--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -204,6 +204,10 @@ define([
         this.element.find('#download_pdf').click(function () {
             that._nbconvert('pdf', true);
         });
+        
+        this.element.find('#download_latex').click(function () {
+            that._nbconvert('latex', true);
+        });
 
         this.element.find('#download_script').click(function () {
             that._nbconvert('script', true);

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -109,6 +109,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
                                 <li id="download_html"><a href="#">HTML (.html)</a></li>
                                 <li id="download_markdown"><a href="#">Markdown (.md)</a></li>
                                 <li id="download_rst"><a href="#">reST (.rst)</a></li>
+                                <li id="download_latex"><a href="#">LaTeX (.tex)</a></li>
                                 <li id="download_pdf"><a href="#">PDF via LaTeX (.pdf)</a></li>
                             </ul>
                         </li>


### PR DESCRIPTION
In response to a question from https://github.com/jupyter/nbconvert/issues/552 about why we don't have a LaTeX dropdown button. 

Note: it doesn't return a zip file with the associated outputs, but neither does the markdown. Fixing that will need to be part of a larger project.