### PR TITLE
Cell tags UI: Ensure close button does not wrap

### DIFF
--- a/notebook/static/notebook/less/tagbar.less
+++ b/notebook/static/notebook/less/tagbar.less
@@ -62,6 +62,7 @@
 
 .cell-tag {
     background-color: #fff;
+    white-space: nowrap;
 }
 
 .tags-input input[type=text]:focus {


### PR DESCRIPTION
Add CSS styling to prevent close button from line-wrapping inside the cell tag elements.

Closes #2459 (minimal fix).