### PR TITLE
Fix test not to expect notebooks sorted

### DIFF
--- a/notebook/services/contents/tests/test_contents_api.py
+++ b/notebook/services/contents/tests/test_contents_api.py
@@ -249,8 +249,8 @@ class APITest(NotebookTestBase):
         self.assertEqual(nbnames, expected)
 
         nbs = notebooks_only(self.api.list('ordering').json())
-        nbnames = [n['name'] for n in nbs]
-        expected = ['A.ipynb', 'b.ipynb', 'C.ipynb']
+        nbnames = {n['name'] for n in nbs}
+        expected = {'A.ipynb', 'b.ipynb', 'C.ipynb'}
         self.assertEqual(nbnames, expected)
 
     def test_list_dirs(self):


### PR DESCRIPTION
PR gh-2281 removed the sorting step from the server. This can result in non-deterministic test failures, because the test checked against a list. Comparing sets instead makes the order not matter.