### PR TITLE
Reset the target cell's undo history after merge_cells

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1782,6 +1782,9 @@ define([
 
         // Delete the other cells
         this.delete_cells(indices);
+        
+        // Reset the target cell's undo history
+        target.code_mirror.clearHistory();
 
         this.select(this.find_cell_index(target));
     };


### PR DESCRIPTION
Closes https://github.com/jupyter/notebook/issues/2207

This will prevent the scenario where a user merges one or more cells, does an undo, types something, and loses the contents of the other cells that were merged into this cell.