### PR TITLE
Improvements to sorting file list

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -102,10 +102,8 @@ define([
         this.selected = [];
         this.sort_function = name_sorter(1);
         // 0 => descending, 1 => ascending
-        this.sort_state = {
-            'last-modified': 0,
-            'sort-name': 1
-        };
+        this.sort_id = 'sort-name';
+        this.sort_direction = 1;
         this._max_upload_size_mb = 25;
         this.EDIT_MIMETYPES = [
           'application/javascript',
@@ -224,15 +222,16 @@ define([
                 // Clear sort indications in UI
                 $(".sort-action i").removeClass("fa-arrow-up").removeClass("fa-arrow-down")
 
-                if (that.sort_state[sort_on] == 0) {
-                    that.sort_list(sort_on, 1);
-                    $("#" + sort_on + " i").addClass("fa-arrow-down");
-                    that.sort_state[sort_on] = 1;
-                } else {
+                if ((that.sort_id === sort_on) && (that.sort_direction === 1)) {
                     that.sort_list(sort_on, 0);
                     $("#" + sort_on + " i").addClass("fa-arrow-up");
-                    that.sort_state[sort_on] = 0;
+                    that.sort_direction = 0;
+                } else {
+                    that.sort_list(sort_on, 1);
+                    $("#" + sort_on + " i").addClass("fa-arrow-down");
+                    that.sort_direction = 1;
                 }
+                that.sort_id = sort_on;
             });
         }
     };

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -112,13 +112,13 @@ data-server-root="{{server_root}}"
               <div id="last_modified" class="pull-right sort_button">
                   <span class="btn btn-xs btn-default sort-action" id="last-modified">
                       Last Modified
-                      <i class="fa fa-arrow-up"></i>
+                      <i class="fa"></i>
                   </span>
               </div>
               <div id="sort_name" class="pull-right sort_button">
                   <span class="btn btn-xs btn-default sort-action" id="sort-name">
                       Name
-                      <i class="fa fa-arrow-up"></i>
+                      <i class="fa fa-arrow-down"></i>
                   </span>
               </div>
             </div>


### PR DESCRIPTION
Sort the file models before displaying them, rather than sorting the DOM elements. This makes it easy to keep the sort order when we refresh the list.

I have also adjusted the UI so that the sort indicator arrow is only shown on the currently selected sort button, rather than showing arrows on both.

Closes gh-1218
Closes gh-1942