### PR TITLE
Use StaticFileHandler when files are local

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -472,11 +472,7 @@ class AuthenticatedFileHandler(IPythonHandler, web.StaticFileHandler):
 
     @web.authenticated
     def get(self, path):
-        if os.path.splitext(path)[1] == '.ipynb':
-            name = path.rsplit('/', 1)[-1]
-            self.set_header('Content-Type', 'application/json')
-            self.set_header('Content-Disposition','attachment; filename="%s"' % escape.url_escape(name))
-        elif self.get_argument("download", False):
+        if os.path.splitext(path)[1] == '.ipynb' or self.get_argument("download", False):
             name = path.rsplit('/', 1)[-1]
             self.set_header('Content-Disposition','attachment; filename="%s"' % escape.url_escape(name))
 

--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -479,7 +479,11 @@ class AuthenticatedFileHandler(IPythonHandler, web.StaticFileHandler):
         return web.StaticFileHandler.get(self, path)
     
     def get_content_type(self):
-        _, name = self.absolute_path.rsplit('/', 1)
+        path = self.absolute_path.strip('/')
+        if '/' in path:
+            _, name = path.rsplit('/', 1)
+        else:
+            name = path
         if name.endswith('.ipynb'):
             return 'application/x-ipynb+json'
         else:

--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -5,6 +5,7 @@
 
 import functools
 import json
+import mimetypes
 import os
 import re
 import sys
@@ -481,6 +482,17 @@ class AuthenticatedFileHandler(IPythonHandler, web.StaticFileHandler):
 
         return web.StaticFileHandler.get(self, path)
     
+    def get_content_type(self):
+        _, name = self.absolute_path.rsplit('/', 1)
+        if name.endswith('.ipynb'):
+            return 'application/x-ipynb+json'
+        else:
+            cur_mime = mimetypes.guess_type(name)[0]
+            if cur_mime == 'text/plain':
+                return 'text/plain; charset=UTF-8'
+            else:
+                return super(AuthenticatedFileHandler, self).get_content_type()
+
     def set_headers(self):
         super(AuthenticatedFileHandler, self).set_headers()
         # disable browser caching, rely on 304 replies for savings

--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -475,7 +475,10 @@ class AuthenticatedFileHandler(IPythonHandler, web.StaticFileHandler):
             name = path.rsplit('/', 1)[-1]
             self.set_header('Content-Type', 'application/json')
             self.set_header('Content-Disposition','attachment; filename="%s"' % escape.url_escape(name))
-        
+        elif self.get_argument("download", False):
+            name = path.rsplit('/', 1)[-1]
+            self.set_header('Content-Disposition','attachment; filename="%s"' % escape.url_escape(name))
+
         return web.StaticFileHandler.get(self, path)
     
     def set_headers(self):

--- a/notebook/files/handlers.py
+++ b/notebook/files/handlers.py
@@ -26,6 +26,13 @@ class FilesHandler(IPythonHandler):
     @web.authenticated
     def get(self, path, include_body=True):
         cm = self.contents_manager
+
+        if cm.files_handler_class:
+            return cm.files_handler_class(self.application, self.request, path=cm.root_dir)._execute(
+                [t(self.request) for t in self.application.transforms],
+                path
+            )
+
         if cm.is_hidden(path):
             self.log.info("Refusing to serve hidden file, via 404 Error")
             raise web.HTTPError(404)

--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -28,6 +28,7 @@ from notebook.utils import (
     is_hidden, is_file_hidden,
     to_api_path,
 )
+from notebook.base.handlers import AuthenticatedFileHandler
 
 try:
     from os.path import samefile
@@ -145,6 +146,10 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
     @default('checkpoints_class')
     def _checkpoints_class_default(self):
         return FileCheckpoints
+
+    @default('files_handler_class')
+    def _files_handler_class_default(self):
+        return AuthenticatedFileHandler
 
     def is_hidden(self, path):
         """Does the API style path correspond to a hidden directory or file?

--- a/notebook/services/contents/manager.py
+++ b/notebook/services/contents/manager.py
@@ -28,6 +28,7 @@ from traitlets import (
     default,
 )
 from ipython_genutils.py3compat import string_types
+from notebook.base.handlers import IPythonHandler
 
 copy_pat = re.compile(r'\-Copy\d*\.')
 
@@ -128,6 +129,8 @@ class ContentsManager(LoggingConfigurable):
             parent=self,
             log=self.log,
         )
+
+    files_handler_class = Type(IPythonHandler, allow_none=True, config=True)
 
     # ContentsManager API part 1: methods that must be
     # implemented in subclasses.

--- a/notebook/tests/test_files.py
+++ b/notebook/tests/test_files.py
@@ -95,7 +95,7 @@ class FilesTest(NotebookTestBase):
 
         r = self.request('GET', 'files/test.txt')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual('text/plain', r.headers['content-type'])
+        self.assertEqual(r.headers['content-type'], 'text/plain; charset=UTF-8')
         self.assertEqual(r.text, 'foobar')
     
     def test_download(self):

--- a/notebook/tests/test_files.py
+++ b/notebook/tests/test_files.py
@@ -95,7 +95,7 @@ class FilesTest(NotebookTestBase):
 
         r = self.request('GET', 'files/test.txt')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.headers['content-type'], 'text/plain; charset=UTF-8')
+        self.assertEqual('text/plain', r.headers['content-type'])
         self.assertEqual(r.text, 'foobar')
     
     def test_download(self):


### PR DESCRIPTION
Implements the set of changes described at #968, and fixes #1024. 

In summary, a `files_handler_class` is added as an attribute to `ContentsManager`, specifying a custom request handler for the `/files` requests. For `FileContentsManager`, this is set to `AuthenticatedFilesHandler` (which is a light proxy over Tornado's `StaticFileHandler`).

Using tornado's `StaticFileHandler` class for serving local files is more efficient and enables HTTP Range requests, which are necessary for seekable video embeds (see #1024).

An additional change is made to the `test_contents_manager` test case to allow both `text/plain` 
and `text/plain; charset=UTF-8` as acceptable `content-type`s. The reason being that while `FilesHandler` explicitly specifies the content type ([here](https://github.com/jupyter/notebook/blob/master/notebook/files/handlers.py#L50)), Tornado's static file handler just sets the content type to the mime-type of the file, which doesn't include charset; overwriting that would be awkward.

This is my first time digging through this codebase so any changes/comments/suggestions would be much appreciated.