### PR TITLE
Factor out output_prompt_function, as is done with input prompt

### DIFF
--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -467,6 +467,11 @@ define([
         this.element.trigger('changed', {output_area: this});
     };
 
+    OutputArea.output_prompt_classical = function(prompt_value) {
+        return '<bdi>'+i18n.msg.sprintf(i18n.msg._('Out[%d]:'),prompt_value)+'</bdi>';
+    };
+
+    OutputArea.output_prompt_function = OutputArea.output_prompt_classical;
 
     OutputArea.prototype.append_execute_result = function (json) {
         var n = json.execution_count || ' ';
@@ -476,9 +481,7 @@ define([
             toinsert.find('div.prompt')
                     .addClass('output_prompt')
                     .empty()
-                    .append(
-                      $('<bdi>').text(i18n.msg.sprintf(i18n.msg._('Out[%d]:'),n))
-                    );
+                    .append(OutputArea.output_prompt_function(n));
         }
         var inserted = this.append_mime_type(json, toinsert);
         if (inserted) {

--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -468,7 +468,7 @@ define([
     };
 
     OutputArea.output_prompt_classical = function(prompt_value) {
-        return '<bdi>'+i18n.msg.sprintf(i18n.msg._('Out[%d]:'),prompt_value)+'</bdi>';
+        return $('<bdi>').text(i18n.msg.sprintf(i18n.msg._('Out[%d]:'),prompt_value));
     };
 
     OutputArea.output_prompt_function = OutputArea.output_prompt_classical;


### PR DESCRIPTION
This allows for much cleaner customization of the output prompt in custom.js, as is currently the case with the input prompt.