### PR TITLE
Remove quotes around URL in tornado_settings example

### DIFF
--- a/docs/source/public_server.rst
+++ b/docs/source/public_server.rst
@@ -289,7 +289,7 @@ with the following configuration setting in
 
     c.NotebookApp.tornado_settings = {
         'headers': {
-            'Content-Security-Policy': "frame-ancestors 'https://mywebsite.example.com' 'self' "
+            'Content-Security-Policy': "frame-ancestors https://mywebsite.example.com 'self' "
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/jupyter/notebook/issues/1639