### PR TITLE
[WIP] Download converted documents with uploadable configuration 

### DIFF
--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -250,5 +250,5 @@ default_handlers = [
     (r"/nbconvert/%s" % _format_regex, NbconvertPostHandler),
     (r"/nbconvert/%s%s" % (_format_regex, path_regex),
          NbconvertFileHandler),
-    (r"/nbconvert-service", NbconvertServiceHandler),
+    (r"/nbconvert", NbconvertServiceHandler),
 ]

--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -78,10 +78,11 @@ def get_exporter(format, **kwargs):
         raise web.HTTPError(500, "Could not construct Exporter: %s" % e)
 
 class NbconvertFileHandler(IPythonHandler):
+    SUPPORTED_METHODS = ('GET',)
 
     @web.authenticated
     def get(self, format, path):
-        exporter = get_exporter(format, log=self.log)
+        exporter = get_exporter(format, config=self.config, log=self.log)
         path = path.strip('/')
         # If the notebook relates to a real file (default contents manager),
         # give its path to nbconvert.
@@ -140,6 +141,7 @@ class NbconvertFileHandler(IPythonHandler):
 
 
 class NbconvertServiceHandler(IPythonHandler):
+    SUPPORTED_METHODS = ('POST',)
 
     @web.authenticated
     def post(self):

--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -45,23 +45,16 @@ def respond_zip(handler, name, output, resources):
     handler.set_header('Content-Type', 'application/zip')
 
     # create zip file
-    buffer = io.BytesIO()
-    with zipfile.ZipFile(buffer, mode='w', compression=zipfile.ZIP_STORED) as zipf:
+    buff = io.BytesIO()
+    with zipfile.ZipFile(buff, mode='w', compression=zipfile.ZIP_STORED) as zipf:
         output_filename = os.path.splitext(name)[0] + resources['output_extension']
         zipf.writestr(output_filename, cast_bytes(output, 'utf-8'))
         for filename, data in output_files.items():
             zipf.writestr(filename, data)
 
-    buffer.seek(0)
-    with open('buffer_write.zip', 'wb') as f:
-        f.write(buffer.read())
-    buffer.seek(0)
-
-    with open('buffer_write_2.zip', 'wb') as f:
-        f.write(buffer.read())
-    buffer.seek(0)
-
-    handler.finish(buffer.getvalue())
+    # pass zip file back
+    buff.seek(0)
+    handler.finish(buff.getvalue())
     return True
 
 def get_exporter(format, **kwargs):

--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -47,7 +47,7 @@ def respond_zip(handler, name, output, resources):
     
     # create zip file 
     buffer = io.BytesIO()
-    with zipfile.ZipFile(buffer, mode='w', compression=zipfile.ZIP_STORED) as zipf:
+    with zipfile.ZipFile(buffer, mode='w', compression=zipfile.ZIP_DEFLATED) as zipf:
         output_filename = os.path.splitext(name)[0] + resources['output_extension']
         zipf.writestr(output_filename, cast_bytes(output, 'utf-8'))
         # add external resources

--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -52,11 +52,6 @@ def respond_zip(handler, name, output, resources):
         for filename, data in output_files.items():
             zipf.writestr(filename, data)
 
-    #  with zipfile.ZipFile('./written_zip_test.zip',mode = 'w', compression=zipfile.ZIP_STORED) as zipf:
-        #  output_filename = os.path.splitext(name)[0] + resources['output_extension']
-        #  zipf.writestr(output_filename, cast_bytes(output, 'utf-8'))
-        #  for filename, data in output_files.items():
-            #  zipf.writestr(filename, data)
     buffer.seek(0)
     with open('buffer_write.zip', 'wb') as f:
         f.write(buffer.read())
@@ -65,25 +60,6 @@ def respond_zip(handler, name, output, resources):
     with open('buffer_write_2.zip', 'wb') as f:
         f.write(buffer.read())
     buffer.seek(0)
-
-    #  tar_filename = os.path.splitext(name)[0] + '.tar'
-    #  handler.set_header('Content-Disposition',
-                       #  'attachment; filename="%s"' % escape.url_escape(tar_filename))
-    #  handler.set_header('Content-Type', 'application/tar')
-#
-    #  output_filename = os.path.splitext(name)[0] + resources['output_extension']
-    #  with tarfile.open(fileobj=buffer, mode='w') as tarf:
-        #  main_file_data = cast_bytes(output, 'utf-8')
-        #  main_file_tarinfo = tarfile.TarInfo()
-        #  main_file_tarinfo.name = output_filename
-        #  main_file_tarinfo.size = len(main_file_data)
-        #  tarf.addfile(main_file_tarinfo, fileobj = io.BytesIO(main_file_data))
-        #  for filename, data in output_files.items():
-            #  extra_file = tarfile.TarInfo()
-            #  extra_file.name = filename
-            #  extra_file.size = len(data)
-            #  tarf.addfile(extra_file, fileobj = io.BytesIO(data))
-
 
     handler.finish(buffer.getvalue())
     return True

--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -140,7 +140,7 @@ class NbconvertFileHandler(IPythonHandler):
         self.finish(output)
 
 
-class NbconvertServiceHandler(IPythonHandler):
+class NbconvertConfigHandler(IPythonHandler):
     SUPPORTED_METHODS = ('POST',)
 
     @web.authenticated
@@ -254,7 +254,7 @@ _format_regex = r"(?P<format>\w+)"
 
 
 default_handlers = [
-    (r"/nbconvert", NbconvertServiceHandler),
+    (r"/nbconvert", NbconvertConfigHandler),
     (r"/nbconvert/%s" % _format_regex, NbconvertPostHandler),
     (r"/nbconvert/%s%s" % (_format_regex, path_regex),
          NbconvertFileHandler),

--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -99,7 +99,7 @@ def get_exporter(format, **kwargs):
 class NbconvertFileHandler(IPythonHandler):
 
     def call_nbconvert(self, format, path, config=None, content=None, post=False):
-        
+
 
         exporter = get_exporter(format, config=config, log=self.log)
         path = path.strip('/')
@@ -116,7 +116,7 @@ class NbconvertFileHandler(IPythonHandler):
         if model['type'] != 'notebook':
             # not a notebook, redirect to files
             return FilesRedirectHandler.redirect_to_files(self, path)
-        
+
         if content is None:
             nb = model['content']
         else:
@@ -162,13 +162,13 @@ class NbconvertFileHandler(IPythonHandler):
             self.set_header('Content-Type',
                             '%s; charset=utf-8' % exporter.output_mimetype)
 
-        self.finish(output) 
+        self.finish(output)
 
     @web.authenticated
     def get(self, format, path):
-        
+
         self.call_nbconvert(format, path, config=self.config)
-    
+
     @web.authenticated
     def post(self, format, path):
         c = Config(self.config)
@@ -178,7 +178,7 @@ class NbconvertFileHandler(IPythonHandler):
         nb_content = json.dumps(json_upload["notebook"])
         self.call_nbconvert(format, path, config=c, content=nb_content, post=True)
 
-       
+
 
 
 class NbconvertPostHandler(IPythonHandler):

--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -79,9 +79,13 @@ def get_exporter(format, **kwargs):
 
 class NbconvertFileHandler(IPythonHandler):
 
+<<<<<<< HEAD
     def call_nbconvert(self, format, path, config=None, content=None, post=False):
 
 
+=======
+    def call_nbconvert(self, format, path, config=None, content=None):
+>>>>>>> removing post argument from API
         exporter = get_exporter(format, config=config, log=self.log)
         path = path.strip('/')
         # If the notebook relates to a real file (default contents manager),
@@ -157,7 +161,7 @@ class NbconvertFileHandler(IPythonHandler):
         json_config = json.loads(json_upload.get("config",{}))
         c.merge(json_config)
         nb_content = json.dumps(json_upload["notebook"])
-        self.call_nbconvert(format, path, config=c, content=nb_content, post=True)
+        self.call_nbconvert(format, path, config=c, content=nb_content)
 
 
 class NbconvertPostHandler(IPythonHandler):

--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -7,7 +7,6 @@ import io
 import os
 import json
 import zipfile
-import tarfile
 
 from tornado import web, escape
 from tornado.log import app_log
@@ -40,39 +39,21 @@ def respond_zip(handler, name, output, resources):
     if not output_files:
         return False
     
-    buffer = io.BytesIO()
-
     # Headers
-    #  zip_filename = os.path.splitext(name)[0] + '.zip'
-    #  handler.set_header('Content-Disposition',
-                       #  'attachment; filename="%s"' % escape.url_escape(zip_filename))
-    #  handler.set_header('Content-Type', 'application/zip')
-    #  zipf = zipfile.ZipFile(buffer, mode='w', compression=zipfile.ZIP_STORED)
-    #  output_filename = os.path.splitext(name)[0] + resources['output_extension']
-    #  zipf.writestr(output_filename, cast_bytes(output, 'utf-8'))
-    #  for filename, data in output_files.items():
-        #  zipf.writestr(filename, data)
-    #  zipf.close()
-
-    tar_filename = os.path.splitext(name)[0] + '.tar'
+    zip_filename = os.path.splitext(name)[0] + '.zip'
     handler.set_header('Content-Disposition',
-                       'attachment; filename="%s"' % escape.url_escape(tar_filename))
-    handler.set_header('Content-Type', 'application/tar')
-
-    output_filename = os.path.splitext(name)[0] + resources['output_extension']
-    with tarfile.open(fileobj=buffer, mode='w') as tarf:
-        main_file_data = cast_bytes(output, 'utf-8')
-        main_file_tarinfo = tarfile.TarInfo()
-        main_file_tarinfo.name = output_filename
-        main_file_tarinfo.size = len(main_file_data)
-        tarf.addfile(main_file_tarinfo, fileobj = io.BytesIO(main_file_data))
+                       'attachment; filename="%s"' % escape.url_escape(zip_filename))
+    handler.set_header('Content-Type', 'application/zip')
+    
+    # create zip file 
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode='w', compression=zipfile.ZIP_STORED) as zipf:
+        output_filename = os.path.splitext(name)[0] + resources['output_extension']
+        zipf.writestr(output_filename, cast_bytes(output, 'utf-8'))
+        # add external resources
         for filename, data in output_files.items():
-            extra_file = tarfile.TarInfo()
-            extra_file.name = filename
-            extra_file.size = len(data)
-            tarf.addfile(extra_file, fileobj = io.BytesIO(data))
-
-
+            zipf.writestr(filename, data)
+    
     handler.finish(buffer.getvalue())
     return True
 
@@ -177,8 +158,6 @@ class NbconvertFileHandler(IPythonHandler):
         c.merge(json_config)
         nb_content = json.dumps(json_upload["notebook"])
         self.call_nbconvert(format, path, config=c, content=nb_content, post=True)
-
-
 
 
 class NbconvertPostHandler(IPythonHandler):

--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -77,9 +77,8 @@ def get_exporter(format, **kwargs):
 
 class NbconvertFileHandler(IPythonHandler):
 
-    def call_nbconvert(self, format, path, config=None, content=None):
+    def call_nbconvert(self, format, path, config=None, content=None, post=False):
         
-
 
         exporter = get_exporter(format, config=config, log=self.log)
         
@@ -156,7 +155,7 @@ class NbconvertFileHandler(IPythonHandler):
         json_upload = self.get_json_body()
         c.merge(json_upload["config"])
         nb_content = json_upload["notebook"]
-        self.call_nbconvert(format, path, config=c, content=nb_content)
+        self.call_nbconvert(format, path, config=c, content=nb_content, post=True)
 
        
 

--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -41,8 +41,7 @@ def respond_zip(handler, name, output, resources):
 
     # Headers
     zip_filename = os.path.splitext(name)[0] + '.zip'
-    handler.set_header('Content-Disposition',
-                       'attachment; filename="%s"' % escape.url_escape(zip_filename))
+    handler.set_attachment_header(zip_filename)
     handler.set_header('Content-Type', 'application/zip')
 
     # create zip file

--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -5,6 +5,7 @@
 
 import io
 import os
+import json
 import zipfile
 
 from tornado import web, escape
@@ -81,7 +82,7 @@ class NbconvertFileHandler(IPythonHandler):
         
 
         exporter = get_exporter(format, config=config, log=self.log)
-        
+        print(format)
         path = path.strip('/')
         # If the notebook relates to a real file (default contents manager),
         # give its path to nbconvert.
@@ -141,7 +142,7 @@ class NbconvertFileHandler(IPythonHandler):
             self.set_header('Content-Type',
                             '%s; charset=utf-8' % exporter.output_mimetype)
 
-        self.finish(output + model['name']) 
+        self.finish(output) 
 
     @web.authenticated
     def get(self, format, path):
@@ -153,8 +154,10 @@ class NbconvertFileHandler(IPythonHandler):
 
         c = Config(self.config)
         json_upload = self.get_json_body()
-        c.merge(json_upload["config"])
-        nb_content = json_upload["notebook"]
+        print("json_upload is {}".format(json_upload))
+        print("config is {}".format(json.loads(json_upload["config"])))
+        c.merge(json.loads(json_upload["config"]))
+        nb_content = json.dumps(json_upload["notebook"])
         self.call_nbconvert(format, path, config=c, content=nb_content, post=True)
 
        

--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -43,36 +43,34 @@ def respond_zip(handler, name, output, resources):
     buffer = io.BytesIO()
 
     # Headers
-    zip_filename = os.path.splitext(name)[0] + '.zip'
-    handler.set_attachment_header(zip_filename)
-    handler.set_header('Content-Type', 'application/zip')
-    zipf = zipfile.ZipFile(buffer, mode='w', compression=zipfile.ZIP_DEFLATED)
-    output_filename = os.path.splitext(name)[0] + resources['output_extension']
-    zipf.writestr(output_filename, cast_bytes(output, 'utf-8'))
-    for filename, data in output_files.items():
-        zipf.writestr(os.path.basename(filename), data)
-    zipf.close()
-
-    #  tar_filename = os.path.splitext(name)[0] + '.tar'
+    #  zip_filename = os.path.splitext(name)[0] + '.zip'
     #  handler.set_header('Content-Disposition',
-                       #  'attachment; filename="%s"' % escape.url_escape(tar_filename))
+                       #  'attachment; filename="%s"' % escape.url_escape(zip_filename))
     #  handler.set_header('Content-Type', 'application/zip')
-
-
-    # Prepare the zip file
+    #  zipf = zipfile.ZipFile(buffer, mode='w', compression=zipfile.ZIP_STORED)
     #  output_filename = os.path.splitext(name)[0] + resources['output_extension']
-    #  with tarfile.open(fileobj=buffer, mode='w') as tarf:
-        #  main_file_data = cast_bytes(output, 'utf-8')
-        #  main_file_tarinfo = tarfile.TarInfo()
-        #  main_file_tarinfo.name = output_filename
-        #  main_file_tarinfo.size = len(main_file_data)
-        #  tarf.addfile(main_file_tarinfo, fileobj = io.BytesIO(main_file_data))
-        #  for filename, data in output_files.items():
-            #  extra_file = tarfile.TarInfo()
-            #  extra_file.name = filename
-            #  extra_file.size = len(data)
-            #  extra_file.gettarinfo(arcname = os.path.basename(filename))
-            #  tarf.addfile(extra_file, fileobj = io.BytesIO(data))
+    #  zipf.writestr(output_filename, cast_bytes(output, 'utf-8'))
+    #  for filename, data in output_files.items():
+        #  zipf.writestr(filename, data)
+    #  zipf.close()
+
+    tar_filename = os.path.splitext(name)[0] + '.tar'
+    handler.set_header('Content-Disposition',
+                       'attachment; filename="%s"' % escape.url_escape(tar_filename))
+    handler.set_header('Content-Type', 'application/tar')
+
+    output_filename = os.path.splitext(name)[0] + resources['output_extension']
+    with tarfile.open(fileobj=buffer, mode='w') as tarf:
+        main_file_data = cast_bytes(output, 'utf-8')
+        main_file_tarinfo = tarfile.TarInfo()
+        main_file_tarinfo.name = output_filename
+        main_file_tarinfo.size = len(main_file_data)
+        tarf.addfile(main_file_tarinfo, fileobj = io.BytesIO(main_file_data))
+        for filename, data in output_files.items():
+            extra_file = tarfile.TarInfo()
+            extra_file.name = filename
+            extra_file.size = len(data)
+            tarf.addfile(extra_file, fileobj = io.BytesIO(data))
 
 
     handler.finish(buffer.getvalue())
@@ -135,7 +133,8 @@ class NbconvertFileHandler(IPythonHandler):
                 "name": nb_title,
                 "modified_date": mod_date
             },
-            "config_dir": self.application.settings['config_dir']
+            "config_dir": self.application.settings['config_dir'],
+            "output_files_dir": nb_title+"_files",
         }
 
         if ext_resources_dir:

--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -38,22 +38,22 @@ def respond_zip(handler, name, output, resources):
     output_files = resources.get('outputs', None)
     if not output_files:
         return False
-    
+
     # Headers
     zip_filename = os.path.splitext(name)[0] + '.zip'
     handler.set_header('Content-Disposition',
                        'attachment; filename="%s"' % escape.url_escape(zip_filename))
     handler.set_header('Content-Type', 'application/zip')
-    
-    # create zip file 
+
+    # create zip file
     buffer = io.BytesIO()
-    with zipfile.ZipFile(buffer, mode='w', compression=zipfile.ZIP_DEFLATED) as zipf:
+    with zipfile.ZipFile(buffer, mode='w', compression=zipfile.ZIP_STORED) as zipf:
         output_filename = os.path.splitext(name)[0] + resources['output_extension']
         zipf.writestr(output_filename, cast_bytes(output, 'utf-8'))
         # add external resources
         for filename, data in output_files.items():
             zipf.writestr(filename, data)
-    
+
     handler.finish(buffer.getvalue())
     return True
 

--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -50,9 +50,41 @@ def respond_zip(handler, name, output, resources):
     with zipfile.ZipFile(buffer, mode='w', compression=zipfile.ZIP_STORED) as zipf:
         output_filename = os.path.splitext(name)[0] + resources['output_extension']
         zipf.writestr(output_filename, cast_bytes(output, 'utf-8'))
-        # add external resources
         for filename, data in output_files.items():
             zipf.writestr(filename, data)
+
+    #  with zipfile.ZipFile('./written_zip_test.zip',mode = 'w', compression=zipfile.ZIP_STORED) as zipf:
+        #  output_filename = os.path.splitext(name)[0] + resources['output_extension']
+        #  zipf.writestr(output_filename, cast_bytes(output, 'utf-8'))
+        #  for filename, data in output_files.items():
+            #  zipf.writestr(filename, data)
+    buffer.seek(0)
+    with open('buffer_write.zip', 'wb') as f:
+        f.write(buffer.read())
+    buffer.seek(0)
+
+    with open('buffer_write_2.zip', 'wb') as f:
+        f.write(buffer.read())
+    buffer.seek(0)
+
+    #  tar_filename = os.path.splitext(name)[0] + '.tar'
+    #  handler.set_header('Content-Disposition',
+                       #  'attachment; filename="%s"' % escape.url_escape(tar_filename))
+    #  handler.set_header('Content-Type', 'application/tar')
+#
+    #  output_filename = os.path.splitext(name)[0] + resources['output_extension']
+    #  with tarfile.open(fileobj=buffer, mode='w') as tarf:
+        #  main_file_data = cast_bytes(output, 'utf-8')
+        #  main_file_tarinfo = tarfile.TarInfo()
+        #  main_file_tarinfo.name = output_filename
+        #  main_file_tarinfo.size = len(main_file_data)
+        #  tarf.addfile(main_file_tarinfo, fileobj = io.BytesIO(main_file_data))
+        #  for filename, data in output_files.items():
+            #  extra_file = tarfile.TarInfo()
+            #  extra_file.name = filename
+            #  extra_file.size = len(data)
+            #  tarf.addfile(extra_file, fileobj = io.BytesIO(data))
+
 
     handler.finish(buffer.getvalue())
     return True
@@ -79,13 +111,7 @@ def get_exporter(format, **kwargs):
 
 class NbconvertFileHandler(IPythonHandler):
 
-<<<<<<< HEAD
-    def call_nbconvert(self, format, path, config=None, content=None, post=False):
-
-
-=======
     def call_nbconvert(self, format, path, config=None, content=None):
->>>>>>> removing post argument from API
         exporter = get_exporter(format, config=config, log=self.log)
         path = path.strip('/')
         # If the notebook relates to a real file (default contents manager),

--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -1186,6 +1186,7 @@ define([
         char_idx_to_js_idx: char_idx_to_js_idx,
         _ansispan:_ansispan,
         change_favicon: change_favicon
+        _get_cookie:_get_cookie
     };
 
     return utils;

--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -1185,7 +1185,7 @@ define([
         js_idx_to_char_idx: js_idx_to_char_idx,
         char_idx_to_js_idx: char_idx_to_js_idx,
         _ansispan:_ansispan,
-        change_favicon: change_favicon
+        change_favicon: change_favicon,
         _get_cookie:_get_cookie
     };
 

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -194,30 +194,31 @@ define('notebook/js/menubar',[
       form.append(fileformat);
       form.append(fileinput);
       body.append(form);
-      
-      var that = this;
 
-      var trigger_nbconvert_post = function() {
+      var that = this;
+      that["format"] = fileformat.val()
+      // really would like to have fileformat accessible inside the filereader.onload but it seems to be out of scope
+
+      var trigger_nbconvert_post = () => {
         var filereader = new FileReader();
-        filereader.onload = function() {
+        filereader.onload = () => {
           var my_config_data = filereader.result;
-          that["json_content"] = create_json(that.notebook, my_config_data);
+          that["json_content"] = build_json_for_post(that.notebook, my_config_data, that.format);
           on_done();
         };
         if (fileinput[0].files.length > 0) {
           filereader.readAsText(fileinput[0].files[0]);
         } else {
-          that["json_content"] = create_json(that.notebook, "{}");
+          that["json_content"] = build_json_for_post(that.notebook, "{}", that.format);
           on_done();
         }
       };
-      var on_done = function() {
+
+      var on_done = () => {
         var url =
           utils.url_path_join(
             that.base_url,
-            "nbconvert",
-            fileformat.val(),
-            notebook_path
+            "nbconvert-service",
           ) +
           "?download=" +
           download.toString();

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -129,13 +129,14 @@ define('notebook/js/menubar',[
 
         this._new_window(url);
     };
-    
-    MenuBar.prototype._nbconvert_upload_conf = function (download) {
-      
-      var body =  $('<div>');
-      var notebook_path = utils.encode_uri_components(this.notebook.notebook_path);
 
-      var create_json = function(notebook, config){
+    MenuBar.prototype._nbconvert_upload_conf = function(download) {
+      var body = $("<div>");
+      var notebook_path = utils.encode_uri_components(
+        this.notebook.notebook_path
+      );
+
+      var create_json = function(notebook, config) {
         var json_to_pass = {
           notebook: notebook.toJSON(),
           config: config
@@ -143,163 +144,176 @@ define('notebook/js/menubar',[
         return json_to_pass;
       };
 
-      
-      var form  = $('<form>');
-      var fileinput = $('<input>')
-        .attr('type', 'file')
-        .attr('tabindex', '1');
+      var form = $("<form>");
+      var fileinput = $("<input>")
+        .attr("type", "file")
+        .attr("tabindex", "1");
 
-      var fileformat = $('<select>');
-      
+      var fileformat = $("<select>");
+
       var export_opts = {
         markdown: {
-          display_text:'markdown',
-          exporter_name:'markdown' 
-          },
+          display_text: "markdown",
+          exporter_name: "markdown"
+        },
         html: {
-          display_text:'html',
-          exporter_name:'html' 
-          },
+          display_text: "html",
+          exporter_name: "html"
+        },
         rst: {
-          display_text:'rst',
-          exporter_name:'rst' 
-          },
+          display_text: "rst",
+          exporter_name: "rst"
+        },
         pdf: {
-          display_text:'PDF',
-          exporter_name:'pdf' 
-          },
+          display_text: "PDF",
+          exporter_name: "pdf"
+        },
         latex: {
-          display_text:'LaTeX',
-          exporter_name:'latex' 
-          },
+          display_text: "LaTeX",
+          exporter_name: "latex"
+        },
         script: {
-          display_text:'script',
-          exporter_name:'script' 
-          }
+          display_text: "script",
+          exporter_name: "script"
+        }
       };
 
-      for(var x in export_opts){
+      for (var x in export_opts) {
         fileformat.append(
-          $('<option/>') 
-            .attr('value', export_opts[x]['exporter_name'])
-            .text(export_opts[x]['display_text'])
+          $("<option/>")
+            .attr("value", export_opts[x]["exporter_name"])
+            .text(export_opts[x]["display_text"])
         );
-      };
-      
+      }
+
       form.append(fileformat);
       form.append(fileinput);
       body.append(form);
       
       var that = this;
 
-      var trigger_nbconvert_post = function(){
+      var trigger_nbconvert_post = function() {
         var filereader = new FileReader();
-        filereader.onload = function(){
+        filereader.onload = function() {
           var my_config_data = filereader.result;
-          that['json_content'] = create_json(that.notebook, my_config_data);
+          that["json_content"] = create_json(that.notebook, my_config_data);
           on_done();
         };
-        if (fileinput[0].files.length>0){
+        if (fileinput[0].files.length > 0) {
           filereader.readAsText(fileinput[0].files[0]);
-        } else{
-          that['json_content']=create_json(that.notebook, '{}')
+        } else {
+          that["json_content"] = create_json(that.notebook, "{}");
           on_done();
         }
       };
-      var on_done = function(){
-          var url = utils.url_path_join(
-              that.base_url,
-              'nbconvert',
-              fileformat.val(),
-              notebook_path
-          ) + "?download=" + download.toString();
-          var create_new_dl_window = function(){
-            console.log("I ran successfully")
-            body.empty().append('<p>').text('conversion in progress')
-            // var win = window.open('',IPython._target);
-            // win.location=url;
-            that._new_window(url);
+      var on_done = function() {
+        var url =
+          utils.url_path_join(
+            that.base_url,
+            "nbconvert",
+            fileformat.val(),
+            notebook_path
+          ) +
+          "?download=" +
+          download.toString();
+        var create_new_dl_window = function() {
+          console.log("I ran successfully");
+          body
+            .empty()
+            .append("<p>")
+            .text("conversion in progress");
+          // var win = window.open('',IPython._target);
+          // win.location=url;
+          that._new_window(url);
 
-            return true;
-          };
-          var my_func = function(result){console.info("hi m and matthias!",typeof(result))}//, result)}
-          console.info("this is inside on done", that.json_content);
-
-          var xsrf_token = utils._get_cookie('_xsrf');
-          console.log(xsrf_token)
-          var xhr = new XMLHttpRequest();
-          xhr.open('POST', url, true);
-          xhr.responseType = 'blob';
-          xhr.withCredentials = true;
-          xhr.setRequestHeader('X-XSRFToken', xsrf_token);
-          // xhr.onload = function(e) {
-            // if (this.status == 200) {
-              // // get binary data as a response
-              // var blob = this.response;
-            // }
-          // };
-          xhr.onreadystatechange = function(){
-            if(xhr.readyState === 4){
-              var blob = xhr.response;
-              var content_disposition = xhr.getResponseHeader('Content-Disposition');
-              var filename = content_disposition.match(/filename="(.+)"/)[1];
-              saveData(blob, filename);
-            }
-          }
-          var data = JSON.stringify(that.json_content);
-          xhr.send(data);
-          // utils.ajax(url, {
-            // method: "POST",
-            // data: data,
-            // processData: false,
-            // responseType: "blob"
-            // //create_new_dl_window
-          // })
-          // .fail(function(){
-            // console.warn('something wrong');
-          // })
-          // .done(function(data,textstatus,jqXHR){
-            // var content_disposition = jqXHR.getResponseHeader('Content-Disposition');
-            // var filename = content_disposition.match(/filename="(.+)"/)[1];
-            // saveData(data,filename);
-          // });
-          //p.onReady(function(){
-          //  body.empty().append('<p>').text('conversion in progress')
-          //});
-          // $.post(url, json_content, create_new_dl_window,"json"); 
-          // get the data from FileReader and make it json. 
-          return true // close the dialog
-          // return false to keep it open.
+          return true;
         };
-        var saveData = (function () {
-            var a = document.createElement("a");
-            document.body.appendChild(a);
-            a.style = "display: none";
-            return function (data, fileName) {
-                var blob = new Blob([data], {type: "octet/stream"}),//this works for tar
-                    url = window.URL.createObjectURL(blob);
-                a.href = url;
-                a.download = fileName;
-                a.click();
-                window.URL.revokeObjectURL(url);
-            };
-        }());
+        var my_func = function(result) {
+          console.info("hi m and matthias!", typeof result);
+        }; //, result)}
+        console.info("this is inside on done", that.json_content);
+
+        var xsrf_token = utils._get_cookie("_xsrf");
+        console.log(xsrf_token);
+        var xhr = new XMLHttpRequest();
+        xhr.open("POST", url, true);
+        xhr.responseType = "blob";
+        xhr.withCredentials = true;
+        xhr.setRequestHeader("X-XSRFToken", xsrf_token);
+        console.log(xhr);
+        // xhr.onload = function(e) {
+        // if (this.status == 200) {
+        // // get binary data as a response
+        // var blob = this.response;
+        // }
+        // };
+        xhr.onreadystatechange = function() {
+          if (xhr.readyState === 4) {
+            var blob = xhr.response;
+            var content_disposition = xhr.getResponseHeader(
+              "Content-Disposition"
+            );
+            var filename = content_disposition.match(/filename\*=utf-8''(.+)/)[1];
+            saveData(blob, filename);
+          }
+        };
+        var data = JSON.stringify(that.json_content);
+        xhr.send(data);
+        // utils.ajax(url, {
+        // method: "POST",
+        // data: data,
+        // processData: false,
+        // responseType: "blob"
+        // //create_new_dl_window
+        // })
+        // .fail(function(){
+        // console.warn('something wrong');
+        // })
+        // .done(function(data,textstatus,jqXHR){
+        // var content_disposition = jqXHR.getResponseHeader('Content-Disposition');
+        // var filename = content_disposition.match(/filename="(.+)"/)[1];
+        // saveData(data,filename);
+        // });
+        //p.onReady(function(){
+        //  body.empty().append('<p>').text('conversion in progress')
+        //});
+        // $.post(url, json_content, create_new_dl_window,"json");
+        // get the data from FileReader and make it json.
+        return true; // close the dialog
+        // return false to keep it open.
+      };
+      var saveData = (function() {
+        var a = document.createElement("a");
+        document.body.appendChild(a);
+        a.style = "display: none";
+        return function(data, fileName) {
+          var blob = new Blob([data], { type: "octet/stream" }), //this works for tar
+            url = window.URL.createObjectURL(blob);
+          a.href = url;
+          a.download = fileName;
+          a.click();
+          window.URL.revokeObjectURL(url);
+        };
+      })();
 
       var mod = dialog.modal({
         notebook: this.notebook,
-        title : "Upload nbconvert config",
-        open : function(){fileinput.focus();},
-        body : body,
-        buttons : {
-          cancel : {
-            click: function(){return true;}
+        title: "Upload nbconvert config",
+        open: function() {
+          fileinput.focus();
+        },
+        body: body,
+        buttons: {
+          cancel: {
+            click: function() {
+              return true;
+            }
           },
-          download : {click: trigger_nbconvert_post}
+          download: { click: trigger_nbconvert_post }
         }
       });
 
-      mod.modal('show');
-      
+      mod.modal("show");
     };
 
 

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -196,20 +196,21 @@ define('notebook/js/menubar',[
       body.append(form);
 
       var that = this;
-      that["format"] = fileformat.val()
-      // really would like to have fileformat accessible inside the filereader.onload but it seems to be out of scope
+      var get_export_format = function() {
+        return fileformat.val();
+      }
 
       var trigger_nbconvert_post = function() {
         var filereader = new FileReader();
         filereader.onload = function() {
           var my_config_data = filereader.result;
-          that["json_content"] = build_json_for_post(that.notebook, my_config_data, that.format);
+          that["json_content"] = build_json_for_post(that.notebook, my_config_data, get_export_format());
           on_done();
         };
         if (fileinput[0].files.length > 0) {
           filereader.readAsText(fileinput[0].files[0]);
         } else {
-          that["json_content"] = build_json_for_post(that.notebook, "{}", that.format);
+          that["json_content"] = build_json_for_post(that.notebook, "{}", get_export_format());
           on_done();
         }
       };

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -158,15 +158,15 @@ define('notebook/js/menubar',[
 
       var export_opts = {
         markdown: {
-          display_text: "markdown",
+          display_text: "Markdown",
           exporter_name: "markdown"
         },
         html: {
-          display_text: "html",
+          display_text: "HTML",
           exporter_name: "html"
         },
         rst: {
-          display_text: "rst",
+          display_text: "reST",
           exporter_name: "rst"
         },
         pdf: {
@@ -180,6 +180,10 @@ define('notebook/js/menubar',[
         script: {
           display_text: "script",
           exporter_name: "script"
+        },
+        slides: {
+          display_text: "Reveal.js slides",
+          exporter_name: "slides"
         }
       };
 

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -143,7 +143,7 @@ define('notebook/js/menubar',[
             name: notebook.notebook_name,
             last_modified: notebook.last_modified
         },
-          output_format: format,
+          export_format: format,
           config: config
         };
         return json_to_pass;

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -136,10 +136,15 @@ define('notebook/js/menubar',[
         this.notebook.notebook_path
       );
 
-      var create_json = function(notebook, config) {
-        var json_to_pass = {
-          notebook: notebook.toJSON(),
-          config: config
+      const build_json_for_post = function(notebook, config, format) {
+        const json_to_pass = {
+          notebook_contents: {
+            content: notebook.toJSON(),
+            name: notebook.notebook_name,
+            last_modified: notebook.last_modified,
+        },
+          output_format: format,
+          config: config,
         };
         return json_to_pass;
       };

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -192,7 +192,7 @@ define('notebook/js/menubar',[
       
       var that = this;
 
-      var handle_nbconvert_post = function(){
+      var trigger_nbconvert_post = function(){
         var filereader = new FileReader();
         filereader.onload = function(){
           var my_config_data = filereader.result;
@@ -257,7 +257,7 @@ define('notebook/js/menubar',[
           cancel : {
             click: function(){return true;}
           },
-          download : {click: handle_nbconvert_post}
+          download : {click: trigger_nbconvert_post}
         }
       });
 

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -199,9 +199,9 @@ define('notebook/js/menubar',[
       that["format"] = fileformat.val()
       // really would like to have fileformat accessible inside the filereader.onload but it seems to be out of scope
 
-      var trigger_nbconvert_post = () => {
+      var trigger_nbconvert_post = function() {
         var filereader = new FileReader();
-        filereader.onload = () => {
+        filereader.onload = function() {
           var my_config_data = filereader.result;
           that["json_content"] = build_json_for_post(that.notebook, my_config_data, that.format);
           on_done();
@@ -214,7 +214,7 @@ define('notebook/js/menubar',[
         }
       };
 
-      var on_done = () => {
+      var on_done = function() {
         var url =
           utils.url_path_join(
             that.base_url,
@@ -253,12 +253,12 @@ define('notebook/js/menubar',[
         return true; // close the dialog
         // return false to keep it open.
       };
-      var saveData = (() => {
+      var saveData = (function() {
         var a = document.createElement("a");
         document.body.appendChild(a);
         a.style = "display: none";
         return (
-          (data, fileName) => {
+          function(data, fileName) {
             var blob = new Blob([data], { type: "octet/stream" }),
               url = window.URL.createObjectURL(blob);
             a.href = url;

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -184,15 +184,12 @@ define('notebook/js/menubar',[
             .attr('value', export_opts[x]['exporter_name'])
             .text(export_opts[x]['display_text'])
         );
-        debugger;
       };
       
       form.append(fileformat);
       form.append(fileinput);
       body.append(form);
       
-      var notebook_path = utils.encode_uri_components(this.notebook.notebook_path);
-
       var that = this;
 
       var handle_nbconvert_post = function(){
@@ -204,8 +201,7 @@ define('notebook/js/menubar',[
         };
         if (fileinput[0].files.length>0){
           filereader.readAsText(fileinput[0].files[0]);
-        }
-        else{
+        } else{
           that['json_content']=create_json(that.notebook, '{}')
           on_done();
         }
@@ -248,6 +244,7 @@ define('notebook/js/menubar',[
           a.download = fileName;
           a.click();
           window.URL.revokeObjectURL(url);
+          a.remove();
         };
       }());
 

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -227,42 +227,44 @@ define('notebook/js/menubar',[
           var my_func = function(result){console.info("hi m and matthias!",typeof(result))}//, result)}
           console.info("this is inside on done", that.json_content);
 
-          // var xhr = new XMLHttpRequest();
-          // xhr.open('POST', '/my/image/name.png', true);
-          // xhr.responseType = 'blob';
-//
+          var xsrf_token = utils._get_cookie('_xsrf');
+          console.log(xsrf_token)
+          var xhr = new XMLHttpRequest();
+          xhr.open('POST', url, true);
+          xhr.responseType = 'blob';
+          xhr.withCredentials = true;
+          xhr.setRequestHeader('X-XSRFToken', xsrf_token);
           // xhr.onload = function(e) {
             // if (this.status == 200) {
               // // get binary data as a response
               // var blob = this.response;
             // }
           // };
+          xhr.onreadystatechange = function(){
+            if(xhr.readyState === 4){
+              var blob = xhr.response;
+              var content_disposition = xhr.getResponseHeader('Content-Disposition');
+              var filename = content_disposition.match(/filename="(.+)"/)[1];
+              saveData(blob, filename);
+            }
+          }
           var data = JSON.stringify(that.json_content);
-          console.log(data) 
-          // xhr.send();
-          utils.ajax(url, {
-            method: "POST",
-            data: data,
-            processData: false,
-            responseType: "blob"
-            //create_new_dl_window
-          })
-          .fail(function(){
-            console.warn('something wrong');
-          })
-          .done(function(data,textstatus,jqXHR){
-            var content_disposition = jqXHR.getResponseHeader('Content-Disposition');
-            var filename = content_disposition.match(/filename="(.+)"/)[1];
-            saveData(data,filename);
-            // var hidden_anchor = $("<a/>");
-            // hidden_anchor.attr('href','data:text/plain;charset=utf-8,' + window.URL.createObjectURL(data))
-              // .attr('download', filename);
-            // hidden_anchor.hide();
-            // console.log(hidden_anchor);
-            // $(document.body).append(hidden_anchor);
-            // hidden_anchor.click();
-            // hidden_anchor.remove();
-          });
+          xhr.send(data);
+          // utils.ajax(url, {
+            // method: "POST",
+            // data: data,
+            // processData: false,
+            // responseType: "blob"
+            // //create_new_dl_window
+          // })
+          // .fail(function(){
+            // console.warn('something wrong');
+          // })
+          // .done(function(data,textstatus,jqXHR){
+            // var content_disposition = jqXHR.getResponseHeader('Content-Disposition');
+            // var filename = content_disposition.match(/filename="(.+)"/)[1];
+            // saveData(data,filename);
+          // });
           //p.onReady(function(){
           //  body.empty().append('<p>').text('conversion in progress')
           //});
@@ -276,8 +278,7 @@ define('notebook/js/menubar',[
             document.body.appendChild(a);
             a.style = "display: none";
             return function (data, fileName) {
-                // var json = JSON.stringify(data),
-                var blob = new Blob([data], {type: "octet/stream"}),
+                var blob = new Blob([data], {type: "octet/stream"}),//this works for tar
                     url = window.URL.createObjectURL(blob);
                 a.href = url;
                 a.download = fileName;

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -190,11 +190,6 @@ define('notebook/js/menubar',[
           var my_config_data = filereader.result;
           console.info("this is my config data: ", my_config_data);
           that['json_content'] = create_json(that.notebook, my_config_data);
-            // var that.json_content = create_json(that.notebook, my_config_data);
-            // var submit_form = $('<form>')
-              // .attr('action',url)
-              // .attr('method','post')
-              // .attr('target','_blank');
           on_done();
         };
         if (fileinput[0].files.length>0){
@@ -202,100 +197,53 @@ define('notebook/js/menubar',[
         }
         else{
           that['json_content']=create_json(that.notebook, '{}')
-          console.log("calling on_done from else with empty config");
-          debugger;
           on_done();
         }
-        // there
       };
       var on_done = function(){
-          var url = utils.url_path_join(
-              that.base_url,
-              'nbconvert',
-              fileformat.val(),
-              notebook_path
-          ) + "?download=" + download.toString();
-          var create_new_dl_window = function(){
-            console.log("I ran successfully")
-            body.empty().append('<p>').text('conversion in progress')
-            // var win = window.open('',IPython._target);
-            // win.location=url;
-            that._new_window(url);
+        var url = utils.url_path_join(
+            that.base_url,
+            'nbconvert',
+            fileformat.val(),
+            notebook_path
+        ) + "?download=" + download.toString();
+          
+        var my_func = function(result){console.info("hi m and matthias!",typeof(result))};
+        console.info("this is inside on done", that.json_content);
 
-            return true;
-          };
-          var my_func = function(result){console.info("hi m and matthias!",typeof(result))}//, result)}
-          console.info("this is inside on done", that.json_content);
-
-          var xsrf_token = utils._get_cookie('_xsrf');
-          console.log(xsrf_token)
-          var xhr = new XMLHttpRequest();
-          xhr.open('POST', url, true);
-          xhr.responseType = 'blob';
-          xhr.withCredentials = true;
-          xhr.setRequestHeader('X-XSRFToken', xsrf_token);
-          // xhr.onload = function(e) {
-            // if (this.status == 200) {
-              // // get binary data as a response
-              // var blob = this.response;
-            // }
-          // };
-          xhr.onreadystatechange = function(){
-            if(xhr.readyState === 4){
-              var blob = xhr.response;
-              var content_disposition = xhr.getResponseHeader('Content-Disposition');
-              var filename = content_disposition.match(/filename="(.+)"/)[1];
-              saveData(blob, filename);
-            }
+        var xsrf_token = utils._get_cookie('_xsrf');
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', url, true);
+        xhr.responseType = 'blob';
+        xhr.withCredentials = true;
+        xhr.setRequestHeader('X-XSRFToken', xsrf_token);
+        xhr.onreadystatechange = function(){
+          if(xhr.readyState === 4){
+            var blob = xhr.response;
+            var content_disposition = xhr.getResponseHeader('Content-Disposition');
+            var filename = content_disposition.match(/filename="(.+)"/)[1];
+            saveData(blob, filename);
           }
-          var data = JSON.stringify(that.json_content);
-          xhr.send(data);
-          // utils.ajax(url, {
-            // method: "POST",
-            // data: data,
-            // processData: false,
-            // responseType: "blob"
-            // //create_new_dl_window
-          // })
-          // .fail(function(){
-            // console.warn('something wrong');
-          // })
-          // .done(function(data,textstatus,jqXHR){
-            // var content_disposition = jqXHR.getResponseHeader('Content-Disposition');
-            // var filename = content_disposition.match(/filename="(.+)"/)[1];
-            // saveData(data,filename);
-          // });
-          //p.onReady(function(){
-          //  body.empty().append('<p>').text('conversion in progress')
-          //});
-          // $.post(url, json_content, create_new_dl_window,"json"); 
-          // get the data from FileReader and make it json. 
-          return true // close the dialog
-          // return false to keep it open.
+        }
+        var data = JSON.stringify(that.json_content);
+        xhr.send(data);
+        return true // close the dialog
+        // return false to keep it open.
+      };
+      var saveData = (function () {
+        var a = document.createElement("a");
+        document.body.appendChild(a);
+        a.style = "display: none";
+        return function (data, fileName) {
+          var blob = new Blob([data], {type: "octet/stream"}),
+              url = window.URL.createObjectURL(blob);
+          a.href = url;
+          a.download = fileName;
+          a.click();
+          window.URL.revokeObjectURL(url);
         };
-        var saveData = (function () {
-            var a = document.createElement("a");
-            document.body.appendChild(a);
-            a.style = "display: none";
-            return function (data, fileName) {
-                var blob = new Blob([data], {type: "octet/stream"}),//this works for tar
-                    url = window.URL.createObjectURL(blob);
-                a.href = url;
-                a.download = fileName;
-                a.click();
-                window.URL.revokeObjectURL(url);
-            };
-        }());
+      }());
 
-      // var data = { x: 42, s: "hello, world", d: new Date() },
-          // fileName = "my-download.json";
-
-      // 1. look at using a form of some kind, browser navigation to do a post request, target new page
-      // open new page straight into the results of post request, form has target url
-      // 2. don't serve content as response, given token back which the front end can make a get request
-      // have it in a dictionary with content that are values of dictionary
-      // 3. see if browsers open a new window with a dataurl, open it from content that js has in memory
-      // 3b. having some other way to initiate a download or a new tab from content js has in memory
       var mod = dialog.modal({
         notebook: this.notebook,
         title : "Upload nbconvert config",
@@ -305,10 +253,8 @@ define('notebook/js/menubar',[
           cancel : {
             click: function(){return true;}
           },
-          my_end_dialog : {
-                     click: handle_nbconvert_post
-                  }
-          }
+          my_end_dialog : {click: handle_nbconvert_post}
+        }
       });
 
       mod.modal('show');

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -151,38 +151,40 @@ define('notebook/js/menubar',[
 
       var fileformat = $('<select>');
       
-      var exporter_options = {
+      var export_opts = {
         markdown: {
-          display_text:'markdown'
+          display_text:'markdown',
           exporter_name:'markdown' 
           },
-        markdown: {
-          display_text:'html'
+        html: {
+          display_text:'html',
           exporter_name:'html' 
           },
-        markdown: {
-          display_text:'rst'
+        rst: {
+          display_text:'rst',
           exporter_name:'rst' 
           },
-        markdown: {
-          display_text:'PDF'
+        pdf: {
+          display_text:'PDF',
           exporter_name:'pdf' 
           },
-        markdown: {
-          display_text:'LaTeX'
+        latex: {
+          display_text:'LaTeX',
           exporter_name:'latex' 
           },
-        markdown: {
-          display_text:'script'
+        script: {
+          display_text:'script',
           exporter_name:'script' 
           }
       };
-      for(option in exporter_options){
+
+      for(var x in export_opts){
         fileformat.append(
           $('<option/>') 
-            .attr('value',option.exporter_name)
-            .text(option.display_text)
+            .attr('value', export_opts[x]['exporter_name'])
+            .text(export_opts[x]['display_text'])
         );
+        debugger;
       };
       
       form.append(fileformat);

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -217,36 +217,21 @@ define('notebook/js/menubar',[
           "?download=" +
           download.toString();
         var create_new_dl_window = function() {
-          console.log("I ran successfully");
           body
             .empty()
             .append("<p>")
             .text("conversion in progress");
-          // var win = window.open('',IPython._target);
-          // win.location=url;
           that._new_window(url);
 
           return true;
         };
-        var my_func = function(result) {
-          console.info("hi m and matthias!", typeof result);
-        }; //, result)}
-        console.info("this is inside on done", that.json_content);
 
         var xsrf_token = utils._get_cookie("_xsrf");
-        console.log(xsrf_token);
         var xhr = new XMLHttpRequest();
         xhr.open("POST", url, true);
         xhr.responseType = "blob";
         xhr.withCredentials = true;
         xhr.setRequestHeader("X-XSRFToken", xsrf_token);
-        console.log(xhr);
-        // xhr.onload = function(e) {
-        // if (this.status == 200) {
-        // // get binary data as a response
-        // var blob = this.response;
-        // }
-        // };
         xhr.onreadystatechange = function() {
           if (xhr.readyState === 4) {
             var blob = xhr.response;
@@ -259,26 +244,6 @@ define('notebook/js/menubar',[
         };
         var data = JSON.stringify(that.json_content);
         xhr.send(data);
-        // utils.ajax(url, {
-        // method: "POST",
-        // data: data,
-        // processData: false,
-        // responseType: "blob"
-        // //create_new_dl_window
-        // })
-        // .fail(function(){
-        // console.warn('something wrong');
-        // })
-        // .done(function(data,textstatus,jqXHR){
-        // var content_disposition = jqXHR.getResponseHeader('Content-Disposition');
-        // var filename = content_disposition.match(/filename="(.+)"/)[1];
-        // saveData(data,filename);
-        // });
-        //p.onReady(function(){
-        //  body.empty().append('<p>').text('conversion in progress')
-        //});
-        // $.post(url, json_content, create_new_dl_window,"json");
-        // get the data from FileReader and make it json.
         return true; // close the dialog
         // return false to keep it open.
       };

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -185,10 +185,8 @@ define('notebook/js/menubar',[
 
       var handle_nbconvert_post = function(){
         var filereader = new FileReader();
-        console.info("this is being hit ");
         filereader.onload = function(){
           var my_config_data = filereader.result;
-          console.info("this is my config data: ", my_config_data);
           that['json_content'] = create_json(that.notebook, my_config_data);
           on_done();
         };
@@ -208,9 +206,6 @@ define('notebook/js/menubar',[
             notebook_path
         ) + "?download=" + download.toString();
           
-        var my_func = function(result){console.info("hi m and matthias!",typeof(result))};
-        console.info("this is inside on done", that.json_content);
-
         var xsrf_token = utils._get_cookie('_xsrf');
         var xhr = new XMLHttpRequest();
         xhr.open('POST', url, true);
@@ -253,7 +248,7 @@ define('notebook/js/menubar',[
           cancel : {
             click: function(){return true;}
           },
-          my_end_dialog : {click: handle_nbconvert_post}
+          download : {click: handle_nbconvert_post}
         }
       });
 

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -253,18 +253,21 @@ define('notebook/js/menubar',[
         return true; // close the dialog
         // return false to keep it open.
       };
-      var saveData = (function() {
+      var saveData = (() => {
         var a = document.createElement("a");
         document.body.appendChild(a);
         a.style = "display: none";
-        return function(data, fileName) {
-          var blob = new Blob([data], { type: "octet/stream" }), //this works for tar
-            url = window.URL.createObjectURL(blob);
-          a.href = url;
-          a.download = fileName;
-          a.click();
-          window.URL.revokeObjectURL(url);
-        };
+        return (
+          (data, fileName) => {
+            var blob = new Blob([data], { type: "octet/stream" }),
+              url = window.URL.createObjectURL(blob);
+            a.href = url;
+            a.download = fileName;
+            a.click();
+            window.URL.revokeObjectURL(url);
+            document.body.removeChild(a);
+          }
+        )
       })();
 
       var mod = dialog.modal({

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -148,32 +148,42 @@ define('notebook/js/menubar',[
       var fileinput = $('<input>')
         .attr('type', 'file')
         .attr('tabindex', '1');
+
       var fileformat = $('<select>');
-      fileformat.append(
-        $('<option>markdown</option>')
-          .attr('value','markdown')
-      );
-      fileformat.append(
-        $('<option/>')
-          .attr('value','html')
-          .text('html')
-      );
-      fileformat.append(
-        $('<option>rst</option>')
-          .attr('value','rst')
-      );
-      fileformat.append(
-        $('<option>pdf</option>')
-          .attr('value','pdf')
-      );
-      fileformat.append(
-        $('<option>latex</option>')
-          .attr('value','latex')
-      );
-      fileformat.append(
-        $('<option>script</option>')
-          .attr('value','script')
-      );
+      
+      var exporter_options = {
+        markdown: {
+          display_text:'markdown'
+          exporter_name:'markdown' 
+          },
+        markdown: {
+          display_text:'html'
+          exporter_name:'html' 
+          },
+        markdown: {
+          display_text:'rst'
+          exporter_name:'rst' 
+          },
+        markdown: {
+          display_text:'PDF'
+          exporter_name:'pdf' 
+          },
+        markdown: {
+          display_text:'LaTeX'
+          exporter_name:'latex' 
+          },
+        markdown: {
+          display_text:'script'
+          exporter_name:'script' 
+          }
+      };
+      for(option in exporter_options){
+        fileformat.append(
+          $('<option/>') 
+            .attr('value',option.exporter_name)
+            .text(option.display_text)
+        );
+      };
       
       form.append(fileformat);
       form.append(fileinput);

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -207,46 +207,83 @@ define('notebook/js/menubar',[
         }
       };
       var on_done = function(){
-        var url = utils.url_path_join(
-            that.base_url,
-            'nbconvert',
-            fileformat.val(),
-            notebook_path
-        ) + "?download=" + download.toString();
-          
-        var xsrf_token = utils._get_cookie('_xsrf');
-        var xhr = new XMLHttpRequest();
-        xhr.open('POST', url, true);
-        xhr.responseType = 'blob';
-        xhr.withCredentials = true;
-        xhr.setRequestHeader('X-XSRFToken', xsrf_token);
-        xhr.onreadystatechange = function(){
-          if(xhr.readyState === 4){
-            var blob = xhr.response;
-            var content_disposition = xhr.getResponseHeader('Content-Disposition');
-            var filename = content_disposition.match(/filename="(.+)"/)[1];
-            saveData(blob, filename);
+          var url = utils.url_path_join(
+              that.base_url,
+              'nbconvert',
+              fileformat.val(),
+              notebook_path
+          ) + "?download=" + download.toString();
+          var create_new_dl_window = function(){
+            console.log("I ran successfully")
+            body.empty().append('<p>').text('conversion in progress')
+            // var win = window.open('',IPython._target);
+            // win.location=url;
+            that._new_window(url);
+
+            return true;
+          };
+          var my_func = function(result){console.info("hi m and matthias!",typeof(result))}//, result)}
+          console.info("this is inside on done", that.json_content);
+
+          var xsrf_token = utils._get_cookie('_xsrf');
+          console.log(xsrf_token)
+          var xhr = new XMLHttpRequest();
+          xhr.open('POST', url, true);
+          xhr.responseType = 'blob';
+          xhr.withCredentials = true;
+          xhr.setRequestHeader('X-XSRFToken', xsrf_token);
+          // xhr.onload = function(e) {
+            // if (this.status == 200) {
+              // // get binary data as a response
+              // var blob = this.response;
+            // }
+          // };
+          xhr.onreadystatechange = function(){
+            if(xhr.readyState === 4){
+              var blob = xhr.response;
+              var content_disposition = xhr.getResponseHeader('Content-Disposition');
+              var filename = content_disposition.match(/filename="(.+)"/)[1];
+              saveData(blob, filename);
+            }
           }
-        }
-        var data = JSON.stringify(that.json_content);
-        xhr.send(data);
-        return true // close the dialog
-        // return false to keep it open.
-      };
-      var saveData = (function () {
-        var a = document.createElement("a");
-        document.body.appendChild(a);
-        a.style = "display: none";
-        return function (data, fileName) {
-          var blob = new Blob([data], {type: "octet/stream"}),
-              url = window.URL.createObjectURL(blob);
-          a.href = url;
-          a.download = fileName;
-          a.click();
-          window.URL.revokeObjectURL(url);
-          a.remove();
+          var data = JSON.stringify(that.json_content);
+          xhr.send(data);
+          // utils.ajax(url, {
+            // method: "POST",
+            // data: data,
+            // processData: false,
+            // responseType: "blob"
+            // //create_new_dl_window
+          // })
+          // .fail(function(){
+            // console.warn('something wrong');
+          // })
+          // .done(function(data,textstatus,jqXHR){
+            // var content_disposition = jqXHR.getResponseHeader('Content-Disposition');
+            // var filename = content_disposition.match(/filename="(.+)"/)[1];
+            // saveData(data,filename);
+          // });
+          //p.onReady(function(){
+          //  body.empty().append('<p>').text('conversion in progress')
+          //});
+          // $.post(url, json_content, create_new_dl_window,"json"); 
+          // get the data from FileReader and make it json. 
+          return true // close the dialog
+          // return false to keep it open.
         };
-      }());
+        var saveData = (function () {
+            var a = document.createElement("a");
+            document.body.appendChild(a);
+            a.style = "display: none";
+            return function (data, fileName) {
+                var blob = new Blob([data], {type: "octet/stream"}),//this works for tar
+                    url = window.URL.createObjectURL(blob);
+                a.href = url;
+                a.download = fileName;
+                a.click();
+                window.URL.revokeObjectURL(url);
+            };
+        }());
 
       var mod = dialog.modal({
         notebook: this.notebook,

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -71,7 +71,7 @@ define('notebook/js/menubar',[
             }
         );
     };
-    
+
     MenuBar.prototype.add_bundler_items = function() {
         var that = this;
         this.config.loaded.then(function() {
@@ -82,7 +82,7 @@ define('notebook/js/menubar',[
                 ids.forEach(function(bundler_id) {
                     var bundler = bundlers[bundler_id];
                     var group = that.element.find('#'+bundler.group+'_menu')
-                    
+
                     // Validate menu item metadata
                     if(!group.length) {
                         console.warn('unknown group', bundler.group, 'for bundler ID', bundler_id, '; skipping');
@@ -91,7 +91,7 @@ define('notebook/js/menubar',[
                         console.warn('no label for bundler ID', bundler_id, '; skipping');
                         return;
                     }
-                    
+
                     // Insert menu item into correct group, click handler
                     group.parent().removeClass('hidden');
                     var $li = $('<li>')
@@ -117,7 +117,7 @@ define('notebook/js/menubar',[
             w.location = url;
         }
     };
-    
+
     MenuBar.prototype._bundle = function(bundler_id) {
         // Read notebook path and base url here in case they change
         var notebook_path = utils.encode_uri_components(this.notebook.notebook_path);
@@ -219,20 +219,10 @@ define('notebook/js/menubar',[
         var url =
           utils.url_path_join(
             that.base_url,
-            "nbconvert-service",
+            "nbconvert",
           ) +
           "?download=" +
           download.toString();
-        var create_new_dl_window = function() {
-          body
-            .empty()
-            .append("<p>")
-            .text("conversion in progress");
-          that._new_window(url);
-
-          return true;
-        };
-
         var xsrf_token = utils._get_cookie("_xsrf");
         var xhr = new XMLHttpRequest();
         xhr.open("POST", url, true);
@@ -301,12 +291,12 @@ define('notebook/js/menubar',[
             format,
             notebook_path
         ) + "?download=" + download.toString();
-        
+
         this._new_window(url);
     };
 
     MenuBar.prototype._size_header = function() {
-        /** 
+        /**
          * Update header spacer size.
          */
         console.warn('`_size_header` is deprecated and will be removed in future versions.'+
@@ -319,7 +309,7 @@ define('notebook/js/menubar',[
          *  File
          */
         var that = this;
-        
+
         this.element.find('#open_notebook').click(function () {
             var parent = utils.url_path_split(that.notebook.notebook_path)[0];
             window.open(
@@ -346,7 +336,7 @@ define('notebook/js/menubar',[
                 that._new_window(url);
             }
         });
-        
+
         this.element.find('#print_preview').click(function () {
             that._nbconvert('html', false);
         });
@@ -446,7 +436,7 @@ define('notebook/js/menubar',[
             })(that, id_act, idx);
         }
 
-        
+
         // Kernel
         this.element.find('#reconnect_kernel').click(function () {
             that.notebook.kernel.reconnect();
@@ -462,33 +452,33 @@ define('notebook/js/menubar',[
         this.element.find('#keyboard_shortcuts').click(function () {
             that.quick_help.show_keyboard_shortcuts();
         });
-        
+
         this.update_restore_checkpoint(null);
-        
+
         this.events.on('checkpoints_listed.Notebook', function (event, data) {
             that.update_restore_checkpoint(that.notebook.checkpoints);
         });
-        
+
         this.events.on('checkpoint_created.Notebook', function (event, data) {
             that.update_restore_checkpoint(that.notebook.checkpoints);
         });
-        
+
         this.events.on('notebook_loaded.Notebook', function() {
             var langinfo = that.notebook.metadata.language_info || {};
             that.update_nbconvert_script(langinfo);
         });
-        
+
         this.events.on('kernel_ready.Kernel', function(event, data) {
             var langinfo = data.kernel.info_reply.language_info || {};
             that.update_nbconvert_script(langinfo);
             that.add_kernel_help_links(data.kernel.info_reply.help_links || []);
         });
     };
-    
+
     MenuBar.prototype._add_celltoolbar_list = function () {
         var that = this;
         var submenu = $("#menu-cell-toolbar-submenu");
-        
+
         function preset_added(event, data) {
             var name = data.name;
             submenu.append(
@@ -512,7 +502,7 @@ define('notebook/js/menubar',[
                 )
             );
         }
-        
+
         // Setup the existing presets
         var presets = celltoolbar.CellToolbar.list_presets();
         preset_added(null, {name: i18n.msg._("None")});
@@ -522,7 +512,7 @@ define('notebook/js/menubar',[
 
         // Setup future preset registrations
         this.events.on('preset_added.CellToolbar', preset_added);
-        
+
         // Handle unregistered presets
         this.events.on('unregistered_preset.CellToolbar', function (event, data) {
             submenu.find("li[data-name='" + encodeURIComponent(data.name) + "']").remove();
@@ -543,7 +533,7 @@ define('notebook/js/menubar',[
             );
             return;
         }
-        
+
         var that = this;
         checkpoints.map(function (checkpoint) {
             var d = new Date(checkpoint.last_modified);
@@ -559,13 +549,13 @@ define('notebook/js/menubar',[
             );
         });
     };
-    
+
     MenuBar.prototype.update_nbconvert_script = function(langinfo) {
         /**
          * Set the 'Download as foo' menu option for the relevant language.
          */
         var el = this.element.find('#download_script');
-        
+
         // Set menu entry text to e.g. "Python (.py)"
         var langname = (langinfo.name || 'Script');
         langname = langname.charAt(0).toUpperCase()+langname.substr(1); // Capitalise
@@ -609,9 +599,8 @@ define('notebook/js/menubar',[
             );
             cursor = cursor.next();
         });
-        
+
     };
 
     return {'MenuBar': MenuBar};
 });
-

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -136,15 +136,15 @@ define('notebook/js/menubar',[
         this.notebook.notebook_path
       );
 
-      const build_json_for_post = function(notebook, config, format) {
-        const json_to_pass = {
+      var build_json_for_post = function(notebook, config, format) {
+        var json_to_pass = {
           notebook_contents: {
             content: notebook.toJSON(),
             name: notebook.notebook_name,
-            last_modified: notebook.last_modified,
+            last_modified: notebook.last_modified
         },
           output_format: format,
-          config: config,
+          config: config
         };
         return json_to_pass;
       };
@@ -219,7 +219,7 @@ define('notebook/js/menubar',[
         var url =
           utils.url_path_join(
             that.base_url,
-            "nbconvert",
+            "nbconvert"
           ) +
           "?download=" +
           download.toString();
@@ -250,12 +250,12 @@ define('notebook/js/menubar',[
         a.style = "display: none";
         return (
           function(data, fileName) {
-            var blob = new Blob([data], { type: "octet/stream" }),
-              url = window.URL.createObjectURL(blob);
-            a.href = url;
+            var blob = new Blob([data], { type: "octet/stream" });
+            var objectUrl = window.URL.createObjectURL(blob);
+            a.href = objectUrl;
             a.download = fileName;
             a.click();
-            window.URL.revokeObjectURL(url);
+            window.URL.revokeObjectURL(objectUrl);
             document.body.removeChild(a);
           }
         )
@@ -417,7 +417,7 @@ define('notebook/js/menubar',[
             '#copy_cell_attachments': 'copy-cell-attachments',
             '#paste_cell_attachments': 'paste-cell-attachments',
             '#insert_image': 'insert-image',
-            '#edit_keyboard_shortcuts' : 'edit-command-mode-keyboard-shortcuts',
+            '#edit_keyboard_shortcuts' : 'edit-command-mode-keyboard-shortcuts'
         };
 
         for(var idx in id_actions_dict){

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -86,6 +86,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
                             <a href="#">{% trans %}Open...{% endtrans %}</a></li>
                         <!-- <hr/> -->
                         <li class="divider"></li>
+                        <li id="custom_download"><a href="#">custom download</a></li>
                         <li id="copy_notebook"
                             title="{% trans %}Open a copy of this notebook's contents and start a new kernel{% endtrans %}">
                             <a href="#">{% trans %}Make a Copy...{% endtrans %}</a></li>
@@ -119,7 +120,6 @@ data-notebook-path="{{notebook_path | urlencode}}"
                                     <a href="#">{{ exporter.display }}</a>
                                 </li>
                                 {% endfor %}
-                                <li id="custom_download"><a href="#">custom download</a></li>
                             </ul>
                         </li>
                         <li class="dropdown-submenu hidden"><a href="#">{% trans %}Deploy as{% endtrans %}</a>

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -107,14 +107,14 @@ data-notebook-path="{{notebook_path | urlencode}}"
                         <li id="custom_download"><a href="#">{% trans %}Custom Download {% endtrans %}</a></li>
                         <li class="dropdown-submenu"><a href="#">{% trans %}Download as{% endtrans %}</a>
                             <ul id="download_menu" class="dropdown-menu">
-                                <li id="download_ipynb"><a href="#">Notebook (.ipynb)</a></li>
-                                <li id="download_script"><a href="#">Script</a></li>
-                                <li id="download_html"><a href="#">HTML (.html)</a></li>
-                                <li id="download_slides"><a href="#">Reveal.js slides (.html)</a></li>
-                                <li id="download_markdown"><a href="#">Markdown (.md)</a></li>
-                                <li id="download_rst"><a href="#">reST (.rst)</a></li>
-                                <li id="download_latex"><a href="#">LaTeX (.tex)</a></li>
-                                <li id="download_pdf"><a href="#">PDF via LaTeX (.pdf)</a></li>
+                                <li id="download_ipynb"><a href="#">{% trans %}Notebook (.ipynb){% endtrans %}</a></li>
+                                <li id="download_script"><a href="#">S{% trans %}script{% endtrans %}</a></li>
+                                <li id="download_html"><a href="#">{% trans %}HTML (.html){% endtrans %}</a></li>
+                                <li id="download_slides"><a href="#">{% trans %}Reveal.js slides (.html){% endtrans %}</a></li>
+                                <li id="download_markdown"><a href="#">{% trans %}Markdown (.md){% endtrans %}</a></li>
+                                <li id="download_rst"><a href="#">{% trans %}reST (.rst){% endtrans %}</a></li>
+                                <li id="download_latex"><a href="#">{% trans %}LaTeX (.tex){% endtrans %}</a></li>
+                                <li id="download_pdf"><a href="#">{% trans %}PDF via LaTeX (.pdf){% endtrans %}</a></li>
                                 {% for exporter in get_custom_frontend_exporters() %}
                                 <li id="download_{{ exporter.name }}">
                                     <a href="#">{{ exporter.display }}</a>

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -106,6 +106,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
                         <li id="print_preview"><a href="#">{% trans %}Print Preview{% endtrans %}</a></li>
                         <li id="custom_download"><a href="#">{% trans %}Custom Download {% endtrans %}</a></li>
                         <li class="dropdown-submenu"><a href="#">{% trans %}Download as{% endtrans %}</a>
+                            <ul id="download_menu" class="dropdown-menu">
                                 <li id="download_ipynb"><a href="#">Notebook (.ipynb)</a></li>
                                 <li id="download_script"><a href="#">Script</a></li>
                                 <li id="download_html"><a href="#">HTML (.html)</a></li>

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -86,7 +86,6 @@ data-notebook-path="{{notebook_path | urlencode}}"
                             <a href="#">{% trans %}Open...{% endtrans %}</a></li>
                         <!-- <hr/> -->
                         <li class="divider"></li>
-                        <li id="custom_download"><a href="#">Custom Download</a></li>
                         <li id="copy_notebook"
                             title="{% trans %}Open a copy of this notebook's contents and start a new kernel{% endtrans %}">
                             <a href="#">{% trans %}Make a Copy...{% endtrans %}</a></li>
@@ -105,8 +104,8 @@ data-notebook-path="{{notebook_path | urlencode}}"
                         </li>
                         <li class="divider"></li>
                         <li id="print_preview"><a href="#">{% trans %}Print Preview{% endtrans %}</a></li>
+                        <li id="custom_download"><a href="#">{% trans %}Custom Download {% endtrans %}</a></li>
                         <li class="dropdown-submenu"><a href="#">{% trans %}Download as{% endtrans %}</a>
-                            <ul id="download_menu" class="dropdown-menu">
                                 <li id="download_ipynb"><a href="#">Notebook (.ipynb)</a></li>
                                 <li id="download_script"><a href="#">Script</a></li>
                                 <li id="download_html"><a href="#">HTML (.html)</a></li>

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -86,7 +86,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
                             <a href="#">{% trans %}Open...{% endtrans %}</a></li>
                         <!-- <hr/> -->
                         <li class="divider"></li>
-                        <li id="custom_download"><a href="#">custom download</a></li>
+                        <li id="custom_download"><a href="#">Custom Download</a></li>
                         <li id="copy_notebook"
                             title="{% trans %}Open a copy of this notebook's contents and start a new kernel{% endtrans %}">
                             <a href="#">{% trans %}Make a Copy...{% endtrans %}</a></li>

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -106,19 +106,20 @@ data-notebook-path="{{notebook_path | urlencode}}"
                         <li id="print_preview"><a href="#">{% trans %}Print Preview{% endtrans %}</a></li>
                         <li class="dropdown-submenu"><a href="#">{% trans %}Download as{% endtrans %}</a>
                             <ul id="download_menu" class="dropdown-menu">
-                                <li id="download_ipynb"><a href="#">{% trans %}Notebook (.ipynb){% endtrans %}</a></li>
-                                <li id="download_script"><a href="#">{% trans %}Script{% endtrans %}</a></li>
-                                <li id="download_html"><a href="#">{% trans %}HTML (.html){% endtrans %}</a></li>
-                                <li id="download_slides"><a href="#">{% trans %}Reveal.js slides (.html){% endtrans %}</a></li>
-                                <li id="download_markdown"><a href="#">{% trans %}Markdown (.md){% endtrans %}</a></li>
-                                <li id="download_rst"><a href="#">{% trans %}reST (.rst){% endtrans %}</a></li>
-                                <li id="download_latex"><a href="#">{% trans %}LaTeX (.tex){% endtrans %}</a></li>
-                                <li id="download_pdf"><a href="#">{% trans %}PDF via LaTeX (.pdf){% endtrans %}</a></li>
+                                <li id="download_ipynb"><a href="#">Notebook (.ipynb)</a></li>
+                                <li id="download_script"><a href="#">Script</a></li>
+                                <li id="download_html"><a href="#">HTML (.html)</a></li>
+                                <li id="download_slides"><a href="#">Reveal.js slides (.html)</a></li>
+                                <li id="download_markdown"><a href="#">Markdown (.md)</a></li>
+                                <li id="download_rst"><a href="#">reST (.rst)</a></li>
+                                <li id="download_latex"><a href="#">LaTeX (.tex)</a></li>
+                                <li id="download_pdf"><a href="#">PDF via LaTeX (.pdf)</a></li>
                                 {% for exporter in get_custom_frontend_exporters() %}
                                 <li id="download_{{ exporter.name }}">
                                     <a href="#">{{ exporter.display }}</a>
                                 </li>
                                 {% endfor %}
+                                <li id="custom_download"><a href="#">custom download</a></li>
                             </ul>
                         </li>
                         <li class="dropdown-submenu hidden"><a href="#">{% trans %}Deploy as{% endtrans %}</a>


### PR DESCRIPTION
At long last! The ability to upload a custom configuration file to customise exports is here.

There are still a lot of issues I need to work out in terms of the UI, but the core functionality is present.

Steps to accomplish this:

1. click on File → Custom Download
2. choose your output format from the dropdown menu
3. click on choose file and add your `.json` config file
4. click submit

Looking forward to getting feedback on this. 

Note: by doing this, I've actually made the current "Download as" sub-menu somewhat redundant as that is equivalent to this case but where you simply don't give it any config file.

~~I'm a little concerned about size limitations due to the current anchor + dataURI approach to downloading things, but I figured others would have clearer thoughts on that than I would be able to express.~~ edit: I realised that the size worries stemmed from an earlier attempt of mine and that I had actually addressed that by using the blob object and createObjectURL approach.

Bonus: it allows downloading without needing to open a new window, which I see as a win.

Thank you to everyone who helped bring this to fruition (@minrk, @takluyver and especially @Carreau). 

cc: @bollwyvl 