### PR TITLE
Protect against hypothetical future where javascript stops using surrogate pairs

### DIFF
--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -1031,7 +1031,8 @@ define([
             if (char_code >= 0xD800 && char_code <= 0xDBFF) {
                 var next_char_code = text.charCodeAt(i+1);
                 if (next_char_code >= 0xDC00 && next_char_code <= 0xDFFF) {
-                    char_idx -= 1;
+                    char_idx--;
+                    i++;
                 }
             }
         }
@@ -1046,7 +1047,8 @@ define([
             if (char_code >= 0xD800 && char_code <= 0xDBFF) {
                 var next_char_code = text.charCodeAt(i+1);
                 if (next_char_code >= 0xDC00 && next_char_code <= 0xDFFF) {
-                    js_idx += 1;
+                    js_idx++;
+                    i++;
                 }
             }
         }

--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -1025,11 +1025,14 @@ define([
     // to js offset (with surrogate pairs taking two spots).
     function js_idx_to_char_idx (js_idx, text) {
         var char_idx = js_idx;
-        for (var i = 0; i < text.length && i < js_idx; i++) {
+        for (var i = 0; i + 1 < text.length && i < js_idx; i++) {
             var char_code = text.charCodeAt(i);
-            // check for the first half of a surrogate pair
-            if (char_code >= 0xD800 && char_code < 0xDC00) {
-                char_idx -= 1;
+            // check for surrogate pair
+            if (char_code >= 0xD800 && char_code <= 0xDBFF) {
+                var next_char_code = text.charCodeAt(i+1);
+                if (next_char_code >= 0xDC00 && next_char_code <= 0xDFFF) {
+                    char_idx -= 1;
+                }
             }
         }
         return char_idx;
@@ -1037,11 +1040,14 @@ define([
 
     function char_idx_to_js_idx (char_idx, text) {
         var js_idx = char_idx;
-        for (var i = 0; i < text.length && i < js_idx; i++) {
+        for (var i = 0; i + 1 < text.length && i < js_idx; i++) {
             var char_code = text.charCodeAt(i);
-            // check for the first half of a surrogate pair
-            if (char_code >= 0xD800 && char_code < 0xDC00) {
-                js_idx += 1;
+            // check for surrogate pair
+            if (char_code >= 0xD800 && char_code <= 0xDBFF) {
+                var next_char_code = text.charCodeAt(i+1);
+                if (next_char_code >= 0xDC00 && next_char_code <= 0xDFFF) {
+                    js_idx += 1;
+                }
             }
         }
         return js_idx;

--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -1053,6 +1053,12 @@ define([
         return js_idx;
     }
 
+    if ('𝐚'.length === 1) {
+        // If javascript fixes string indices of non-BMP characters,
+        // don't keep shifting offsets to compensate for surrogate pairs
+        char_idx_to_js_idx = js_idx_to_char_idx = function (idx, text) { return idx; };
+    }
+
     // Test if a drag'n'drop event contains a file (as opposed to an HTML
     // element/text from the document)
     var dnd_contain_file = function(event) {

--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -80,7 +80,7 @@ define([
                 username : this.username,
                 session : this.session_id,
                 msg_type : msg_type,
-                version : "5.0"
+                version : "5.2",
             },
             metadata : metadata || {},
             content : content,


### PR DESCRIPTION
to avoid introducing the inverse of https://github.com/jupyter/jupyter_client/issues/259

and check surrogate pairs more strictly, in case of wonky unicode that shouldn't happen but is technically possible.

bumps protocol version to 5.2 for explicit unicode fix (https://github.com/jupyter/jupyter_client/pull/262)

follow-up to #2509