### PR TITLE
Ensure NbserverListApp produces valid json even for multiple/no servers

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -389,18 +389,28 @@ class NbserverListApp(JupyterApp):
     description=_("List currently running notebook servers.")
     
     flags = dict(
+        jsonlist=({'NbserverListApp': {'jsonlist': True}},
+              _("Produce machine-readable JSON list output.")),
         json=({'NbserverListApp': {'json': True}},
-              _("Produce machine-readable JSON output.")),
+              _("Produce machine-readable JSON object on each line of output.")),
     )
     
+    jsonlist = Bool(False, config=True,
+          help=_("If True, the output will be a JSON list of objects, one per "
+                 "active notebook server, each with the details from the "
+                 "relevant server info file."))
     json = Bool(False, config=True,
           help=_("If True, each line of output will be a JSON object with the "
-                  "details from the server info file."))
+                  "details from the server info file. For a JSON list output, "
+                  "see the NbserverListApp.jsonlist configuration value"))
 
     def start(self):
         serverinfo_list = list(list_running_servers(self.runtime_dir))
-        if self.json:
-            print(json.dumps(serverinfo_list))
+        if self.jsonlist:
+            print(json.dumps(serverinfo_list, indent=2))
+        elif self.json:
+            for serverinfo in serverinfo_list:
+                print(json.dumps(serverinfo))
         else:
             print("Currently running servers:")
             for serverinfo in serverinfo_list:

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -398,12 +398,12 @@ class NbserverListApp(JupyterApp):
                   "details from the server info file."))
 
     def start(self):
-        if not self.json:
-            print(_("Currently running servers:"))
-        for serverinfo in list_running_servers(self.runtime_dir):
-            if self.json:
-                print(json.dumps(serverinfo))
-            else:
+        serverinfo_list = list(list_running_servers(self.runtime_dir))
+        if self.json:
+            print(json.dumps(serverinfo_list))
+        else:
+            print("Currently running servers:")
+            for serverinfo in serverinfo_list:
                 url = serverinfo['url']
                 if serverinfo.get('token'):
                     url = url + '?token=%s' % serverinfo['token']


### PR DESCRIPTION
This PR makes a small adjustment to the NbserverListApp class to ensure valid json output.

Currently, the NbserverListApp outputs a json object for each running server, without wrapping them in a list. This means that if there are no running servers, there is no output, and if multiple servers are running, the response is invalid json.
