### PR TITLE
Prevent extra newline between nested lists

### DIFF
--- a/notebook/static/notebook/less/renderedhtml.less
+++ b/notebook/static/notebook/less/renderedhtml.less
@@ -28,10 +28,16 @@
     ul:not(.list-inline),
     ol:not(.list-inline) {padding-left: 2em;}
     ul {list-style:disc;}
-    ul ul {list-style:square;}
+    ul ul {
+      list-style:square;
+      margin-top: 0;
+    }
     ul ul ul {list-style:circle;}
     ol {list-style:decimal;}
-    ol ol {list-style:upper-alpha; }
+    ol ol {
+      list-style:upper-alpha; 
+      margin-top: 0;
+    }
     ol ol ol {list-style:lower-alpha; }
     ol ol ol ol {list-style:lower-roman; }
     /* any extras will just be numbers: */


### PR DESCRIPTION
Closes https://github.com/jupyter/notebook/issues/2676