### PR TITLE
accept jquery's ajax({url: '...'}) signature

### DIFF
--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -772,7 +772,12 @@ define([
     };
     
     var ajax = function (url, settings) {
-        // like $.ajax, but ensure Authorization header is set
+        // like $.ajax, but ensure XSRF or Authorization header is set
+        if (typeof url === "object") {
+            // called with single argument: $.ajax({url: '...'})
+            settings = url;
+            url = settings.url;
+        }
         settings = _add_auth_header(settings);
         return $.ajax(url, settings);
     };

--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -777,6 +777,7 @@ define([
             // called with single argument: $.ajax({url: '...'})
             settings = url;
             url = settings.url;
+            delete settings.url;
         }
         settings = _add_auth_header(settings);
         return $.ajax(url, settings);


### PR DESCRIPTION
in `utils.ajax`.

to ease extensions updating from `$.ajax` to `utils.ajax`

cc @damianavila who ran into this