### PR TITLE
Use `_new_window` method for "Download as .ipynb"

### DIFF
--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -172,16 +172,15 @@ define([
         this.element.find('#download_ipynb').click(function () {
             var base_url = that.notebook.base_url;
             var notebook_path = utils.encode_uri_components(that.notebook.notebook_path);
-            var w = window.open('');
             var url = utils.url_path_join(
                 base_url, 'files', notebook_path
             ) + '?download=1';
             if (that.notebook.dirty && that.notebook.writable) {
                 that.notebook.save_notebook().then(function() {
-                    w.location = url;
+                    that._new_window(url);
                 });
             } else {
-                w.location = url;
+                that._new_window(url);
             }
         });
         


### PR DESCRIPTION
Closes https://github.com/jupyter/notebook/issues/2310

This makes the logic for all "Download as" methods the same and prevents a new tab from opening when "Download as .ipynb" is selected.