### PR TITLE
changed all python variables named file to file_name to not override built_in file

### DIFF
--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -190,9 +190,9 @@ def install_nbextension(path, overwrite=False, symlink=False,
                     if logger:
                         logger.info("Making directory: %s" % dest_dir)
                     os.makedirs(dest_dir)
-                for file in files:
-                    src = pjoin(parent, file)
-                    dest_file = pjoin(dest_dir, file)
+                for file_name in files:
+                    src = pjoin(parent, file_name)
+                    dest_file = pjoin(dest_dir, file_name)
                     _maybe_copy(src, dest_file, logger=logger)
         else:
             src = path

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1515,9 +1515,9 @@ def list_running_servers(runtime_dir=None):
     if not os.path.isdir(runtime_dir):
         return
 
-    for file in os.listdir(runtime_dir):
-        if file.startswith('nbserver-'):
-            with io.open(os.path.join(runtime_dir, file), encoding='utf-8') as f:
+    for file_name in os.listdir(runtime_dir):
+        if file_name.startswith('nbserver-'):
+            with io.open(os.path.join(runtime_dir, file_name), encoding='utf-8') as f:
                 info = json.load(f)
 
             # Simple check whether that process is really still running
@@ -1527,7 +1527,7 @@ def list_running_servers(runtime_dir=None):
             else:
                 # If the process has died, try to delete its info file
                 try:
-                    os.unlink(os.path.join(runtime_dir, file))
+                    os.unlink(os.path.join(runtime_dir, file_name))
                 except OSError:
                     pass  # TODO: This should warn or log or something
 #-----------------------------------------------------------------------------

--- a/notebook/tests/test_nbextensions.py
+++ b/notebook/tests/test_nbextensions.py
@@ -33,17 +33,17 @@ from notebook.nbextensions import (install_nbextension, check_nbextension,
 from traitlets.config.manager import BaseJSONConfigManager
 
 
-def touch(file, mtime=None):
+def touch(file_name, mtime=None):
     """ensure a file exists, and set its modification time
     
     returns the modification time of the file
     """
-    open(file, 'a').close()
+    open(file_name, 'a').close()
     # set explicit mtime
     if mtime:
-        atime = os.stat(file).st_atime
-        os.utime(file, (atime, mtime))
-    return os.stat(file).st_mtime
+        atime = os.stat(file_name).st_atime
+        os.utime(file_name, (atime, mtime))
+    return os.stat(file_name).st_mtime
 
 
 def test_help_output():
@@ -77,8 +77,8 @@ class TestInstallNBExtension(TestCase):
             pjoin(u'∂ir', u'ƒile1'),
             pjoin(u'∂ir', u'∂ir2', u'ƒile2'),
         ]
-        for file in files:
-            fullpath = os.path.join(self.src, file)
+        for file_name in files:
+            fullpath = os.path.join(self.src, file_name)
             parent = os.path.dirname(fullpath)
             if not os.path.exists(parent):
                 os.makedirs(parent)
@@ -144,9 +144,9 @@ class TestInstallNBExtension(TestCase):
             }):
                 install_nbextension(self.src, user=True)
                 self.assert_dir_exists(data_dir)
-                for file in self.files:
+                for file_name in self.files:
                     self.assert_installed(
-                        pjoin(basename(self.src), file),
+                        pjoin(basename(self.src), file_name),
                         user=True,
                     )
     
@@ -169,9 +169,9 @@ class TestInstallNBExtension(TestCase):
                 )
     
     def test_single_file(self):
-        file = self.files[0]
-        install_nbextension(pjoin(self.src, file))
-        self.assert_installed(file)
+        file_name = self.files[0]
+        install_nbextension(pjoin(self.src, file_name))
+        self.assert_installed(file_name)
     
     def test_single_dir(self):
         d = u'∂ir'
@@ -188,8 +188,8 @@ class TestInstallNBExtension(TestCase):
             self.assert_installed(self.files[-1])
 
     def test_destination_file(self):
-        file = self.files[0]
-        install_nbextension(pjoin(self.src, file), destination = u'ƒiledest')
+        file_name = self.files[0]
+        install_nbextension(pjoin(self.src, file_name), destination = u'ƒiledest')
         self.assert_installed(u'ƒiledest')
 
     def test_destination_dir(self):


### PR DESCRIPTION
I do not believe that this is the cause of #2829, but in looking into it, I noticed that we were overwriting the file built_in which is only safe to do in python3. Since notebook is py2/3 compat, we shouldn't do that.

This takes care of all the cases I could find.