### PR TITLE
Fix typo setting write_config_dir in config manager

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1046,7 +1046,6 @@ class NotebookApp(JupyterApp):
         self.config_manager = self.config_manager_class(
             parent=self,
             log=self.log,
-            config_dir=os.path.join(self.config_dir, 'nbconfig'),
         )
 
     def init_logging(self):


### PR DESCRIPTION
There is no `config_dir` attribute so it is ignored, triggering a warning in traitlets. Typos like this will eventually become errors (as they should be).

closes #2316