### PR TITLE
ensure a trailing slash on the base_url

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -759,7 +759,7 @@ class NotebookApp(JupyterApp):
         value = proposal['value']
         if not value.startswith('/'):
             value = '/' + value
-        elif not value.endswith('/'):
+        if not value.endswith('/'):
             value = value + '/'
         return value
     

--- a/notebook/static/terminal/js/main.js
+++ b/notebook/static/terminal/js/main.js
@@ -36,7 +36,7 @@ require([
         // 1.02 here arrived at by trial and error to make the spacing look right
     var termColWidth =  function() { return 1.02 * $("#dummy-screen-rows")[0].offsetWidth / 80;};
 
-    var base_url = utils.get_body_data('baseUrl');
+    var base_url = utils.get_body_data('baseUrl').replace(/\/?$/, '/');
     var ws_path = utils.get_body_data('wsPath');
     var ws_url = utils.get_body_data('wsUrl');
     if (!ws_url) {


### PR DESCRIPTION
For some reason the `/` wasn't coming on the terminals endpoint for v5, resulting in:

<img width="1415" alt="screen shot 2017-04-05 at 12 11 39 pm" src="https://cloud.githubusercontent.com/assets/836375/24810095/ed71c444-1b75-11e7-8adf-3e123e571322.png">

I went ahead and ensured a trailing slash on the baseURL. If there's a better way to do this or a more core issue (python side insurance that basepath ends with a slash), I'm all ears.