### PR TITLE
include metadata when copying a cell

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1697,11 +1697,16 @@ define([
         if (cell.is_splittable()) {
             var texta = cell.get_pre_cursor();
             var textb = cell.get_post_cursor();
+            // current cell becomes the second one
+            // so we don't need to worry about selection
             cell.set_text(textb);
+            // create new cell with same type
             var new_cell = this.insert_cell_above(cell.cell_type);
             // Unrender the new cell so we can call set_text.
             new_cell.unrender();
             new_cell.set_text(texta);
+            // duplicate metadata
+            new_cell.metadata = JSON.parse(JSON.stringify(cell.metadata));
         }
     };
 


### PR DESCRIPTION
Following up on #2273, I came up with this proposal.

I was not able to test this though, because I do not know how to try out my modified code in a running jupyter

Also I chose to copy the original cell's metadata using json, because I believe a copy is required in this context, but there might be better ways to do that copy

This is my first pull request ever and I am not too comfy in javascript either.. 

closes #2273