### PR TITLE
Issue #2502: Add line break after The Jupyter Notebook is running at:

### DIFF
--- a/docs/source/security.rst
+++ b/docs/source/security.rst
@@ -31,7 +31,8 @@ When you start a notebook server with token authentication enabled (default),
 a token is generated to use for authentication.
 This token is logged to the terminal, so that you can copy/paste the URL into your browser::
 
-    [I 11:59:16.597 NotebookApp] The Jupyter Notebook is running at: http://localhost:8888/?token=c8de56fa4deed24899803e93c227592aef6538f93025fe01
+    [I 11:59:16.597 NotebookApp] The Jupyter Notebook is running at:
+    http://localhost:8888/?token=c8de56fa4deed24899803e93c227592aef6538f93025fe01
 
 
 If the notebook server is going to open your browser automatically

--- a/docs/source/security.rst
+++ b/docs/source/security.rst
@@ -31,8 +31,7 @@ When you start a notebook server with token authentication enabled (default),
 a token is generated to use for authentication.
 This token is logged to the terminal, so that you can copy/paste the URL into your browser::
 
-    [I 11:59:16.597 NotebookApp] The Jupyter Notebook is running at:
-    http://localhost:8888/?token=c8de56fa4deed24899803e93c227592aef6538f93025fe01
+    [I 11:59:16.597 NotebookApp] The Jupyter Notebook is running at: http://localhost:8888/?token=c8de56fa4deed24899803e93c227592aef6538f93025fe01
 
 
 If the notebook server is going to open your browser automatically

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -187,7 +187,7 @@ class NotebookWebApplication(web.Application):
         jenv_opt.update(jinja_env_options if jinja_env_options else {})
 
         env = Environment(loader=FileSystemLoader(template_path), **jenv_opt)
-
+        
         sys_info = get_sys_info()
         if sys_info['commit_source'] == 'repository':
             # don't cache (rely on 304) when working from master
@@ -197,13 +197,13 @@ class NotebookWebApplication(web.Application):
             version_hash = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
 
         if jupyter_app.ignore_minified_js:
-            log.warning("""The `ignore_minified_js` flag is deprecated and no
+            log.warning("""The `ignore_minified_js` flag is deprecated and no 
                 longer works.  Alternatively use `npm run build:watch` when
                 working on the notebook's Javascript and LESS""")
             warnings.warn("The `ignore_minified_js` flag is deprecated and will be removed in Notebook 6.0", DeprecationWarning)
 
         now = utcnow()
-
+        
         root_dir = contents_manager.root_dir
         home = os.path.expanduser('~')
         if root_dir.startswith(home + os.path.sep):
@@ -226,7 +226,7 @@ class NotebookWebApplication(web.Application):
             },
             version_hash=version_hash,
             ignore_minified_js=jupyter_app.ignore_minified_js,
-
+            
             # rate limits
             iopub_msg_rate_limit=jupyter_app.iopub_msg_rate_limit,
             iopub_data_rate_limit=jupyter_app.iopub_data_rate_limit,
@@ -236,7 +236,7 @@ class NotebookWebApplication(web.Application):
             # tornado defaults are 100 MiB, we increase it to 0.5 GiB
             max_body_size = 512 * 1024 * 1024,
             max_buffer_size = 512 * 1024 * 1024,
-
+            
             # authentication
             cookie_secret=jupyter_app.cookie_secret,
             login_url=url_path_join(base_url,'/login'),
@@ -273,7 +273,7 @@ class NotebookWebApplication(web.Application):
 
     def init_handlers(self, settings):
         """Load the (URL pattern, handler) tuples for each component."""
-
+        
         # Order matters. The first handler to match the URL will handle the request.
         handlers = []
         handlers.extend(load_handlers('tree.handlers'))
@@ -294,7 +294,7 @@ class NotebookWebApplication(web.Application):
         handlers.extend(load_handlers('services.nbconvert.handlers'))
         handlers.extend(load_handlers('services.kernelspecs.handlers'))
         handlers.extend(load_handlers('services.security.handlers'))
-
+        
         handlers.append(
             (r"/nbextensions/(.*)", FileFindHandler, {
                 'path': settings['nbextensions_path'],
@@ -334,7 +334,7 @@ class NotebookPasswordApp(JupyterApp):
     Setting a password secures the notebook server
     and removes the need for token-based authentication.
     """
-
+    
     description = __doc__
 
     def _config_file_default(self):
@@ -378,12 +378,12 @@ class NbserverStopApp(JupyterApp):
 class NbserverListApp(JupyterApp):
     version = __version__
     description="List currently running notebook servers."
-
+    
     flags = dict(
         json=({'NbserverListApp': {'json': True}},
               "Produce machine-readable JSON output."),
     )
-
+    
     json = Bool(False, config=True,
           help="If True, each line of output will be a JSON object with the "
                   "details from the server info file.")
@@ -416,11 +416,11 @@ flags['pylab']=(
 flags['no-mathjax']=(
     {'NotebookApp' : {'enable_mathjax' : False}},
     """Disable MathJax
-
+    
     MathJax is the javascript library Jupyter uses to render math/LaTeX. It is
     very large, so you may want to disable it if you have a slow internet
     connection, or for offline use of the notebook.
-
+    
     When disabled, equations etc. will appear as their untransformed TeX source.
     """
 )
@@ -460,14 +460,14 @@ class NotebookApp(JupyterApp):
     version = __version__
     description = """
         The Jupyter HTML Notebook.
-
+        
         This launches a Tornado based HTML Notebook Server that serves up an
         HTML5/Javascript Notebook client.
     """
     examples = _examples
     aliases = aliases
     flags = flags
-
+    
     classes = [
         KernelManager, Session, MappingKernelManager,
         ContentsManager, FileContentsManager, NotebookNotary,
@@ -475,7 +475,7 @@ class NotebookApp(JupyterApp):
     ]
     flags = Dict(flags)
     aliases = Dict(aliases)
-
+    
     subcommands = dict(
         list=(NbserverListApp, NbserverListApp.description.splitlines()[0]),
         stop=(NbserverStopApp, NbserverStopApp.description.splitlines()[0]),
@@ -492,7 +492,7 @@ class NotebookApp(JupyterApp):
     def _default_log_datefmt(self):
         """Exclude date from default date format"""
         return "%H:%M:%S"
-
+    
     @default('log_format')
     def _default_log_format(self):
         """override default log format to include time"""
@@ -500,48 +500,48 @@ class NotebookApp(JupyterApp):
 
     ignore_minified_js = Bool(False,
             config=True,
-            help='Deprecated: Use minified JS file or not, mainly use during dev to avoid JS recompilation',
+            help='Deprecated: Use minified JS file or not, mainly use during dev to avoid JS recompilation', 
             )
 
     # file to be opened in the notebook server
     file_to_run = Unicode('', config=True)
 
     # Network related information
-
+    
     allow_origin = Unicode('', config=True,
         help="""Set the Access-Control-Allow-Origin header
-
+        
         Use '*' to allow any origin to access your server.
-
+        
         Takes precedence over allow_origin_pat.
         """
     )
-
+    
     allow_origin_pat = Unicode('', config=True,
         help="""Use a regular expression for the Access-Control-Allow-Origin header
-
+        
         Requests from an origin matching the expression will get replies with:
-
+        
             Access-Control-Allow-Origin: origin
-
+        
         where `origin` is the origin of the request.
-
+        
         Ignored if allow_origin is set.
         """
     )
-
+    
     allow_credentials = Bool(False, config=True,
         help="Set the Access-Control-Allow-Credentials: true header"
     )
-
-    allow_root = Bool(False, config=True,
+    
+    allow_root = Bool(False, config=True, 
         help="Whether to allow the user to run the notebook as root."
     )
 
     default_url = Unicode('/tree', config=True,
         help="The default URL to redirect to from `/`"
     )
-
+    
     ip = Unicode('localhost', config=True,
         help="The IP address the notebook server will listen on."
     )
@@ -549,7 +549,7 @@ class NotebookApp(JupyterApp):
     @default('ip')
     def _default_ip(self):
         """Return localhost if available, 127.0.0.1 otherwise.
-
+        
         On some (horribly broken) systems, localhost cannot be bound.
         """
         s = socket.socket()
@@ -577,18 +577,18 @@ class NotebookApp(JupyterApp):
         help="The number of additional ports to try if the specified port is not available."
     )
 
-    certfile = Unicode(u'', config=True,
+    certfile = Unicode(u'', config=True, 
         help="""The full path to an SSL/TLS certificate file."""
     )
-
-    keyfile = Unicode(u'', config=True,
+    
+    keyfile = Unicode(u'', config=True, 
         help="""The full path to a private key file for usage with SSL/TLS."""
     )
-
+    
     client_ca = Unicode(u'', config=True,
         help="""The full path to a certificate authority certificate for SSL/TLS client authentication."""
     )
-
+    
     cookie_secret_file = Unicode(config=True,
         help="""The file where the cookie secret is stored."""
     )
@@ -596,17 +596,17 @@ class NotebookApp(JupyterApp):
     @default('cookie_secret_file')
     def _default_cookie_secret_file(self):
         return os.path.join(self.runtime_dir, 'notebook_cookie_secret')
-
+    
     cookie_secret = Bytes(b'', config=True,
         help="""The random bytes used to secure cookies.
         By default this is a new random number every time you start the Notebook.
         Set it to a value in a config file to enable logins to persist across server sessions.
-
+        
         Note: Cookie secrets should be kept private, do not share config files with
         cookie_secret stored in plaintext (you can read the value from a file).
         """
     )
-
+    
     @default('cookie_secret')
     def _default_cookie_secret(self):
         if os.path.exists(self.cookie_secret_file):
@@ -616,7 +616,7 @@ class NotebookApp(JupyterApp):
             secret = encodebytes(os.urandom(1024))
             self._write_cookie_secret_file(secret)
             return secret
-
+    
     def _write_cookie_secret_file(self, secret):
         """write my secret to my secret_file"""
         self.log.info("Writing notebook server cookie secret to %s", self.cookie_secret_file)
@@ -732,15 +732,15 @@ class NotebookApp(JupyterApp):
         help="DEPRECATED, use tornado_settings"
     )
 
-    @observe('webapp_settings')
+    @observe('webapp_settings') 
     def _update_webapp_settings(self, change):
         self.log.warning("\n    webapp_settings is deprecated, use tornado_settings.\n")
         self.tornado_settings = change['new']
-
+    
     tornado_settings = Dict(config=True,
             help="Supply overrides for the tornado.web.Application that the "
                  "Jupyter notebook uses.")
-
+    
     terminado_settings = Dict(config=True,
             help='Supply overrides for terminado. Currently only supports "shell_command".')
 
@@ -751,15 +751,15 @@ class NotebookApp(JupyterApp):
     ssl_options = Dict(config=True,
             help="""Supply SSL options for the tornado HTTPServer.
             See the tornado docs for details.""")
-
-    jinja_environment_options = Dict(config=True,
+    
+    jinja_environment_options = Dict(config=True, 
             help="Supply extra arguments that will be passed to Jinja environment.")
 
     jinja_template_vars = Dict(
         config=True,
         help="Extra variables to supply to jinja templates when rendering.",
     )
-
+    
     enable_mathjax = Bool(True, config=True,
         help="""Whether to enable MathJax for typesetting math/TeX
 
@@ -792,7 +792,7 @@ class NotebookApp(JupyterApp):
         if not value.endswith('/'):
             value = value + '/'
         return value
-
+    
     base_project_url = Unicode('/', config=True, help="""DEPRECATED use base_url""")
 
     @observe('base_project_url')
@@ -802,16 +802,16 @@ class NotebookApp(JupyterApp):
 
     extra_static_paths = List(Unicode(), config=True,
         help="""Extra paths to search for serving static files.
-
+        
         This allows adding javascript/css to be available from the notebook server machine,
         or overriding individual files in the IPython"""
     )
-
+    
     @property
     def static_file_path(self):
         """return extra paths + the default location"""
         return self.extra_static_paths + [DEFAULT_STATIC_FILES_PATH]
-
+    
     static_custom_path = List(Unicode(),
         help="""Path to search for custom.js, css"""
     )
@@ -838,7 +838,7 @@ class NotebookApp(JupyterApp):
     extra_nbextensions_path = List(Unicode(), config=True,
         help="""extra paths to look for Javascript notebook extensions"""
     )
-
+    
     @property
     def nbextensions_path(self):
         """The path to look for Javascript notebook extensions"""
@@ -855,7 +855,7 @@ class NotebookApp(JupyterApp):
     websocket_url = Unicode("", config=True,
         help="""The base URL for websockets,
         if it differs from the HTTP server (hint: it almost certainly doesn't).
-
+        
         Should be in the form of an HTTP origin: ws[s]://hostname[:port]
         """
     )
@@ -873,7 +873,7 @@ class NotebookApp(JupyterApp):
             return u''
         static_url_prefix = self.tornado_settings.get("static_url_prefix", "static")
         return url_path_join(static_url_prefix, 'components', 'MathJax', 'MathJax.js')
-
+    
     @observe('mathjax_url')
     def _update_mathjax_url(self, change):
         new = change['new']
@@ -955,7 +955,7 @@ class NotebookApp(JupyterApp):
     def _default_info_file(self):
         info_file = "nbserver-%s.json" % os.getpid()
         return os.path.join(self.runtime_dir, info_file)
-
+    
     pylab = Unicode('disabled', config=True,
         help="""
         DISABLED: use %pylab or %matplotlib in the notebook to enable matplotlib.
@@ -1014,12 +1014,12 @@ class NotebookApp(JupyterApp):
     server_extensions = List(Unicode(), config=True,
         help=("DEPRECATED use the nbserver_extensions dict instead")
     )
-
+    
     @observe('server_extensions')
     def _update_server_extensions(self, change):
         self.log.warning("server_extensions is deprecated, use nbserver_extensions")
         self.server_extensions = change['new']
-
+        
     nbserver_extensions = Dict({}, config=True,
         help=("Dict of Python modules to load as notebook server extensions."
               "Entry values can be used to enable and disable the loading of"
@@ -1041,7 +1041,7 @@ class NotebookApp(JupyterApp):
         Maximum rate at which stream output can be sent on iopub before they are
         limited.""")
 
-    rate_limit_window = Float(3, config=True, help="""(sec) Time window used to
+    rate_limit_window = Float(3, config=True, help="""(sec) Time window used to 
         check the message and data rate limits.""")
 
     def parse_command_line(self, argv=None):
@@ -1054,7 +1054,7 @@ class NotebookApp(JupyterApp):
             if not os.path.exists(f):
                 self.log.critical("No such file or directory: %s", f)
                 self.exit(1)
-
+            
             # Use config here, to ensure that it takes higher priority than
             # anything that comes from the config dirs.
             c = Config()
@@ -1094,7 +1094,7 @@ class NotebookApp(JupyterApp):
         # self.log is a child of. The logging module dipatches log messages to a log
         # and all of its ancenstors until propagate is set to False.
         self.log.propagate = False
-
+        
         for log in app_log, access_log, gen_log:
             # consistent log output name (NotebookApp instead of tornado.access, etc.)
             log.name = self.log.name
@@ -1103,7 +1103,7 @@ class NotebookApp(JupyterApp):
         logger.propagate = True
         logger.parent = self.log
         logger.setLevel(self.log.level)
-
+    
     def init_webapp(self):
         """initialize tornado webapp and httpserver"""
         self.tornado_settings['allow_origin'] = self.allow_origin
@@ -1150,7 +1150,7 @@ class NotebookApp(JupyterApp):
             ssl_options.setdefault('ssl_version', ssl.PROTOCOL_TLSv1)
             if ssl_options.get('ca_certs', False):
                 ssl_options.setdefault('cert_reqs', ssl.CERT_REQUIRED)
-
+        
         self.login_handler_class.validate_security(self, ssl_options=ssl_options)
         self.http_server = httpserver.HTTPServer(self.web_app, ssl_options=ssl_options,
                                                  xheaders=self.trust_xheaders)
@@ -1176,7 +1176,7 @@ class NotebookApp(JupyterApp):
             self.log.critical('ERROR: the notebook server could not be started because '
                               'no available port could be found.')
             self.exit(1)
-
+    
     @property
     def display_url(self):
         ip = self.ip if self.ip else '[all ip addresses on your system]'
@@ -1215,7 +1215,7 @@ class NotebookApp(JupyterApp):
         if hasattr(signal, 'SIGINFO'):
             # only on BSD-based systems
             signal.signal(signal.SIGINFO, self._signal_info)
-
+    
     def _handle_sigint(self, sig, frame):
         """SIGINT handler spawns confirmation dialog"""
         # register more forceful signal handler for ^C^C case
@@ -1225,17 +1225,17 @@ class NotebookApp(JupyterApp):
         thread = threading.Thread(target=self._confirm_exit)
         thread.daemon = True
         thread.start()
-
+    
     def _restore_sigint_handler(self):
         """callback for restoring original SIGINT handler"""
         signal.signal(signal.SIGINT, self._handle_sigint)
-
+    
     def _confirm_exit(self):
         """confirm shutdown on ^C
-
+        
         A second ^C, or answering 'y' within 5s will cause shutdown,
         otherwise original SIGINT handler will be restored.
-
+        
         This doesn't work on Windows.
         """
         info = self.log.info
@@ -1258,14 +1258,14 @@ class NotebookApp(JupyterApp):
         # use IOLoop.add_callback because signal.signal must be called
         # from main thread
         ioloop.IOLoop.current().add_callback(self._restore_sigint_handler)
-
+    
     def _signal_stop(self, sig, frame):
         self.log.critical("received signal %s, stopping", sig)
         ioloop.IOLoop.current().stop()
 
     def _signal_info(self, sig, frame):
         print(self.notebook_info())
-
+    
     def init_components(self):
         """Check the components submodule, and warn if it's unclean"""
         # TODO: this should still check, but now we use bower, not git submodule
@@ -1276,10 +1276,10 @@ class NotebookApp(JupyterApp):
 
         Import the module, then call the load_jupyter_server_extension function,
         if one exists.
-
+        
         The extension API is experimental, and may change in future releases.
         """
-
+        
         # TODO: Remove me in notebook 5.0
         for modulename in self.server_extensions:
             # Don't override disable state of the extension if it already exist
@@ -1342,7 +1342,7 @@ class NotebookApp(JupyterApp):
 
     def cleanup_kernels(self):
         """Shutdown all kernels.
-
+        
         The kernels will shutdown themselves when this process no longer exists,
         but explicit shutdown allows the KernelManagers to cleanup the connection files.
         """
@@ -1353,8 +1353,7 @@ class NotebookApp(JupyterApp):
         "Return the current working directory and the server url information"
         info = self.contents_manager.info_string() + "\n"
         info += "%d active kernels \n" % len(self.kernel_manager._kernels)
-        # Format the info so that the URL fits on a single line in 80 char display
-        return info + "The Jupyter Notebook is running at:\n\r%s" % self.display_url
+        return info + "The Jupyter Notebook is running at: %s" % self.display_url
 
     def server_info(self):
         """Return a JSONable dict of information about this server."""
@@ -1376,7 +1375,7 @@ class NotebookApp(JupyterApp):
 
     def remove_server_info_file(self):
         """Remove the nbserver-<pid>.json file created for this server.
-
+        
         Ignores the error raised when the file has already been removed.
         """
         try:
@@ -1387,7 +1386,7 @@ class NotebookApp(JupyterApp):
 
     def start(self):
         """ Start the Notebook server app, after initialization
-
+        
         This method takes no arguments so all configuration and initialization
         must be done prior to calling this method."""
 
@@ -1421,7 +1420,7 @@ class NotebookApp(JupyterApp):
             except webbrowser.Error as e:
                 self.log.warning('No web browser found: %s.' % e)
                 browser = None
-
+            
             if self.file_to_run:
                 if not os.path.exists(self.file_to_run):
                     self.log.critical("%s does not exist" % self.file_to_run)
@@ -1472,7 +1471,7 @@ class NotebookApp(JupyterApp):
 
 def list_running_servers(runtime_dir=None):
     """Iterate over the server info files of running notebook servers.
-
+    
     Given a runtime directory, find nbserver-* files in the security directory,
     and yield dicts of their information, each one pertaining to
     a currently running notebook server instance.

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1353,7 +1353,8 @@ class NotebookApp(JupyterApp):
         "Return the current working directory and the server url information"
         info = self.contents_manager.info_string() + "\n"
         info += "%d active kernels \n" % len(self.kernel_manager._kernels)
-        return info + "The Jupyter Notebook is running at: %s" % self.display_url
+        # Format the info so that the URL fits on a single line in 80 char display
+        return info + "The Jupyter Notebook is running at:\n\r%s" % self.display_url
 
     def server_info(self):
         """Return a JSONable dict of information about this server."""

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -187,7 +187,7 @@ class NotebookWebApplication(web.Application):
         jenv_opt.update(jinja_env_options if jinja_env_options else {})
 
         env = Environment(loader=FileSystemLoader(template_path), **jenv_opt)
-        
+
         sys_info = get_sys_info()
         if sys_info['commit_source'] == 'repository':
             # don't cache (rely on 304) when working from master
@@ -197,13 +197,13 @@ class NotebookWebApplication(web.Application):
             version_hash = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
 
         if jupyter_app.ignore_minified_js:
-            log.warning("""The `ignore_minified_js` flag is deprecated and no 
+            log.warning("""The `ignore_minified_js` flag is deprecated and no
                 longer works.  Alternatively use `npm run build:watch` when
                 working on the notebook's Javascript and LESS""")
             warnings.warn("The `ignore_minified_js` flag is deprecated and will be removed in Notebook 6.0", DeprecationWarning)
 
         now = utcnow()
-        
+
         root_dir = contents_manager.root_dir
         home = os.path.expanduser('~')
         if root_dir.startswith(home + os.path.sep):
@@ -226,7 +226,7 @@ class NotebookWebApplication(web.Application):
             },
             version_hash=version_hash,
             ignore_minified_js=jupyter_app.ignore_minified_js,
-            
+
             # rate limits
             iopub_msg_rate_limit=jupyter_app.iopub_msg_rate_limit,
             iopub_data_rate_limit=jupyter_app.iopub_data_rate_limit,
@@ -236,7 +236,7 @@ class NotebookWebApplication(web.Application):
             # tornado defaults are 100 MiB, we increase it to 0.5 GiB
             max_body_size = 512 * 1024 * 1024,
             max_buffer_size = 512 * 1024 * 1024,
-            
+
             # authentication
             cookie_secret=jupyter_app.cookie_secret,
             login_url=url_path_join(base_url,'/login'),
@@ -273,7 +273,7 @@ class NotebookWebApplication(web.Application):
 
     def init_handlers(self, settings):
         """Load the (URL pattern, handler) tuples for each component."""
-        
+
         # Order matters. The first handler to match the URL will handle the request.
         handlers = []
         handlers.extend(load_handlers('tree.handlers'))
@@ -294,7 +294,7 @@ class NotebookWebApplication(web.Application):
         handlers.extend(load_handlers('services.nbconvert.handlers'))
         handlers.extend(load_handlers('services.kernelspecs.handlers'))
         handlers.extend(load_handlers('services.security.handlers'))
-        
+
         handlers.append(
             (r"/nbextensions/(.*)", FileFindHandler, {
                 'path': settings['nbextensions_path'],
@@ -334,7 +334,7 @@ class NotebookPasswordApp(JupyterApp):
     Setting a password secures the notebook server
     and removes the need for token-based authentication.
     """
-    
+
     description = __doc__
 
     def _config_file_default(self):
@@ -378,12 +378,12 @@ class NbserverStopApp(JupyterApp):
 class NbserverListApp(JupyterApp):
     version = __version__
     description="List currently running notebook servers."
-    
+
     flags = dict(
         json=({'NbserverListApp': {'json': True}},
               "Produce machine-readable JSON output."),
     )
-    
+
     json = Bool(False, config=True,
           help="If True, each line of output will be a JSON object with the "
                   "details from the server info file.")
@@ -416,11 +416,11 @@ flags['pylab']=(
 flags['no-mathjax']=(
     {'NotebookApp' : {'enable_mathjax' : False}},
     """Disable MathJax
-    
+
     MathJax is the javascript library Jupyter uses to render math/LaTeX. It is
     very large, so you may want to disable it if you have a slow internet
     connection, or for offline use of the notebook.
-    
+
     When disabled, equations etc. will appear as their untransformed TeX source.
     """
 )
@@ -460,14 +460,14 @@ class NotebookApp(JupyterApp):
     version = __version__
     description = """
         The Jupyter HTML Notebook.
-        
+
         This launches a Tornado based HTML Notebook Server that serves up an
         HTML5/Javascript Notebook client.
     """
     examples = _examples
     aliases = aliases
     flags = flags
-    
+
     classes = [
         KernelManager, Session, MappingKernelManager,
         ContentsManager, FileContentsManager, NotebookNotary,
@@ -475,7 +475,7 @@ class NotebookApp(JupyterApp):
     ]
     flags = Dict(flags)
     aliases = Dict(aliases)
-    
+
     subcommands = dict(
         list=(NbserverListApp, NbserverListApp.description.splitlines()[0]),
         stop=(NbserverStopApp, NbserverStopApp.description.splitlines()[0]),
@@ -492,7 +492,7 @@ class NotebookApp(JupyterApp):
     def _default_log_datefmt(self):
         """Exclude date from default date format"""
         return "%H:%M:%S"
-    
+
     @default('log_format')
     def _default_log_format(self):
         """override default log format to include time"""
@@ -500,48 +500,48 @@ class NotebookApp(JupyterApp):
 
     ignore_minified_js = Bool(False,
             config=True,
-            help='Deprecated: Use minified JS file or not, mainly use during dev to avoid JS recompilation', 
+            help='Deprecated: Use minified JS file or not, mainly use during dev to avoid JS recompilation',
             )
 
     # file to be opened in the notebook server
     file_to_run = Unicode('', config=True)
 
     # Network related information
-    
+
     allow_origin = Unicode('', config=True,
         help="""Set the Access-Control-Allow-Origin header
-        
+
         Use '*' to allow any origin to access your server.
-        
+
         Takes precedence over allow_origin_pat.
         """
     )
-    
+
     allow_origin_pat = Unicode('', config=True,
         help="""Use a regular expression for the Access-Control-Allow-Origin header
-        
+
         Requests from an origin matching the expression will get replies with:
-        
+
             Access-Control-Allow-Origin: origin
-        
+
         where `origin` is the origin of the request.
-        
+
         Ignored if allow_origin is set.
         """
     )
-    
+
     allow_credentials = Bool(False, config=True,
         help="Set the Access-Control-Allow-Credentials: true header"
     )
-    
-    allow_root = Bool(False, config=True, 
+
+    allow_root = Bool(False, config=True,
         help="Whether to allow the user to run the notebook as root."
     )
 
     default_url = Unicode('/tree', config=True,
         help="The default URL to redirect to from `/`"
     )
-    
+
     ip = Unicode('localhost', config=True,
         help="The IP address the notebook server will listen on."
     )
@@ -549,7 +549,7 @@ class NotebookApp(JupyterApp):
     @default('ip')
     def _default_ip(self):
         """Return localhost if available, 127.0.0.1 otherwise.
-        
+
         On some (horribly broken) systems, localhost cannot be bound.
         """
         s = socket.socket()
@@ -577,18 +577,18 @@ class NotebookApp(JupyterApp):
         help="The number of additional ports to try if the specified port is not available."
     )
 
-    certfile = Unicode(u'', config=True, 
+    certfile = Unicode(u'', config=True,
         help="""The full path to an SSL/TLS certificate file."""
     )
-    
-    keyfile = Unicode(u'', config=True, 
+
+    keyfile = Unicode(u'', config=True,
         help="""The full path to a private key file for usage with SSL/TLS."""
     )
-    
+
     client_ca = Unicode(u'', config=True,
         help="""The full path to a certificate authority certificate for SSL/TLS client authentication."""
     )
-    
+
     cookie_secret_file = Unicode(config=True,
         help="""The file where the cookie secret is stored."""
     )
@@ -596,17 +596,17 @@ class NotebookApp(JupyterApp):
     @default('cookie_secret_file')
     def _default_cookie_secret_file(self):
         return os.path.join(self.runtime_dir, 'notebook_cookie_secret')
-    
+
     cookie_secret = Bytes(b'', config=True,
         help="""The random bytes used to secure cookies.
         By default this is a new random number every time you start the Notebook.
         Set it to a value in a config file to enable logins to persist across server sessions.
-        
+
         Note: Cookie secrets should be kept private, do not share config files with
         cookie_secret stored in plaintext (you can read the value from a file).
         """
     )
-    
+
     @default('cookie_secret')
     def _default_cookie_secret(self):
         if os.path.exists(self.cookie_secret_file):
@@ -616,7 +616,7 @@ class NotebookApp(JupyterApp):
             secret = encodebytes(os.urandom(1024))
             self._write_cookie_secret_file(secret)
             return secret
-    
+
     def _write_cookie_secret_file(self, secret):
         """write my secret to my secret_file"""
         self.log.info("Writing notebook server cookie secret to %s", self.cookie_secret_file)
@@ -732,15 +732,15 @@ class NotebookApp(JupyterApp):
         help="DEPRECATED, use tornado_settings"
     )
 
-    @observe('webapp_settings') 
+    @observe('webapp_settings')
     def _update_webapp_settings(self, change):
         self.log.warning("\n    webapp_settings is deprecated, use tornado_settings.\n")
         self.tornado_settings = change['new']
-    
+
     tornado_settings = Dict(config=True,
             help="Supply overrides for the tornado.web.Application that the "
                  "Jupyter notebook uses.")
-    
+
     terminado_settings = Dict(config=True,
             help='Supply overrides for terminado. Currently only supports "shell_command".')
 
@@ -751,15 +751,15 @@ class NotebookApp(JupyterApp):
     ssl_options = Dict(config=True,
             help="""Supply SSL options for the tornado HTTPServer.
             See the tornado docs for details.""")
-    
-    jinja_environment_options = Dict(config=True, 
+
+    jinja_environment_options = Dict(config=True,
             help="Supply extra arguments that will be passed to Jinja environment.")
 
     jinja_template_vars = Dict(
         config=True,
         help="Extra variables to supply to jinja templates when rendering.",
     )
-    
+
     enable_mathjax = Bool(True, config=True,
         help="""Whether to enable MathJax for typesetting math/TeX
 
@@ -792,7 +792,7 @@ class NotebookApp(JupyterApp):
         if not value.endswith('/'):
             value = value + '/'
         return value
-    
+
     base_project_url = Unicode('/', config=True, help="""DEPRECATED use base_url""")
 
     @observe('base_project_url')
@@ -802,16 +802,16 @@ class NotebookApp(JupyterApp):
 
     extra_static_paths = List(Unicode(), config=True,
         help="""Extra paths to search for serving static files.
-        
+
         This allows adding javascript/css to be available from the notebook server machine,
         or overriding individual files in the IPython"""
     )
-    
+
     @property
     def static_file_path(self):
         """return extra paths + the default location"""
         return self.extra_static_paths + [DEFAULT_STATIC_FILES_PATH]
-    
+
     static_custom_path = List(Unicode(),
         help="""Path to search for custom.js, css"""
     )
@@ -838,7 +838,7 @@ class NotebookApp(JupyterApp):
     extra_nbextensions_path = List(Unicode(), config=True,
         help="""extra paths to look for Javascript notebook extensions"""
     )
-    
+
     @property
     def nbextensions_path(self):
         """The path to look for Javascript notebook extensions"""
@@ -855,7 +855,7 @@ class NotebookApp(JupyterApp):
     websocket_url = Unicode("", config=True,
         help="""The base URL for websockets,
         if it differs from the HTTP server (hint: it almost certainly doesn't).
-        
+
         Should be in the form of an HTTP origin: ws[s]://hostname[:port]
         """
     )
@@ -873,7 +873,7 @@ class NotebookApp(JupyterApp):
             return u''
         static_url_prefix = self.tornado_settings.get("static_url_prefix", "static")
         return url_path_join(static_url_prefix, 'components', 'MathJax', 'MathJax.js')
-    
+
     @observe('mathjax_url')
     def _update_mathjax_url(self, change):
         new = change['new']
@@ -955,7 +955,7 @@ class NotebookApp(JupyterApp):
     def _default_info_file(self):
         info_file = "nbserver-%s.json" % os.getpid()
         return os.path.join(self.runtime_dir, info_file)
-    
+
     pylab = Unicode('disabled', config=True,
         help="""
         DISABLED: use %pylab or %matplotlib in the notebook to enable matplotlib.
@@ -1014,12 +1014,12 @@ class NotebookApp(JupyterApp):
     server_extensions = List(Unicode(), config=True,
         help=("DEPRECATED use the nbserver_extensions dict instead")
     )
-    
+
     @observe('server_extensions')
     def _update_server_extensions(self, change):
         self.log.warning("server_extensions is deprecated, use nbserver_extensions")
         self.server_extensions = change['new']
-        
+
     nbserver_extensions = Dict({}, config=True,
         help=("Dict of Python modules to load as notebook server extensions."
               "Entry values can be used to enable and disable the loading of"
@@ -1041,7 +1041,7 @@ class NotebookApp(JupyterApp):
         Maximum rate at which stream output can be sent on iopub before they are
         limited.""")
 
-    rate_limit_window = Float(3, config=True, help="""(sec) Time window used to 
+    rate_limit_window = Float(3, config=True, help="""(sec) Time window used to
         check the message and data rate limits.""")
 
     def parse_command_line(self, argv=None):
@@ -1054,7 +1054,7 @@ class NotebookApp(JupyterApp):
             if not os.path.exists(f):
                 self.log.critical("No such file or directory: %s", f)
                 self.exit(1)
-            
+
             # Use config here, to ensure that it takes higher priority than
             # anything that comes from the config dirs.
             c = Config()
@@ -1094,7 +1094,7 @@ class NotebookApp(JupyterApp):
         # self.log is a child of. The logging module dipatches log messages to a log
         # and all of its ancenstors until propagate is set to False.
         self.log.propagate = False
-        
+
         for log in app_log, access_log, gen_log:
             # consistent log output name (NotebookApp instead of tornado.access, etc.)
             log.name = self.log.name
@@ -1103,7 +1103,7 @@ class NotebookApp(JupyterApp):
         logger.propagate = True
         logger.parent = self.log
         logger.setLevel(self.log.level)
-    
+
     def init_webapp(self):
         """initialize tornado webapp and httpserver"""
         self.tornado_settings['allow_origin'] = self.allow_origin
@@ -1150,7 +1150,7 @@ class NotebookApp(JupyterApp):
             ssl_options.setdefault('ssl_version', ssl.PROTOCOL_TLSv1)
             if ssl_options.get('ca_certs', False):
                 ssl_options.setdefault('cert_reqs', ssl.CERT_REQUIRED)
-        
+
         self.login_handler_class.validate_security(self, ssl_options=ssl_options)
         self.http_server = httpserver.HTTPServer(self.web_app, ssl_options=ssl_options,
                                                  xheaders=self.trust_xheaders)
@@ -1176,7 +1176,7 @@ class NotebookApp(JupyterApp):
             self.log.critical('ERROR: the notebook server could not be started because '
                               'no available port could be found.')
             self.exit(1)
-    
+
     @property
     def display_url(self):
         ip = self.ip if self.ip else '[all ip addresses on your system]'
@@ -1215,7 +1215,7 @@ class NotebookApp(JupyterApp):
         if hasattr(signal, 'SIGINFO'):
             # only on BSD-based systems
             signal.signal(signal.SIGINFO, self._signal_info)
-    
+
     def _handle_sigint(self, sig, frame):
         """SIGINT handler spawns confirmation dialog"""
         # register more forceful signal handler for ^C^C case
@@ -1225,17 +1225,17 @@ class NotebookApp(JupyterApp):
         thread = threading.Thread(target=self._confirm_exit)
         thread.daemon = True
         thread.start()
-    
+
     def _restore_sigint_handler(self):
         """callback for restoring original SIGINT handler"""
         signal.signal(signal.SIGINT, self._handle_sigint)
-    
+
     def _confirm_exit(self):
         """confirm shutdown on ^C
-        
+
         A second ^C, or answering 'y' within 5s will cause shutdown,
         otherwise original SIGINT handler will be restored.
-        
+
         This doesn't work on Windows.
         """
         info = self.log.info
@@ -1258,14 +1258,14 @@ class NotebookApp(JupyterApp):
         # use IOLoop.add_callback because signal.signal must be called
         # from main thread
         ioloop.IOLoop.current().add_callback(self._restore_sigint_handler)
-    
+
     def _signal_stop(self, sig, frame):
         self.log.critical("received signal %s, stopping", sig)
         ioloop.IOLoop.current().stop()
 
     def _signal_info(self, sig, frame):
         print(self.notebook_info())
-    
+
     def init_components(self):
         """Check the components submodule, and warn if it's unclean"""
         # TODO: this should still check, but now we use bower, not git submodule
@@ -1276,10 +1276,10 @@ class NotebookApp(JupyterApp):
 
         Import the module, then call the load_jupyter_server_extension function,
         if one exists.
-        
+
         The extension API is experimental, and may change in future releases.
         """
-        
+
         # TODO: Remove me in notebook 5.0
         for modulename in self.server_extensions:
             # Don't override disable state of the extension if it already exist
@@ -1342,7 +1342,7 @@ class NotebookApp(JupyterApp):
 
     def cleanup_kernels(self):
         """Shutdown all kernels.
-        
+
         The kernels will shutdown themselves when this process no longer exists,
         but explicit shutdown allows the KernelManagers to cleanup the connection files.
         """
@@ -1353,7 +1353,8 @@ class NotebookApp(JupyterApp):
         "Return the current working directory and the server url information"
         info = self.contents_manager.info_string() + "\n"
         info += "%d active kernels \n" % len(self.kernel_manager._kernels)
-        return info + "The Jupyter Notebook is running at: %s" % self.display_url
+        # Format the info so that the URL fits on a single line in 80 char display
+        return info + "The Jupyter Notebook is running at:\n\r%s" % self.display_url
 
     def server_info(self):
         """Return a JSONable dict of information about this server."""
@@ -1375,7 +1376,7 @@ class NotebookApp(JupyterApp):
 
     def remove_server_info_file(self):
         """Remove the nbserver-<pid>.json file created for this server.
-        
+
         Ignores the error raised when the file has already been removed.
         """
         try:
@@ -1386,7 +1387,7 @@ class NotebookApp(JupyterApp):
 
     def start(self):
         """ Start the Notebook server app, after initialization
-        
+
         This method takes no arguments so all configuration and initialization
         must be done prior to calling this method."""
 
@@ -1420,7 +1421,7 @@ class NotebookApp(JupyterApp):
             except webbrowser.Error as e:
                 self.log.warning('No web browser found: %s.' % e)
                 browser = None
-            
+
             if self.file_to_run:
                 if not os.path.exists(self.file_to_run):
                     self.log.critical("%s does not exist" % self.file_to_run)
@@ -1471,7 +1472,7 @@ class NotebookApp(JupyterApp):
 
 def list_running_servers(runtime_dir=None):
     """Iterate over the server info files of running notebook servers.
-    
+
     Given a runtime directory, find nbserver-* files in the security directory,
     and yield dicts of their information, each one pertaining to
     a currently running notebook server instance.


### PR DESCRIPTION
Updated both notebook/notebookapp.py and docs/source/security.rst to add a newline before the URL - testing showed that the URL still did not fit in 80 columns because of the `[I 11:59:16.597 NotebookApp]` leader - changed to a `\n\r` to get the correct results. - Dropped the \ at the end idea as the logger output makes this pointless.

Tested that the clipboard gives the correct results. 

Minor change to currently untested feature so no test cases added. Existing tests still pass with one exception - `ERROR: Failure: ImportError (No module named fcntl)` which is as before for me.

Note: A number of lines in notebook/notebookapp.py were changed due to trailing spaces the only actual changes are on lines 1356-1357.