### PR TITLE
Add Mathjax/jax/element/mml to package_data

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -194,6 +194,7 @@ def find_package_data():
         mj('jax', 'input', 'TeX'),
         mj('jax', 'output', 'HTML-CSS', 'fonts', 'STIX-Web'),
         mj('jax', 'output', 'SVG', 'fonts', 'STIX-Web'),
+        mj('jax', 'element', 'mml'),
     ]:
         for parent, dirs, files in os.walk(tree):
             for f in files:


### PR DESCRIPTION
Closes gh-2780
Closes gh-1108

One of the comments on #1108 concerns a file `mathchoice.js` which is the `extensions` directory under Mathjax. Do we want to include that as well (350KB total)?