### PR TITLE
More specific check for missing body data

### DIFF
--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -615,7 +615,7 @@ define([
          * until we are building an actual request
          */
         var val = $('body').data(key);
-        if (!val)
+        if (typeof val === 'undefined')
             return val;
         return decodeURIComponent(val);
     };


### PR DESCRIPTION
As described in #2611, `0` is a valid file name, giving `data-notebook-path="0"`. jQuery helpfully coerces the string to a number, and because 0 is false-y, it was returned directly. Other numbers pass through `decodeURIComponent()`, which coerces them back to a string.

I think this check was meant to prevent returning `'undefined'` as a string, so I've made it check specifically for undefined, rather than false-y objects in general. The empty string passes through `decodeURIComponent()` unchanged, so that's OK.

Closes gh-2611