### PR TITLE
Capitalization of 'Edit cell Attachments' dialog title

### DIFF
--- a/notebook/static/notebook/js/celltoolbarpresets/attachments.js
+++ b/notebook/static/notebook/js/celltoolbarpresets/attachments.js
@@ -18,7 +18,7 @@ define([
             cell.unrender();
             cell.render();
           },
-          name: 'cell',
+          name: 'Cell',
           notebook: cell.notebook,
           keyboard_manager: cell.keyboard_manager
         });


### PR DESCRIPTION
Use title case for the attachments editing dialog, as it's already used for the metadata editing dialog in [default.js](https://github.com/jupyter/notebook/blob/master/notebook/static/notebook/js/celltoolbarpresets/default.js#L18).

resolves #2565