### PR TITLE
Allow session of type other than notebook.

### DIFF
--- a/notebook/static/tree/js/sessionlist.js
+++ b/notebook/static/tree/js/sessionlist.js
@@ -71,13 +71,18 @@ define([
         var len = data.length;
         var nb_path;
         for (var i=0; i<len; i++) {
-            nb_path = data[i].notebook.path;
-            this.sessions[nb_path] = {
-                id: data[i].id,
-                kernel: {
-                  name: data[i].kernel.name
-                }
-            };
+            // The classic notebook only knows about sessions for notebooks,
+            // but the server now knows about more general sessions for
+            // things like consoles.
+            if (data[i].type === 'notebook') {
+                nb_path = data[i].notebook.path;
+                this.sessions[nb_path] = {
+                    id: data[i].id,
+                    kernel: {
+                    name: data[i].kernel.name
+                    }
+                };
+            }
         }
         this.events.trigger('sessions_loaded.Dashboard', this.sessions);
     };


### PR DESCRIPTION
The notebook server session API now allows session for things other than notebooks (consoles, etc.). However, the frontend was assuming a notebook type. This was causing problems when jupyterlab had consoles running. This adds a test to make sure the classic notebook only deals with notebook sessions.

This will need to be backported into a 5.x bug fix release for the JupyterLab beta.

@gnestor 