### PR TITLE
load locale dynamically only when not en-us

### DIFF
--- a/notebook/static/bidi/bidi.js
+++ b/notebook/static/bidi/bidi.js
@@ -1,56 +1,57 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-define([
-    'bidi/numericshaping',
-], function (numericshaping){
-    "use strict";
-    
-    var shaperType="";
-    var textDir="";
-    
-    var _uiLang= function (){
-    	return navigator.language.toLowerCase();
-    };
+define(['bidi/numericshaping'], function(numericshaping) {
+  'use strict';
 
-	var _loadLocale = function () {
-		if(_isMirroringEnabled()){
-			$("body").attr("dir","rtl");
-		}
-		requirejs(['components/moment/locale/'+_uiLang()], function (err){
-			console.warn("Error loading the required locale");
-			console.warn(err);
-	    });
-		shaperType= _uiLang()=='ar'? "national" : "defaultNumeral";
-    };
-    
-    var _isMirroringEnabled= function() {
-    	return (new RegExp("^(ar|he)").test(_uiLang()));
-    };
+  var shaperType = '';
+  var textDir = '';
 
-    /**
+  var _uiLang = function() {
+    return navigator.language.toLowerCase();
+  };
+
+  var _loadLocale = function() {
+    if (_isMirroringEnabled()) {
+      $('body').attr('dir', 'rtl');
+    }
+    var uiLang = _uiLang();
+
+    if (uiLang !== 'en' && uiLang !== 'en-us') {
+      // moment does not ship with a separate file for locale/en or locale/en-us
+      // so we must skip dynamically requiring it
+      requirejs(['components/moment/locale/' + _uiLang()], function(err) {
+        console.warn('Error loading the required locale');
+        console.warn(err);
+      });
+    }
+
+    shaperType = _uiLang() == 'ar' ? 'national' : 'defaultNumeral';
+  };
+
+  var _isMirroringEnabled = function() {
+    return new RegExp('^(ar|he)').test(_uiLang());
+  };
+
+  /**
      * NS :  for digit Shaping.
      * BTD : for future work in case of Base Text Direction Addition.
-     */  
-    /*var _flags= {
-        NS: 1,
-    	BTD : 2
-    };*/
-    
-    /**
+     */
+
+  /**
      * @param value : the string to apply the bidi-support on it.
      * @param flag :indicates the type of bidi-support (Numeric-shaping ,Base-text-dir ).
      */
-    var _applyBidi = function (value /*, flag*/) {
-    	value = numericshaping.shapeNumerals(value, shaperType);
-        return value;
-    };
-    
-    var bidi = {
-    	applyBidi : _applyBidi,
-    	isMirroringEnabled : _isMirroringEnabled,
-    	loadLocale : _loadLocale,
-    };
-    
-    return bidi;
+  var _applyBidi = function(value /*, flag*/) {
+    value = numericshaping.shapeNumerals(value, shaperType);
+    return value;
+  };
+
+  var bidi = {
+    applyBidi: _applyBidi,
+    isMirroringEnabled: _isMirroringEnabled,
+    loadLocale: _loadLocale,
+  };
+
+  return bidi;
 });


### PR DESCRIPTION
While trying to investigate failing tests on master, I noticed that there were errors because moment doesn't have a separate locale file for `en` or `en-us`. They keep it as a default per https://github.com/moment/moment/issues/2081.

Since the whitespace was misleading in this file (I thought some of these functions were inside each other until I cleaned it up), I ran `prettier` over it.