### PR TITLE
NotebookApp.websocket_compression_options config

### DIFF
--- a/notebook/base/zmqhandlers.py
+++ b/notebook/base/zmqhandlers.py
@@ -296,5 +296,4 @@ class AuthenticatedZMQStreamHandler(ZMQStreamHandler, IPythonHandler):
         self.session = Session(config=self.config)
 
     def get_compression_options(self):
-        # use deflate compress websocket
-        return {}
+        return self.settings.get('websocket_compression_options', None)

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -93,7 +93,7 @@ from jupyter_client.kernelspec import KernelSpecManager, NoSuchKernel, NATIVE_KE
 from jupyter_client.session import Session
 from nbformat.sign import NotebookNotary
 from traitlets import (
-    Dict, Unicode, Integer, List, Bool, Bytes, Instance,
+    Any, Dict, Unicode, Integer, List, Bool, Bytes, Instance,
     TraitError, Type, Float, observe, default, validate
 )
 from ipython_genutils import py3compat
@@ -740,7 +740,18 @@ class NotebookApp(JupyterApp):
     tornado_settings = Dict(config=True,
             help="Supply overrides for the tornado.web.Application that the "
                  "Jupyter notebook uses.")
-    
+
+    websocket_compression_options = Any(None, config=True,
+        help="""
+        Set the tornado compression options for websocket connections.
+
+        This value will be returned from :meth:`WebSocketHandler.get_compression_options`.
+        None (default) will disable compression.
+        A dict (even an empty one) will enable compression.
+
+        See the tornado docs for WebSocketHandler.get_compression_options for details.
+        """
+    )
     terminado_settings = Dict(config=True,
             help='Supply overrides for terminado. Currently only supports "shell_command".')
 
@@ -1107,6 +1118,7 @@ class NotebookApp(JupyterApp):
     def init_webapp(self):
         """initialize tornado webapp and httpserver"""
         self.tornado_settings['allow_origin'] = self.allow_origin
+        self.tornado_settings['websocket_compression_options'] = self.websocket_compression_options
         if self.allow_origin_pat:
             self.tornado_settings['allow_origin_pat'] = re.compile(self.allow_origin_pat)
         self.tornado_settings['allow_credentials'] = self.allow_credentials

--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -77,7 +77,7 @@ define([
         this.prompt_overlay.addClass('out_prompt_overlay prompt');
         this.prompt_overlay.attr('title', 'click to expand output; double click to hide output');
         
-        this.collapse();
+        this.expand();
     };
 
     /**
@@ -976,6 +976,7 @@ define([
             this._display_id_targets = {};
             this.trusted = true;
             this.unscroll_area();
+            this.expand();
             return;
         }
     };


### PR DESCRIPTION
expose passthrough for WebSocketHandler.get_compression_options

adds `NotebookApp.websocket_compression_options` configurable as a passthrough for setting the return value for [WebSocketHandler.get_compression_options()](http://www.tornadoweb.org/en/stable/websocket.html#tornado.websocket.WebSocketHandler.get_compression_options) with a default of None (no compression).

This works, but marked WIP while waiting for a decision on default from #2490. Other options:

- default: 'auto' so that compression is off for localhost by default and on for remote connections (as identified via `remote_ip`)
- allow setting a callable instead of a scalar, so that config could enable custom logic (such as 'auto' based on remote_ip)

closes #2490