### PR TITLE
Change comment identifier to be valid JavaScript

### DIFF
--- a/docs/source/frontend_config.rst
+++ b/docs/source/frontend_config.rst
@@ -61,7 +61,7 @@ four spaces. Enter the following code snippet in your JavaScript console::
     var config = cell.config;
     var patch = {
           CodeCell:{
-            cm_config:{indentUnit: null} # only change here.
+            cm_config:{indentUnit: null} // only change here.
           }
         }
     config.update(patch)


### PR DESCRIPTION
Copying and pasting the snippet with `#` as a comment identifier caused an error, so use `//` instead.