### PR TITLE
Don't double encode item_path for edit button

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -1036,7 +1036,7 @@ define([
             var item_path = utils.encode_uri_components(item.path);
             // Handle ipynb files differently
             var item_type = item_path.endsWith('.ipynb') ? 'notebooks' : 'edit';
-            window.open(utils.url_path_join(that.base_url, item_type, utils.encode_uri_components(item_path)), IPython._target);
+            window.open(utils.url_path_join(that.base_url, item_type, item_path), IPython._target);
       	});
     };
 


### PR DESCRIPTION
This is a secondary issue found in #2585.