### PR TITLE
schedule IOLoop.stop on the main thread

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1292,7 +1292,7 @@ class NotebookApp(JupyterApp):
     
     def _signal_stop(self, sig, frame):
         self.log.critical(_("received signal %s, stopping"), sig)
-        self.io_loop.add_callback(self.io_loop.stop)
+        self.io_loop.add_callback_from_signal(self.io_loop.stop)
 
     def _signal_info(self, sig, frame):
         print(self.notebook_info())

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1279,7 +1279,7 @@ class NotebookApp(JupyterApp):
                 self.log.critical(_("Shutdown confirmed"))
                 # schedule stop on the main thread,
                 # since this might be called from a signal handler
-                self.io_loop.add_callback(self.io_loop.stop)
+                self.io_loop.add_callback_from_signal(self.io_loop.stop)
                 return
         else:
             print(_("No answer for 5s:"), end=' ')
@@ -1288,7 +1288,7 @@ class NotebookApp(JupyterApp):
         # set it back to original SIGINT handler
         # use IOLoop.add_callback because signal.signal must be called
         # from main thread
-        self.io_loop.add_callback(self._restore_sigint_handler)
+        self.io_loop.add_callback_from_signal(self._restore_sigint_handler)
     
     def _signal_stop(self, sig, frame):
         self.log.critical(_("received signal %s, stopping"), sig)

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1277,7 +1277,9 @@ class NotebookApp(JupyterApp):
             line = sys.stdin.readline()
             if line.lower().startswith(yes) and no not in line.lower():
                 self.log.critical(_("Shutdown confirmed"))
-                ioloop.IOLoop.current().stop()
+                # schedule stop on the main thread,
+                # since this might be called from a signal handler
+                self.io_loop.add_callback(self.io_loop.stop)
                 return
         else:
             print(_("No answer for 5s:"), end=' ')
@@ -1286,11 +1288,11 @@ class NotebookApp(JupyterApp):
         # set it back to original SIGINT handler
         # use IOLoop.add_callback because signal.signal must be called
         # from main thread
-        ioloop.IOLoop.current().add_callback(self._restore_sigint_handler)
+        self.io_loop.add_callback(self._restore_sigint_handler)
     
     def _signal_stop(self, sig, frame):
         self.log.critical(_("received signal %s, stopping"), sig)
-        ioloop.IOLoop.current().stop()
+        self.io_loop.add_callback(self.io_loop.stop)
 
     def _signal_info(self, sig, frame):
         print(self.notebook_info())


### PR DESCRIPTION
loop.stop() will not be safe from a thread in tornado 5

There has never been a guarantee to this effect, but it has happened to be true so far.

The result is that the stop event will not fire until the next loop iteration (e.g. triggered by an HTTP request). Using add_callback ensures that the main thread wakes and handles the stop event.

cf tornadoweb/tornado#2119