### PR TITLE
Attempt to fix mysterious mathjax callback error

### DIFF
--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -945,7 +945,8 @@ define([
             MathJax.Hub.Queue(["Typeset", MathJax.Hub, this]);
             try {
                 MathJax.Hub.Queue(
-                    ["resetEquationNumbers", MathJax.InputJax.TeX]
+                    ["Require", MathJax.Ajax, "[MathJax]/extensions/TeX/AMSmath.js"],
+                    function() { MathJax.InputJax.TeX.resetEquationNumbers(); }
                 );
             } catch (e) {
                 console.error("Error queueing resetEquationNumbers:", e);

--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -940,12 +940,16 @@ define([
         if(!window.MathJax){
             return;
         }
-        return $el.map(function(){
+        $el.map(function(){
             // MathJax takes a DOM node: $.map makes `this` the context
-            return MathJax.Hub.Queue(
-                ["Typeset", MathJax.Hub, this],
-                ["resetEquationNumbers",MathJax.InputJax.TeX]
-            );
+            MathJax.Hub.Queue(["Typeset", MathJax.Hub, this]);
+            try {
+                MathJax.Hub.Queue(
+                    ["resetEquationNumbers", MathJax.InputJax.TeX]
+                );
+            } catch (e) {
+                console.error("Error queueing resetEquationNumbers:", e);
+            }
         });
     };
 

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -3001,7 +3001,7 @@ define([
             this.fromJSON(data);
         } catch (e) {
             failed = e;
-            console.log("Notebook failed to load from JSON:", e);
+            console.error("Notebook failed to load from JSON:", e);
         }
         if (failed || data.message) {
             // *either* fromJSON failed or validation failed


### PR DESCRIPTION
Looking at #2733 again, I noticed that @willingc's JS console did show tracebacks, which I had  somehow overlooked before. Partly that was just me not looking closely enough, but we can also make it stand out more by logging it with `console.error`, which this PR does.

That pointed to the code which was modified in PR #2677 just last month; this fits with people first running into the error when we made an RC.

That change asks Mathjax to call `MathJax.InputJax.TeX.resetEquationNumbers()` after typesetting each thing. That function is defined in a Mathjax extension `extensions/TeX/AMSmath.js`. While I still can't reproduce the error, I guess that looking up the function is in a race condition with the extension loading; if it loses the race, then there's nothing to call, so an error pops out.

This PR:

* Catches errors from enqueueing resetEquationNumbers(), logs them and carries on, so that these (hopefully) cannot cause a failure to load the notebook.
* Based on my speculation, enqueues a Mathjax `Require` call immediately before to ensure that the extension is loaded before we use it.

If this passes review, I suggest that we make an RC3 soon after merging it and ask the people who can reproduce the issue to see if it's fixed.