### PR TITLE
d/s/examples/N/Importing Notebooks.ipynb: disable execution.

### DIFF
--- a/docs/source/examples/Notebook/Importing Notebooks.ipynb
+++ b/docs/source/examples/Notebook/Importing Notebooks.ipynb
@@ -511,6 +511,9 @@
  ],
  "metadata": {
   "gist_id": "6011986",
+  "nbsphinx": {
+   "execute": "never"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
This notebook example includes writing to the directory of another
module, usually resulting in a doc build failure.  Therefore we
disable its execution by nbsphinx.

Closes: #2372
See-Also: https://bugs.gentoo.org/show_bug.cgi?id=626860