### PR TITLE
Changes single ` markdown highlighting

### DIFF
--- a/notebook/static/notebook/less/renderedhtml.less
+++ b/notebook/static/notebook/less/renderedhtml.less
@@ -46,10 +46,14 @@
 
     pre {
         margin: 1em 2em;
+        padding: 0px;
         background-color: @body-bg;
     }
 
-    code {background-color: #eff0f1;}
+    code {
+        background-color: #eff0f1;
+        padding: 1px 5px;
+    }
 
     pre code {background-color: @body-bg;}
 
@@ -57,7 +61,6 @@
         border:             0;
         color:              @text-color;
         font-size:          100%;
-        padding:            0px;
     }
 
     blockquote {margin: 1em 2em;}

--- a/notebook/static/notebook/less/renderedhtml.less
+++ b/notebook/static/notebook/less/renderedhtml.less
@@ -44,11 +44,17 @@
         background-color: @rendered_html_border_color;
     }
 
-    pre {margin: 1em 2em;}
+    pre {
+        margin: 1em 2em;
+        background-color: @body-bg;
+    }
+
+    code {background-color: #eff0f1;}
+
+    pre code {background-color: @body-bg;}
 
     pre, code {
         border:             0;
-        background-color:   @body-bg;
         color:              @text-color;
         font-size:          100%;
         padding:            0px;


### PR DESCRIPTION
Changes highlighting of text surrounded by single ` in markdown cells by
adding gray background under the text. Highlighting should resemble the
stack-overflow highlighting.

Before:
![before](https://user-images.githubusercontent.com/9467741/27046022-44aaba0c-4fa3-11e7-8095-6bfa8b23f032.png)

After:
![after](https://user-images.githubusercontent.com/9467741/27053295-257e01f6-4fbd-11e7-9520-4a2a1cfe9303.png)


Signed-off-by: Ondrej <o.jariabka@gmail.com>