### PR TITLE
Add buffers argument to comm open/close

### DIFF
--- a/notebook/static/services/kernels/comm.js
+++ b/notebook/static/services/kernels/comm.js
@@ -30,8 +30,8 @@ define([
             kernel.register_iopub_handler(msg_type, $.proxy(this[msg_type], this));
         }
     };
-    
-    CommManager.prototype.new_comm = function (target_name, data, callbacks, metadata, comm_id) {
+
+    CommManager.prototype.new_comm = function (target_name, data, callbacks, metadata, comm_id, buffers) {
         /**
          * Create a new Comm, register it, and open its Kernel-side counterpart
          * Mimics the auto-registration in `Comm.__init__` in the Jupyter Comm.
@@ -40,7 +40,7 @@ define([
          */
         var comm = new Comm(target_name, comm_id);
         this.register_comm(comm);
-        comm.open(data, callbacks, metadata);
+        comm.open(data, callbacks, metadata, buffers);
         return comm;
     };
     

--- a/notebook/static/services/kernels/comm.js
+++ b/notebook/static/services/kernels/comm.js
@@ -147,13 +147,13 @@ define([
     };
     
     // methods for sending messages
-    Comm.prototype.open = function (data, callbacks, metadata) {
+    Comm.prototype.open = function (data, callbacks, metadata, buffers) {
         var content = {
             comm_id : this.comm_id,
             target_name : this.target_name,
             data : data || {},
         };
-        return this.kernel.send_shell_message("comm_open", content, callbacks, metadata);
+        return this.kernel.send_shell_message("comm_open", content, callbacks, metadata, buffers);
     };
     
     Comm.prototype.send = function (data, callbacks, metadata, buffers) {
@@ -163,13 +163,13 @@ define([
         };
         return this.kernel.send_shell_message("comm_msg", content, callbacks, metadata, buffers);
     };
-    
-    Comm.prototype.close = function (data, callbacks, metadata) {
+
+    Comm.prototype.close = function (data, callbacks, metadata, buffers) {
         var content = {
             comm_id : this.comm_id,
             data : data || {},
         };
-        return this.kernel.send_shell_message("comm_close", content, callbacks, metadata);
+        return this.kernel.send_shell_message("comm_close", content, callbacks, metadata, buffers);
     };
     
     // methods for registering callbacks for incoming messages


### PR DESCRIPTION
Adds an argument `buffers` to `services.kernels.comm.Comm.open()`/`close()`. It is passed through to the `send_shell_message` similarly to what is done in `Comm.send()`.

Fixes #2730.