### PR TITLE
stop using old websocket implementation in tests

### DIFF
--- a/notebook/jstest.py
+++ b/notebook/jstest.py
@@ -324,8 +324,6 @@ class JSController(TestController):
         c.start()
         env = os.environ.copy()
         env.update(self.env)
-        if self.engine == 'phantomjs':
-            env['IPYTHON_ALLOW_DRAFT_WEBSOCKETS_FOR_PHANTOMJS'] = '1'
         self.server = subprocess.Popen(command,
             stdout = c.writefd,
             stderr = subprocess.STDOUT,

--- a/notebook/tests/services/serialize.js
+++ b/notebook/tests/services/serialize.js
@@ -4,10 +4,6 @@
 //
 
 casper.notebook_test(function () {
-    if (!this.slimerjs) {
-        console.log("Can't test binary websockets on phantomjs.");
-        return;
-    }
     // create EchoBuffers target on js-side.
     // it just captures and echos comm messages.
     this.then(function () {


### PR DESCRIPTION
since we are using phantomjs 2, we don't need the old websocket implementation anymore, which is broken with tornado 4.5, anyway.

This appears to be the cause of the recent failures on Travis.