### PR TITLE
Restore flat edge of rendered html code block

### DIFF
--- a/notebook/static/notebook/less/renderedhtml.less
+++ b/notebook/static/notebook/less/renderedhtml.less
@@ -52,7 +52,6 @@
 
     code {
         background-color: #eff0f1;
-        padding: 1px 5px;
     }
 
     pre code {background-color: @body-bg;}

--- a/notebook/static/notebook/less/renderedhtml.less
+++ b/notebook/static/notebook/less/renderedhtml.less
@@ -54,12 +54,16 @@
         background-color: #eff0f1;
     }
 
+    p code {
+        padding: 1px 5px;
+    }
+
     pre code {background-color: @body-bg;}
 
     pre, code {
-        border:             0;
-        color:              @text-color;
-        font-size:          100%;
+        border: 0;
+        color: @text-color;
+        font-size: 100%;
     }
 
     blockquote {margin: 1em 2em;}


### PR DESCRIPTION
The extra padding causes the first line of each markdown rendered code block to be indented, but does not indent the rest of the code block, resulting in a jagged left edge. Removing this bit of CSS restores a flat left edge.

You can verify this by trying to render the following:

    abc
        def
        ghi

This fix will revert 533aea11fdcb3a358add0ae4cbe41c97dac2cf2c.

![screenshot from 2017-07-26 15-39-22](https://user-images.githubusercontent.com/266668/28640216-03e142d2-7219-11e7-9740-ec8e927b11c1.png)