### PR TITLE
Fix search background style

### DIFF
--- a/notebook/static/edit/less/edit.less
+++ b/notebook/static/edit/less/edit.less
@@ -49,3 +49,7 @@
         }
     }
 }
+
+.CodeMirror-dialog {
+  background-color: @page-color;
+}


### PR DESCRIPTION
Closes https://github.com/jupyter/notebook/issues/2362

Before:

![image](https://cloud.githubusercontent.com/assets/9772542/24625045/c463e2d2-187b-11e7-84ab-cb2f2670a49b.png)

After:

![image](https://cloud.githubusercontent.com/assets/512354/24816748/cb3f9270-1b8e-11e7-8fab-878bf4633aa9.png)
