### PR TITLE
Only show busy favicon when execution lasts > 1s

### DIFF
--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -1103,6 +1103,10 @@ define([
         link.type = 'image/x-icon';
         link.rel = 'shortcut icon';
         link.href = utils.url_path_join(utils.get_body_data('baseUrl'), src);
+        if (link.href === oldLink.href) {
+            // This favicon is already set, don't modify the DOM.
+            return;
+        }
         if (oldLink) document.head.removeChild(oldLink);
         document.head.appendChild(link);
     };

--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -1103,7 +1103,7 @@ define([
         link.type = 'image/x-icon';
         link.rel = 'shortcut icon';
         link.href = utils.url_path_join(utils.get_body_data('baseUrl'), src);
-        if (link.href === oldLink.href) {
+        if (oldLink && (link.href === oldLink.href)) {
             // This favicon is already set, don't modify the DOM.
             return;
         }

--- a/notebook/static/notebook/js/notificationarea.js
+++ b/notebook/static/notebook/js/notificationarea.js
@@ -42,11 +42,19 @@ define([
         var $modal_ind_icon = $("#modal_indicator");
         var $readonly_ind_icon = $('#readonly-indicator');
         var $body = $('body');
+        var busy_favicon_timer = -1;
         
         var set_busy_favicon = function(on) {
             if (on) {
-                utils.change_favicon('/static/base/images/favicon-busy-1.ico');
+                // Only show the busy icon if execution lasts > 1s
+                // This is to avoid rapidly switching icons and making lots of
+                // HTTP requests.
+                clearTimeout(busy_favicon_timer);
+                busy_favicon_timer = setTimeout(function() {
+                    utils.change_favicon('/static/base/images/favicon-busy-1.ico');
+                }, 1000);
             } else {
+                clearTimeout(busy_favicon_timer);
                 utils.change_favicon('/static/base/images/favicon-notebook.ico');
             }
         };


### PR DESCRIPTION
This avoids making lots of HTTP requests as we rapidly change the favicon between the 'notebook' (idle) and 'busy' icons. Now it should be no more than one per second in the most pathological case.

Closes gh-2673