### PR TITLE
Disable nbextension in first location found

### DIFF
--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -805,7 +805,7 @@ class EnableNBExtensionApp(BaseExtensionApp):
     Enable an nbextension in frontend configuration.
 
     Usage
-        jupyter nbextension enable [--system|--sys-prefix]
+        jupyter nbextension enable [--system|--sys-prefix] myext
     """
     version = __version__
 
@@ -848,7 +848,7 @@ class DisableNBExtensionApp(BaseExtensionApp):
     Disable an nbextension in frontend configuration.
     
     Usage
-        jupyter nbextension disable [--system|--sys-prefix]
+        jupyter nbextension disable [--user|--sys-prefix] myext
     """
     version = __version__
     flags = {


### PR DESCRIPTION
Alternative to #2724.

This implements option 1 from [Min's comment](https://github.com/jupyter/notebook/pull/2715#issuecomment-319687449): find the first location where the config enables the extension, and remove it. This makes it the default, and simplifies the options available, on the grounds that 99% of the time, when you're asking to disable something, you don't care which bit of config is enabling it.

It adds some code because it bypasses the inheritance tree of applications that has been built. Looking at this code, I think we've over-abstracted the actual operations a bit, which makes it less clear what's going on. I'd like to flatten it a bit, but not in this PR.