### PR TITLE
don’t start output areas with collapsed metadata

### DIFF
--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -77,7 +77,7 @@ define([
         this.prompt_overlay.addClass('out_prompt_overlay prompt');
         this.prompt_overlay.attr('title', 'click to expand output; double click to hide output');
         
-        this.collapse();
+        this.expand();
     };
 
     /**
@@ -976,6 +976,7 @@ define([
             this._display_id_targets = {};
             this.trusted = true;
             this.unscroll_area();
+            this.expand();
             return;
         }
     };


### PR DESCRIPTION
this sets `metadata.collapsed = true` on cells with no output, causing churn in notebook files in version control (open and save would result in different metadata from open, run all, save).

Starting collapsed was an early fix for empty output areas having some extra height. This has been fixed at some point with CSS.