### PR TITLE
Trigger 'clear_output.CodeCell' before clearing output

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -313,7 +313,7 @@ define([
             stop_on_error = true;
         }
 
-        this.output_area.clear_output(false, true);
+        this.clear_output(false, true);
         var old_msg_id = this.last_msg_id;
         if (old_msg_id) {
             this.kernel.clear_callbacks_for_msg(old_msg_id);
@@ -509,10 +509,10 @@ define([
     };
 
 
-    CodeCell.prototype.clear_output = function (wait) {
-        this.output_area.clear_output(wait);
-        this.set_input_prompt();
+    CodeCell.prototype.clear_output = function (wait, ignore_que) {
         this.events.trigger('clear_output.CodeCell', {cell: this});
+        this.output_area.clear_output(wait, ignore_que);
+        this.set_input_prompt();
     };
 
 

--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -969,7 +969,6 @@ define([
 
             // Notify others of changes.
             this.element.trigger('changed');
-            this.element.trigger('cleared');
             
             this.outputs = [];
             this._display_id_targets = {};


### PR DESCRIPTION
Follow up from https://github.com/jupyter/notebook/pull/2297

This will trigger the `clear_output_CodeCell` event before clearing the output area, allowing extensions to clean up before clearing the output element. This also triggers the event on `CodeCell.execute`.