### PR TITLE
Open terminal tab using a hash rather than undefined for IE compatibility.

### DIFF
--- a/notebook/static/tree/js/terminallist.js
+++ b/notebook/static/tree/js/terminallist.js
@@ -42,7 +42,7 @@ define([
     };
 
     TerminalList.prototype.new_terminal = function () {
-        var w = window.open(undefined, IPython._target);
+        var w = window.open('#', IPython._target);
         var base_url = this.base_url;
         var settings = {
             type : "POST",


### PR DESCRIPTION
I ran into this issue when using Jupyter on Windows 7 with IE 11. It appears as though `window.open(undefined)` does not behave the same way in IE as it does in other major browsers, and instead of keeping the location of the resulting window the same as the current window it appends 'undefined' to the end of the URL resulting in a 404 in Jupyter.

This PR simply changes the temporary location that the window is opened to a hash mark to effectively achieve the same thing but ensure compatibility with IE.