### PR TITLE
add missing `@default` decorator on checkpoints_class

### DIFF
--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -142,6 +142,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
             raise TraitError("%r is not a directory" % value)
         return value
 
+    @default('checkpoints_class')
     def _checkpoints_class_default(self):
         return FileCheckpoints
 


### PR DESCRIPTION
This is not strictly required as default generators are no longer deprecated, but it's still a good idea.

closes #2315