### PR TITLE
Add /api/shutdown handler

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -294,6 +294,7 @@ class NotebookWebApplication(web.Application):
         handlers.extend(load_handlers('services.nbconvert.handlers'))
         handlers.extend(load_handlers('services.kernelspecs.handlers'))
         handlers.extend(load_handlers('services.security.handlers'))
+        handlers.extend(load_handlers('services.shutdown'))
         
         handlers.append(
             (r"/nbextensions/(.*)", FileFindHandler, {

--- a/notebook/services/shutdown.py
+++ b/notebook/services/shutdown.py
@@ -1,0 +1,15 @@
+"""HTTP handler to shut down the notebook server.
+"""
+from tornado import web, ioloop
+from notebook.base.handlers import IPythonHandler
+
+class ShutdownHandler(IPythonHandler):
+    @web.authenticated
+    def post(self):
+        self.log.info("Shutting down on /api/shutdown request.")
+        ioloop.IOLoop.current().stop()
+
+
+default_handlers = [
+    (r"/api/shutdown", ShutdownHandler),
+]


### PR DESCRIPTION
First part of a solution for #1530. This allows an authenticated POST request to `/api/shutdown` to shut down the notebook server. I deliberately haven't proposed any UI for this yet; that can come in a later PR, or be done in extensions if we can't agree on it.