### PR TITLE
avoid modifying settings['headers'] in add_default_headers

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -68,13 +68,14 @@ class AuthenticatedHandler(web.RequestHandler):
         ])
 
     def set_default_headers(self):
-        headers = self.settings.get('headers', {})
+        headers = {}
+        headers.update(self.settings.get('headers', {}))
 
         if "Content-Security-Policy" not in headers:
             headers["Content-Security-Policy"] = self.content_security_policy
-
+        
         # Allow for overriding headers
-        for header_name,value in headers.items() :
+        for header_name, value in headers.items():
             try:
                 self.set_header(header_name, value)
             except Exception as e:

--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -64,7 +64,7 @@ class AuthenticatedHandler(web.RequestHandler):
         return '; '.join([
             "frame-ancestors 'self'",
             # Make sure the report-uri is relative to the base_url
-            "report-uri " + url_path_join(self.base_url, csp_report_uri),
+            "report-uri " + self.settings.get('csp_report_uri', url_path_join(self.base_url, csp_report_uri)),
         ])
 
     def set_default_headers(self):


### PR DESCRIPTION
Use a copy to avoid writing content security policy into settings['headers'], which can be a problem because APIHandlers have a stricter CSP than page handlers, adding `default-src: 'none'`.

If an API request is made before the first page request, pages would fail to load due to CSP violations because the API CSP would be saved in `settings['headers']` and used for all subsequent requests.

cc @tkinz27 @kalvinnchau who reported this on Gitter