### PR TITLE
sys.stdin can be None

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1206,7 +1206,7 @@ class NotebookApp(JupyterApp):
             log("Terminals not available (error was %s)", e)
 
     def init_signal(self):
-        if not sys.platform.startswith('win') and sys.stdin.isatty():
+        if not sys.platform.startswith('win') and sys.stdin and sys.stdin.isatty():
             signal.signal(signal.SIGINT, self._handle_sigint)
         signal.signal(signal.SIGTERM, self._signal_stop)
         if hasattr(signal, 'SIGUSR1'):


### PR DESCRIPTION
When the underlying FD [is not valid](https://github.com/python/cpython/blob/v3.6.1/Python/pylifecycle.c#L1077).

in which case we can't check if it's a tty or read from it


cf https://github.com/jupyterhub/jupyterhub/issues/1108