### PR TITLE
added robots.txt

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -689,5 +689,6 @@ path_regex = r"(?P<path>(?:(?:/[^/]+)+|/?))"
 
 default_handlers = [
     (r".*/", TrailingSlashHandler),
-    (r"api", APIVersionHandler)
+    (r"api", APIVersionHandler),
+    (r'/(robots\.txt|favicon\.ico)', web.StaticFileHandler),
 ]

--- a/notebook/static/favicon.ico
+++ b/notebook/static/favicon.ico
@@ -1,0 +1,1 @@
+base/images/favicon.ico

--- a/notebook/static/robots.txt
+++ b/notebook/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: / 


### PR DESCRIPTION
This commit fixes issue #1387 by adding a file `robots.txt`
that makes robots go away.

This commit is also similar to
https://github.com/jupyter/nbviewer/commit/316665e5d7eee4cba9010d12803df94bf993fc40
as it also adds the `favicon.ico`.