### PR TITLE
Upgrade xterm.js to newly released 2.8.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,6 @@
     "requirejs": "~2.1",
     "text-encoding": "~0.1",
     "underscore": "components/underscore#~1.8.3",
-    "xterm.js": "sourcelair/xterm.js#~2.7.0"
+    "xterm.js": "sourcelair/xterm.js#~2.8.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/2256

/CC @gnestor @takluyver