### PR TITLE
Add x-xsrftoken to Access-Control-Allow-Headers

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -503,7 +503,8 @@ class APIHandler(IPythonHandler):
         return super(APIHandler, self).finish(*args, **kwargs)
 
     def options(self, *args, **kwargs):
-        self.set_header('Access-Control-Allow-Headers', 'accept, content-type, authorization')
+        self.set_header('Access-Control-Allow-Headers',
+                        'accept, content-type, authorization, x-xsrftoken')
         self.set_header('Access-Control-Allow-Methods',
                         'GET, PUT, POST, PATCH, DELETE, OPTIONS')
         self.finish()


### PR DESCRIPTION
When starting a kernel using the Jupyter Notebook Kernel API, web
browsers will automatically check for the presence of `x-xsrftoken` in
the Access-Control-Allow-Headers during the preflight CORS check
([ref][ref]).

[ref]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers

Since we didn't allow this header before, web browsers would fail the
preflight check even when the x-xsrftoken header isn't being used by the
notebook server.

This meant that running a webpage on localhost:8080 that used Javascript
to start a kernel on a notebook server running on localhost:8888 would
fail.

How I tested this commit:

1. Start a notebook server using

		jupyter notebook --no-browser --NotebookApp.allow_origin="*" --NotebookApp.disable_check_xsrf=True --NotebookApp.token=''

2. Build the [web3](https://github.com/jupyter-widgets/ipywidgets/tree/master/examples/web3) example from ipywidgets.
3. In that directory, run `npm run host`.
4. Verify that visiting http://localhost:8080/ starts a kernel in the notebook server.