### PR TITLE
Set CodeMirror mode using mimetype, not mode name

### DIFF
--- a/notebook/static/edit/js/editor.js
+++ b/notebook/static/edit/js/editor.js
@@ -150,8 +150,10 @@ function(
         /** set the codemirror mode from a modeinfo struct */
         var that = this;
         utils.requireCodeMirrorMode(modeinfo, function () {
-            that.codemirror.setOption('mode', modeinfo.mode);
+            that.codemirror.setOption('mode', modeinfo.mime);
             that.events.trigger("mode_changed.Editor", modeinfo);
+        }, function(err) {
+            console.log('Error getting CodeMirror mode: ' + err);
         });
     };
 


### PR DESCRIPTION
One mode definition file can contain different modes, e.g. clike includes C, C++, C#, Java, and a few others. We need to use the mime type to distinguish which one we want.

Closes gh-2737

@gnestor can we sneak this fix into 5.1?