### PR TITLE
Pass the output area object in events specific to the output area.

### DIFF
--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -348,7 +348,7 @@ define([
             this._needs_height_reset = false;
         }
 
-        this.element.trigger('resizeOutput');
+        this.element.trigger('resizeOutput', {output_area: this});
     };
 
     OutputArea.prototype.create_output_area = function () {
@@ -451,7 +451,7 @@ define([
         }
 
         // Notify others of changes.
-        this.element.trigger('changed');
+        this.element.trigger('changed', {output_area: this});
     };
 
 
@@ -965,11 +965,12 @@ define([
             // Remove load event handlers from img tags because we don't want
             // them to fire if the image is never added to the page.
             this.element.find('img').off('load');
+            this.element.trigger('clearing', {output_area: this});
             this.element.html("");
 
             // Notify others of changes.
-            this.element.trigger('changed');
-            this.element.trigger('cleared');
+            this.element.trigger('changed', {output_area: this});
+            this.element.trigger('cleared', {output_area: this});
             
             this.outputs = [];
             this._display_id_targets = {};


### PR DESCRIPTION
Also, add a new event triggered right before the output area is cleared. This is useful if an output renderer has cleanup work to do before the DOM element is removed off of the page.

@gnestor and I both want to add mimebundle renderers that should have a method called when the rendered value needs to be cleaned up.

Passing the output area in also makes it easy to listen for this event at the notebook level once and perform some action on whatever output area triggers the event.