### PR TITLE
Add missing codemirror keymaps to keyboard shortcuts dialog

### DIFF
--- a/notebook/static/notebook/js/quickhelp.js
+++ b/notebook/static/notebook/js/quickhelp.js
@@ -42,6 +42,11 @@ define([
             { shortcut: "Alt-Right",  help:i18n.msg._("go one word right")  },
             { shortcut: "Alt-Backspace",      help:i18n.msg._("delete word before")  },
             { shortcut: "Alt-Delete",         help:i18n.msg._("delete word after")  },
+            { shortcut: "Ctrl-k",   help:i18n.msg._("emacs-style line kill")  },
+            { shortcut: "Cmd-Backspace",   help:i18n.msg._("delete line left of cursor")  },
+            { shortcut: "Cmd-Delete",   help:i18n.msg._("delete line right of cursor")  },
+            { shortcut: cmd_ctrl + "Shift-z",   help:i18n.msg._("redo")  },
+            { shortcut: "Shift-Cmd-u",   help:i18n.msg._("redo selection")  }
         ];
     } else {
         // PC specific
@@ -54,6 +59,8 @@ define([
             { shortcut: "Ctrl-Right", help:i18n.msg._("go one word right")  },
             { shortcut: "Ctrl-Backspace", help:i18n.msg._("delete word before")  },
             { shortcut: "Ctrl-Delete",    help:i18n.msg._("delete word after")  },
+            { shortcut: cmd_ctrl + "y",   help:i18n.msg._("redo")  },
+            { shortcut: "Alt-u",   help:i18n.msg._("redo selection")  }
         ];
     }
 
@@ -64,8 +71,11 @@ define([
         { shortcut: cmd_ctrl + "[",   help:i18n.msg._("dedent")  },
         { shortcut: cmd_ctrl + "a",   help:i18n.msg._("select all")  },
         { shortcut: cmd_ctrl + "z",   help:i18n.msg._("undo")  },
-        { shortcut: cmd_ctrl + "Shift-z",   help:i18n.msg._("redo")  },
-        { shortcut: cmd_ctrl + "y",   help:i18n.msg._("redo")  },
+        { shortcut: cmd_ctrl + "/",   help:i18n.msg._("comment")  },
+        { shortcut: "esc",   help:i18n.msg._("single selection")  },
+        { shortcut: cmd_ctrl + "d",   help:i18n.msg._("delete whole line")  },
+        { shortcut: cmd_ctrl + "u",   help:i18n.msg._("undo selection")  },
+        { shortcut: "Insert",   help:i18n.msg._("toggle overwrite flag")  }
     ].concat( platform_specific );
     
     var mac_humanize_map = {

--- a/notebook/static/notebook/js/quickhelp.js
+++ b/notebook/static/notebook/js/quickhelp.js
@@ -42,11 +42,11 @@ define([
             { shortcut: "Alt-Right",  help:i18n.msg._("go one word right")  },
             { shortcut: "Alt-Backspace",      help:i18n.msg._("delete word before")  },
             { shortcut: "Alt-Delete",         help:i18n.msg._("delete word after")  },
+            { shortcut: "Cmd-Shift-z",   help:i18n.msg._("redo")  },
+            { shortcut: "Shift-Cmd-u",   help:i18n.msg._("redo selection")  },
             { shortcut: "Ctrl-k",   help:i18n.msg._("emacs-style line kill")  },
             { shortcut: "Cmd-Backspace",   help:i18n.msg._("delete line left of cursor")  },
             { shortcut: "Cmd-Delete",   help:i18n.msg._("delete line right of cursor")  },
-            { shortcut: cmd_ctrl + "Shift-z",   help:i18n.msg._("redo")  },
-            { shortcut: "Shift-Cmd-u",   help:i18n.msg._("redo selection")  }
         ];
     } else {
         // PC specific
@@ -59,7 +59,7 @@ define([
             { shortcut: "Ctrl-Right", help:i18n.msg._("go one word right")  },
             { shortcut: "Ctrl-Backspace", help:i18n.msg._("delete word before")  },
             { shortcut: "Ctrl-Delete",    help:i18n.msg._("delete word after")  },
-            { shortcut: cmd_ctrl + "y",   help:i18n.msg._("redo")  },
+            { shortcut: "Ctrl-y",   help:i18n.msg._("redo")  },
             { shortcut: "Alt-u",   help:i18n.msg._("redo selection")  }
         ];
     }

--- a/notebook/static/notebook/js/quickhelp.js
+++ b/notebook/static/notebook/js/quickhelp.js
@@ -36,45 +36,45 @@ define([
         // Mac OS X specific
         cmd_ctrl = 'Cmd-';
         platform_specific = [
-            { shortcut: "Cmd-Up",     help:i18n.msg._("go to cell start")  },
-            { shortcut: "Cmd-Down",   help:i18n.msg._("go to cell end")  },
-            { shortcut: "Alt-Left",   help:i18n.msg._("go one word left")  },
-            { shortcut: "Alt-Right",  help:i18n.msg._("go one word right")  },
-            { shortcut: "Alt-Backspace",      help:i18n.msg._("delete word before")  },
-            { shortcut: "Alt-Delete",         help:i18n.msg._("delete word after")  },
-            { shortcut: "Cmd-Shift-z",   help:i18n.msg._("redo")  },
-            { shortcut: "Shift-Cmd-u",   help:i18n.msg._("redo selection")  },
-            { shortcut: "Ctrl-k",   help:i18n.msg._("emacs-style line kill")  },
-            { shortcut: "Cmd-Backspace",   help:i18n.msg._("delete line left of cursor")  },
-            { shortcut: "Cmd-Delete",   help:i18n.msg._("delete line right of cursor")  },
+            { shortcut: "Cmd-Up", help:i18n.msg._("go to cell start") },
+            { shortcut: "Cmd-Down", help:i18n.msg._("go to cell end") },
+            { shortcut: "Alt-Left", help:i18n.msg._("go one word left") },
+            { shortcut: "Alt-Right", help:i18n.msg._("go one word right") },
+            { shortcut: "Alt-Backspace", help:i18n.msg._("delete word before") },
+            { shortcut: "Alt-Delete", help:i18n.msg._("delete word after") },
+            { shortcut: "Cmd-Shift-z", help:i18n.msg._("redo") },
+            { shortcut: "Shift-Cmd-u", help:i18n.msg._("redo selection") },
+            { shortcut: "Ctrl-k", help:i18n.msg._("emacs-style line kill") },
+            { shortcut: "Cmd-Backspace", help:i18n.msg._("delete line left of cursor") },
+            { shortcut: "Cmd-Delete", help:i18n.msg._("delete line right of cursor") }
         ];
     } else {
         // PC specific
         platform_specific = [
-            { shortcut: "Ctrl-Home",  help:i18n.msg._("go to cell start")  },
-            { shortcut: "Ctrl-Up",    help:i18n.msg._("go to cell start")  },
-            { shortcut: "Ctrl-End",   help:i18n.msg._("go to cell end")  },
-            { shortcut: "Ctrl-Down",  help:i18n.msg._("go to cell end")  },
-            { shortcut: "Ctrl-Left",  help:i18n.msg._("go one word left")  },
-            { shortcut: "Ctrl-Right", help:i18n.msg._("go one word right")  },
-            { shortcut: "Ctrl-Backspace", help:i18n.msg._("delete word before")  },
-            { shortcut: "Ctrl-Delete",    help:i18n.msg._("delete word after")  },
-            { shortcut: "Ctrl-y",   help:i18n.msg._("redo")  },
-            { shortcut: "Alt-u",   help:i18n.msg._("redo selection")  }
+            { shortcut: "Ctrl-Home", help:i18n.msg._("go to cell start") },
+            { shortcut: "Ctrl-Up", help:i18n.msg._("go to cell start") },
+            { shortcut: "Ctrl-End", help:i18n.msg._("go to cell end") },
+            { shortcut: "Ctrl-Down", help:i18n.msg._("go to cell end") },
+            { shortcut: "Ctrl-Left", help:i18n.msg._("go one word left") },
+            { shortcut: "Ctrl-Right", help:i18n.msg._("go one word right") },
+            { shortcut: "Ctrl-Backspace", help:i18n.msg._("delete word before")},
+            { shortcut: "Ctrl-Delete", help:i18n.msg._("delete word after")},
+            { shortcut: "Ctrl-y", help:i18n.msg._("redo")},
+            { shortcut: "Alt-u", help:i18n.msg._("redo selection") }
         ];
     }
 
     var cm_shortcuts = [
-        { shortcut:"Tab",   help:i18n.msg._("code completion or indent") },
-        { shortcut:"Shift-Tab",   help:i18n.msg._("tooltip") },
-        { shortcut: cmd_ctrl + "]",   help:i18n.msg._("indent")  },
-        { shortcut: cmd_ctrl + "[",   help:i18n.msg._("dedent")  },
-        { shortcut: cmd_ctrl + "a",   help:i18n.msg._("select all")  },
-        { shortcut: cmd_ctrl + "z",   help:i18n.msg._("undo")  },
-        { shortcut: cmd_ctrl + "/",   help:i18n.msg._("comment")  },
-        { shortcut: cmd_ctrl + "d",   help:i18n.msg._("delete whole line")  },
-        { shortcut: cmd_ctrl + "u",   help:i18n.msg._("undo selection")  },
-        { shortcut: "Insert",   help:i18n.msg._("toggle overwrite flag")  }
+        { shortcut:"Tab", help:i18n.msg._("code completion or indent") },
+        { shortcut:"Shift-Tab", help:i18n.msg._("tooltip") },
+        { shortcut: cmd_ctrl + "]", help:i18n.msg._("indent") },
+        { shortcut: cmd_ctrl + "[", help:i18n.msg._("dedent") },
+        { shortcut: cmd_ctrl + "a", help:i18n.msg._("select all") },
+        { shortcut: cmd_ctrl + "z", help:i18n.msg._("undo") },
+        { shortcut: cmd_ctrl + "/", help:i18n.msg._("comment") },
+        { shortcut: cmd_ctrl + "d", help:i18n.msg._("delete whole line") },
+        { shortcut: cmd_ctrl + "u", help:i18n.msg._("undo selection") },
+        { shortcut: "Insert", help:i18n.msg._("toggle overwrite flag") }
     ].concat( platform_specific );
     
     var mac_humanize_map = {

--- a/notebook/static/notebook/js/quickhelp.js
+++ b/notebook/static/notebook/js/quickhelp.js
@@ -43,7 +43,7 @@ define([
             { shortcut: "Alt-Backspace", help:i18n.msg._("delete word before") },
             { shortcut: "Alt-Delete", help:i18n.msg._("delete word after") },
             { shortcut: "Cmd-Shift-z", help:i18n.msg._("redo") },
-            { shortcut: "Shift-Cmd-u", help:i18n.msg._("redo selection") },
+            { shortcut: "Cmd-Shift-u", help:i18n.msg._("redo selection") },
             { shortcut: "Ctrl-k", help:i18n.msg._("emacs-style line kill") },
             { shortcut: "Cmd-Backspace", help:i18n.msg._("delete line left of cursor") },
             { shortcut: "Cmd-Delete", help:i18n.msg._("delete line right of cursor") }

--- a/notebook/static/notebook/js/quickhelp.js
+++ b/notebook/static/notebook/js/quickhelp.js
@@ -72,7 +72,6 @@ define([
         { shortcut: cmd_ctrl + "a",   help:i18n.msg._("select all")  },
         { shortcut: cmd_ctrl + "z",   help:i18n.msg._("undo")  },
         { shortcut: cmd_ctrl + "/",   help:i18n.msg._("comment")  },
-        { shortcut: "esc",   help:i18n.msg._("single selection")  },
         { shortcut: cmd_ctrl + "d",   help:i18n.msg._("delete whole line")  },
         { shortcut: cmd_ctrl + "u",   help:i18n.msg._("undo selection")  },
         { shortcut: "Insert",   help:i18n.msg._("toggle overwrite flag")  }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/512354/28645295-db0e49ba-7211-11e7-8799-e20f773570e4.png)

After:
![image](https://user-images.githubusercontent.com/512354/28645259-bd16c306-7211-11e7-9a35-460ac6d8114f.png)

Closes https://github.com/jupyter/notebook/issues/1593