### PR TITLE
clear equation labels on typesetting so that labels don't stop equations from rendering

### DIFF
--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -942,7 +942,10 @@ define([
         }
         return $el.map(function(){
             // MathJax takes a DOM node: $.map makes `this` the context
-            return MathJax.Hub.Queue(["Typeset", MathJax.Hub, this]);
+            return MathJax.Hub.Queue(
+                ["Typeset", MathJax.Hub, this],
+                ["resetEquationNumbers",MathJax.InputJax.TeX]
+            );
         });
     };
 


### PR DESCRIPTION
This tiny change makes it possible to use labels in the live notebook by constantly clearing the id storage (which otherwise would stop it from rendering since the id would be present more than once).