### PR TITLE
Don’t check XSRF token on CSP reports

### DIFF
--- a/notebook/services/security/handlers.py
+++ b/notebook/services/security/handlers.py
@@ -17,6 +17,10 @@ class CSPReportHandler(APIHandler):
         """Don't check origin when reporting origin-check violations!"""
         return True
 
+    def check_xsrf_cookie(self):
+        # don't check XSRF for CSP reports
+        return
+
     @json_errors
     @web.authenticated
     def post(self):


### PR DESCRIPTION
Browsers send these requests, we can’t add xsrf tokens to them.