### PR TITLE
Adjust positioning of filename in save widget

### DIFF
--- a/notebook/static/notebook/less/savewidget.less
+++ b/notebook/static/notebook/less/savewidget.less
@@ -6,7 +6,6 @@ span.save_widget {
     span.filename {
         height: 1em;
         line-height: 1em;
-        padding: 3px;
         margin-left: @padding-large-horizontal;
         border: none;
         font-size: 146.5%;


### PR DESCRIPTION
I noticed that the filename was partly hidden on Firefox, and badly aligned vertically on both Firefox and Chromium).

Before (L Firefox, R Chromium):

![screenshot from 2017-05-04 13-27-54](https://cloud.githubusercontent.com/assets/327925/25703570/01101a60-30ce-11e7-9276-61842ab48c56.png)

After:

![screenshot from 2017-05-04 13-29-28](https://cloud.githubusercontent.com/assets/327925/25703576/05cd11a2-30ce-11e7-8dca-786b2ebd56d2.png)
