### PR TITLE
Prevent uploading file twice

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -1176,6 +1176,7 @@ define([
                 var add_uploading_button = function (f, item) {
                     // change buttons, add a progress bar
                     var uploading_button = item.find('.upload_button').text("Uploading");
+                    uploading_button.off('click');  // Prevent double upload
                     var progress_bar = $('<span/>')
                         .addClass('progress-bar')
                         .css('top', '0')


### PR DESCRIPTION
Closes gh-2773

I'm not sure I've completely prevented it - double clicking really fast might still fire two events before the button is disabled - but I've tried a few times and can't make it happen, whereas I can easily reproduce the bug in master.