### PR TITLE
Log how many kernels need shutting down

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1359,7 +1359,8 @@ class NotebookApp(JupyterApp):
         The kernels will shutdown themselves when this process no longer exists,
         but explicit shutdown allows the KernelManagers to cleanup the connection files.
         """
-        self.log.info('Shutting down kernels')
+        self.log.info('Shutting down %d kernels',
+                      len(self.kernel_manager.list_kernel_ids()))
         self.kernel_manager.shutdown_all()
 
     def notebook_info(self):


### PR DESCRIPTION
While responding to ipython/ipython#10679, it occurred to me that it would be useful to know how many kernels the server is attempting to shut down.