### PR TITLE
Update link of messaging  in Jupyter

### DIFF
--- a/docs/source/examples/Notebook/What is the Jupyter Notebook.ipynb
+++ b/docs/source/examples/Notebook/What is the Jupyter Notebook.ipynb
@@ -111,7 +111,7 @@
     "\n",
     "The default kernel runs Python code. The notebook provides a simple way for users to pick which of these kernels is used for a given notebook. \n",
     "\n",
-    "Each of these kernels communicate with the notebook web application and web browser using a JSON over ZeroMQ/WebSockets message protocol that is described [here](http://ipython.org/ipython-doc/dev/development/messaging.html). Most users don't need to know about these details, but it helps to understand that \"kernels run code.\""
+    "Each of these kernels communicate with the notebook web application and web browser using a JSON over ZeroMQ/WebSockets message protocol that is described [here](https://jupyter-client.readthedocs.io/en/latest/messaging.html#messaging). Most users don't need to know about these details, but it helps to understand that \"kernels run code.\""
    ]
   },
   {


### PR DESCRIPTION
The link given in the docs is for an old version of IPython and it has a link to the newer docs i.e. https://jupyter-client.readthedocs.io