### PR TITLE
Add "all" flag to nbextension and serverextension commands

### DIFF
--- a/notebook/extensions.py
+++ b/notebook/extensions.py
@@ -58,6 +58,7 @@ class BaseExtensionApp(JupyterApp):
 
     user = Bool(False, config=True, help="Whether to do a user install")
     sys_prefix = Bool(False, config=True, help="Use the sys.prefix as the prefix")
+    all = Bool(False, config=True, help="Whether to do both a user and sys.prefix install")
     python = Bool(False, config=True, help="Install from a Python package")
 
     # Remove for 5.0...
@@ -71,6 +72,11 @@ class BaseExtensionApp(JupyterApp):
     def _log_format_default(self):
         """A default format for messages"""
         return "%(message)s"
+        
+    def start(self):
+        if self.all:
+            self.user = True
+            self.sys_prefix = True
 
 def _get_config_dir(user=False, sys_prefix=False):
     """Get the location of config files for the current context

--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -671,6 +671,8 @@ class InstallNBExtensionApp(BaseExtensionApp):
 
     def start(self):
         """Perform the App's function as configured"""
+        super(InstallNBExtensionApp, self).start()
+        
         if not self.extra_args:
             sys.exit('Please specify an nbextension to install')
         else:
@@ -736,6 +738,8 @@ class UninstallNBExtensionApp(BaseExtensionApp):
             uninstall_nbextension(self.extra_args[0], **kwargs)
     
     def start(self):
+        super(UninstallNBExtensionApp, self).start()
+        
         if not self.extra_args:
             sys.exit('Please specify an nbextension to uninstall')
         else:
@@ -800,6 +804,8 @@ class ToggleNBExtensionApp(BaseExtensionApp):
                       logger=self.log)
         
     def start(self):
+        super(ToggleNBExtensionApp, self).start()
+
         if not self.extra_args:
             sys.exit('Please specify an nbextension/package to enable or disable')
         elif len(self.extra_args) > 1:
@@ -869,6 +875,8 @@ class ListNBExtensionsApp(BaseExtensionApp):
     
     def start(self):
         """Perform the App's functions as configured"""
+        super(ListNBExtensionsApp, self).start()
+        
         self.list_nbextensions()
 
 

--- a/notebook/serverextensions.py
+++ b/notebook/serverextensions.py
@@ -203,6 +203,8 @@ class ToggleServerExtensionApp(BaseExtensionApp):
 
     def start(self):
         """Perform the App's actions as configured"""
+        super(ToggleServerExtensionApp, self).start()
+        
         if not self.extra_args:
             sys.exit('Please specify a server extension/package to enable or disable')
         for arg in self.extra_args:
@@ -265,6 +267,8 @@ class ListServerExtensionsApp(BaseExtensionApp):
 
     def start(self):
         """Perform the App's actions as configured"""
+        super(ListServerExtensionsApp, self).start()
+        
         self.list_server_extensions()
 
 


### PR DESCRIPTION
@takluyver @minrk I'm not sure whether this is the right approach... As opposed to "check every level where the enable config is defined", this is just adding an "all" trait to the top-level class and some logic to the `start` method that will set `user` and `sys_prefix` to `True` if the all flag is enabled. This requires all subclass instances to call `super(CommandInstance, self).start()`.

Closes https://github.com/jupyter/notebook/issues/2149