### PR TITLE
pin setuptools to < 35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
 before_install:
     - pip install --upgrade pip
     - pip install --upgrade setuptools wheel nose coverage codecov
+    - pip install 'setuptools<35' # FIXME: unpin setuptools
     - nvm install 6.9.2
     - nvm use 6.9.2
     - node --version


### PR DESCRIPTION
setuptools 35 may be causing js tests to fail presumably due to a change in manifest files (?).

This PR is mostly to verify that setuptools 35 is actually the cause,
and serves as a temporary fix to avoid blocking other work, if so.