### PR TITLE
Use `events.one` vs `events.on` inside of `CodeCell.execute`

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -335,11 +335,13 @@ define([
         this.render();
         this.events.trigger('execute.CodeCell', {cell: this});
         var that = this;
-        this.events.on('finished_iopub.Kernel', function (evt, data) {
+        function handleFinished(evt, data) {
             if (that.kernel.id === data.kernel.id && that.last_msg_id === data.msg_id) {
-		that.events.trigger('finished_execute.CodeCell', {cell: that});
-	    }
-        });
+            		that.events.trigger('finished_execute.CodeCell', {cell: that});
+                that.events.off('finished_iopub.Kernel', handleFinished);
+      	    }
+        }
+        this.events.on('finished_iopub.Kernel', handleFinished);
     };
     
     /**


### PR DESCRIPTION
Patches https://github.com/jupyter/notebook/pull/2061

Closes https://github.com/jupyter/notebook/issues/2352