### PR TITLE
Render the logout page without auth tokens

### DIFF
--- a/notebook/templates/logout.html
+++ b/notebook/templates/logout.html
@@ -1,5 +1,12 @@
 {% extends "page.html" %}
 
+{# This template is rendered in response to an authenticated request, so the
+   user is technically logged in. But when the user sees it, the cookie is
+   cleared by the Javascript, so we should render this as if the user was logged
+   out, without e.g. authentication tokens.
+#}
+{% set logged_in = False %}
+
 {% block stylesheet %}
 {{super()}}
 <link rel="stylesheet" href="{{ static_url("auth/css/override.css") }}" type="text/css" />


### PR DESCRIPTION
The user is technically still logged in when the logout page is produced, but this is not obvious to the user, and they may leave the page open.

This ensures that it is rendered without information such as auth tokens which should only be available to a logged-in user.