### PR TITLE
Add id=favicon in templates

### DIFF
--- a/notebook/templates/edit.html
+++ b/notebook/templates/edit.html
@@ -2,7 +2,7 @@
 
 {% block title %}{{page_title}}{% endblock %}
 
-{% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="{{static_url("base/images/favicon-file.ico") }}">{% endblock %}
+{% block favicon %}<link id="favicon" rel="shortcut icon" type="image/x-icon" href="{{static_url("base/images/favicon-file.ico") }}">{% endblock %}
 
 {% block stylesheet %}
 <link rel="stylesheet" href="{{ static_url('components/codemirror/lib/codemirror.css') }}">

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -1,6 +1,6 @@
 {% extends "page.html" %}
 
-{% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="{{static_url("base/images/favicon-notebook.ico") }}">{% endblock %}
+{% block favicon %}<link id="favicon" rel="shortcut icon" type="image/x-icon" href="{{static_url("base/images/favicon-notebook.ico") }}">{% endblock %}
 
 {% block stylesheet %}
 

--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
 
     <title>{% block title %}Jupyter Notebook{% endblock %}</title>
-    {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="{{static_url("base/images/favicon.ico") }}">{% endblock %}
+    {% block favicon %}<link id="favicon" rel="shortcut icon" type="image/x-icon" href="{{static_url("base/images/favicon.ico") }}">{% endblock %}
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link rel="stylesheet" href="{{static_url("components/jquery-ui/themes/smoothness/jquery-ui.min.css") }}" type="text/css" />
     <link rel="stylesheet" href="{{static_url("components/jquery-typeahead/dist/jquery.typeahead.min.css") }}" type="text/css" />

--- a/notebook/templates/terminal.html
+++ b/notebook/templates/terminal.html
@@ -2,7 +2,7 @@
 
 {% block title %}{{page_title}}{% endblock %}
 
-{% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="{{static_url("base/images/favicon-terminal.ico") }}">{% endblock %}
+{% block favicon %}<link id="favicon" rel="shortcut icon" type="image/x-icon" href="{{static_url("base/images/favicon-terminal.ico") }}">{% endblock %}
 
 {% block bodyclasses %}terminal-app {{super()}}{% endblock %}
 


### PR DESCRIPTION
The new dynamic favicon-changing code looks for an existing favicon in the DOM with id 'favicon'. This uses that id in the templates, so we don't end up with two favicon links in the page.

I was hoping that this would fix some issues I'm having with the favicon getting stuck, but it doesn't seem to. :-( It seems like the right thing to do anyway.