### PR TITLE
editor: remember user language choices per file extension

### DIFF
--- a/notebook/static/edit/js/editor.js
+++ b/notebook/static/edit/js/editor.js
@@ -61,7 +61,9 @@ function(
                 var modename = cfg.file_extension_modes[that._get_file_extension()];
                 if (modename) {
                     var modeinfo = CodeMirror.findModeByName(modename);
-                    that.set_codemirror_mode(modeinfo);
+                    if (modeinfo) {
+                        that.set_codemirror_mode(modeinfo);
+                    }
                 }
             }
             that._clean_state();

--- a/notebook/static/edit/js/menubar.js
+++ b/notebook/static/edit/js/menubar.js
@@ -146,6 +146,8 @@ define([
         function make_set_mode(info) {
             return function () {
                 editor.set_codemirror_mode(info);
+                // save codemirror mode for extension when explicitly selected
+                editor.save_codemirror_mode(info);
             };
         }
         for (var i = 0; i < CodeMirror.modeInfo.length; i++) {


### PR DESCRIPTION
When the language is selected manually, record the file extension and choice in config so that future files opened with the same extension use the same mode.

This allows users to teach the editor about file extensions CodeMirror doesn't know about.

cc @mebersole