### PR TITLE
Inlcude CONTRIBUTING.rst in the sdist, not CONTRIBUTING.md

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include COPYING.md
-include CONTRIBUTING.md
+include CONTRIBUTING.rst
 include README.md
 include package.json
 include bower.json


### PR DESCRIPTION
Fixup for ac89707eccc830622076558eeb25d05f4f66d08a

Currently, there is a doc error without CONTRIBUTING.rst:

    docs/source/contributing.rst:3: SEVERE: Problems with "include" directive path:
    InputError: [Errno 2] No such file or directory: 'CONTRIBUTING.rst'.

This change should fix it.