### PR TITLE
allow raises-exception to continue

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -310,7 +310,18 @@ define([
         }
 
         if (stop_on_error === undefined) {
-            stop_on_error = true;
+            if (this.metadata !== undefined && 
+                    this.metadata.tags !== undefined) {
+                if (this.metadata.tags.indexOf('raises-exception') !== -1) {
+                    stop_on_error = false;
+                } else if (this.metadata.tags.indexOf('nbval-raises-exception') !== -1) {
+                    stop_on_error = false;
+                } else {
+                    stop_on_error = true;
+                }
+            } else {
+               stop_on_error = true;
+            }
         }
 
         this.clear_output(false, true);

--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -314,8 +314,6 @@ define([
                     this.metadata.tags !== undefined) {
                 if (this.metadata.tags.indexOf('raises-exception') !== -1) {
                     stop_on_error = false;
-                } else if (this.metadata.tags.indexOf('nbval-raises-exception') !== -1) {
-                    stop_on_error = false;
                 } else {
                     stop_on_error = true;
                 }


### PR DESCRIPTION
Fixes #2516  — allows for code execution to continue if a tag “raises-exception” or “nbval-raises-exception” is encountered