### PR TITLE
Specify `charset=UTF-8` when serving non-base64 files

### DIFF
--- a/notebook/files/handlers.py
+++ b/notebook/files/handlers.py
@@ -46,7 +46,9 @@ class FilesHandler(IPythonHandler):
             self.set_header('Content-Type', 'application/x-ipynb+json')
         else:
             cur_mime = mimetypes.guess_type(name)[0]
-            if cur_mime is not None:
+            if cur_mime == 'text/plain':
+                self.set_header('Content-Type', 'text/plain; charset=UTF-8')
+            elif cur_mime is not None:
                 self.set_header('Content-Type', cur_mime)
             else:
                 if model['format'] == 'base64':

--- a/notebook/files/handlers.py
+++ b/notebook/files/handlers.py
@@ -52,7 +52,7 @@ class FilesHandler(IPythonHandler):
                 if model['format'] == 'base64':
                     self.set_header('Content-Type', 'application/octet-stream')
                 else:
-                    self.set_header('Content-Type', 'text/plain')
+                    self.set_header('Content-Type', 'text/plain; charset=UTF-8')
 
         if include_body:
             if model['format'] == 'base64':

--- a/notebook/tests/test_files.py
+++ b/notebook/tests/test_files.py
@@ -95,7 +95,7 @@ class FilesTest(NotebookTestBase):
 
         r = self.request('GET', 'files/test.txt')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.headers['content-type'], 'text/plain')
+        self.assertEqual(r.headers['content-type'], 'text/plain; charset=UTF-8')
         self.assertEqual(r.text, 'foobar')
     
     def test_download(self):


### PR DESCRIPTION
Closes https://github.com/jupyter/notebook/issues/2397