### PR TITLE
demote allow-root message to warning from an error

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1395,8 +1395,7 @@ class NotebookApp(JupyterApp):
             except AttributeError:
                 uid = -1 # anything nonzero here, since we can't check UID assume non-root
             if uid == 0:
-                self.log.critical("Running as root is not recommended. Use --allow-root to bypass.")
-                self.exit(1)
+                self.log.critical("Running as root is not recommended. Use --allow-root to suppress this warning.")
 
         super(NotebookApp, self).start()
 


### PR DESCRIPTION
rather than refusing to run, warn about safety. There are plenty of cases, especially in containers, where this is a fine thing to do.