### PR TITLE
fix some absolute URL paths

### DIFF
--- a/notebook/static/custom/custom.js
+++ b/notebook/static/custom/custom.js
@@ -63,16 +63,6 @@
  *        });
  *    });
  *
- * __Example 3:__
- *
- *  Use `jQuery.getScript(url [, success(script, textStatus, jqXHR)] );`
- *  to load custom script into the notebook.
- *
- *    // to load the metadata ui extension example.
- *    $.getScript('/static/notebook/js/celltoolbarpresets/example.js');
- *    // or
- *    // to load the metadata ui extension to control slideshow mode / reveal js for nbconvert
- *    $.getScript('/static/notebook/js/celltoolbarpresets/slideshow.js');
  *
  *
  * @module IPython

--- a/notebook/static/notebook/js/celltoolbarpresets/example.js
+++ b/notebook/static/notebook/js/celltoolbarpresets/example.js
@@ -1,13 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-// Example Use for the CellToolbar library
-// add the following to your custom.js to load
-// Celltoolbar UI for slideshow
-
-// ```
-// $.getScript('/static/js/celltoolbarpresets/example.js');
-// ```
 define([
     'notebook/js/celltoolbar',
 ], function(celltoolbar) {

--- a/notebook/static/notebook/js/notificationarea.js
+++ b/notebook/static/notebook/js/notificationarea.js
@@ -250,7 +250,7 @@ define([
             link.id = 'favicon';
             link.type = 'image/x-icon';
             link.rel = 'shortcut icon';
-            link.href = src;
+            link.href = utils.url_path_join(utils.get_body_data('baseUrl'), src);
             if (oldLink) document.head.removeChild(oldLink);
             document.head.appendChild(link);
         };

--- a/notebook/static/notebook/js/pager.js
+++ b/notebook/static/notebook/js/pager.js
@@ -140,7 +140,7 @@ define([
         .append(
                 $('<link>')
                 .attr('rel',"stylesheet")
-                .attr('href',"/static/css/notebook.css")
+                .attr('href', utils.url_path_join(utils.get_body_data('baseUrl'), "static/style/style.min.css"))
                 .attr('type',"text/css")
         )
         .append(


### PR DESCRIPTION
URLs always need to be relative to base_url in the javascript, because they will 404 when run on a non-empty URL prefix (e.g. JupyterHub).

closes https://github.com/jupyterhub/jupyterhub/issues/1086

I also removed a couple of outdated and incorrect examples while finding other instances of mistaken absolute paths.