### PR TITLE
Fix jitter caused by rounding height.

### DIFF
--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -966,7 +966,8 @@ define([
             // Fix the output div's height if the clear_output is waiting for
             // new output (it is being used in an animation).
             if (!ignore_clear_queue && this.clear_queued) {
-                var height = this.element.height();
+                // this.element.height() rounds the height, so we get the exact value
+                var height = this.element[0].getBoundingClientRect().height;
                 this.element.height(height);
                 this.clear_queued = false;
             }


### PR DESCRIPTION
Fixes #2668.

Before height rounding fix (notice that the cell below the interact jitters its height):
![jitter](https://user-images.githubusercontent.com/192614/28619862-794469e6-71d8-11e7-8a58-a70a4904b3bf.gif)

After:
![jitterfixed](https://user-images.githubusercontent.com/192614/28619867-7fbb3430-71d8-11e7-8e4f-a6316502e0dc.gif)
