### PR TITLE
Redirect paste menu items to call actions

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -283,6 +283,12 @@ define(function(require){
                 env.notebook.copy_cell();
             }
         },
+        'paste-cell-replace' : {
+            help: 'paste cells replace',
+            handler : function (env) {
+                env.notebook.paste_cell_replace();
+            }
+        },
         'paste-cell-above' : {
             help: 'paste cells above',
             help_index : 'eg',

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1571,7 +1571,7 @@ define([
                     'jupyter-notebook:paste-cell-replace');});
             $('#paste_cell_above').removeClass('disabled')
                 .on('click', function () {that.keyboard_manager.actions.call(
-                    'jupyter-notebook:paste_cell_above');});
+                    'jupyter-notebook:paste-cell-above');});
             $('#paste_cell_below').removeClass('disabled')
                 .on('click', function () {that.keyboard_manager.actions.call(
                     'jupyter-notebook:paste-cell-below');});

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1567,11 +1567,14 @@ define([
         var that = this;
         if (!this.paste_enabled) {
             $('#paste_cell_replace').removeClass('disabled')
-                .on('click', function () {that.paste_cell_replace();});
+                .on('click', function () {that.keyboard_manager.actions.call(
+                    'jupyter-notebook:paste-cell-replace');});
             $('#paste_cell_above').removeClass('disabled')
-                .on('click', function () {that.paste_cell_above();});
+                .on('click', function () {that.keyboard_manager.actions.call(
+                    'jupyter-notebook:paste_cell_above');});
             $('#paste_cell_below').removeClass('disabled')
-                .on('click', function () {that.paste_cell_below();});
+                .on('click', function () {that.keyboard_manager.actions.call(
+                    'jupyter-notebook:paste-cell-below');});
             this.paste_enabled = true;
         }
     };


### PR DESCRIPTION
Closes #2415 regarding paste menu items calling the notebook's paste functions directly rather than the relevant actions.

My apologies for all the extraneous changes in notebook.js and notificationarea.js. It seems my text editor automatically removed trailing whitespace on a number of lines. The substantial changes in notebook.js are at line 1570.