### PR TITLE
Fix hidden prompt overlay button

### DIFF
--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -77,7 +77,6 @@ define([
 
     OutputArea.prototype.style = function () {
         this.collapse_button.hide();
-        this.prompt_overlay.hide();
         
         this.wrapper.addClass('output_wrapper');
         this.element.addClass('output');


### PR DESCRIPTION
Closes https://github.com/jupyter/notebook/issues/2590

It looks like `this.collapsed` is returning `false` and therefore `this.prompt_overlay.show()` is not being called: https://github.com/jupyter/notebook/blob/master/notebook/static/notebook/js/outputarea.js#L155