### PR TITLE
fix codemirror.less to match CodeMirror's expected padding layout

### DIFF
--- a/notebook/static/notebook/less/codemirror.less
+++ b/notebook/static/notebook/less/codemirror.less
@@ -26,7 +26,9 @@
 .CodeMirror-lines {
     /* In CM2, this used to be 0.4em, but in CM3 it went to 4px. We need the em value because */
     /* we have set a different line-height and want this to scale with that. */
-    padding: @code_padding;
+    /* Note that this should set vertical padding only, since CodeMirror assumes
+       that horizontal padding will be set on CodeMirror pre */
+    padding: @code_padding 0;
 }
 
 .CodeMirror-linenumber {
@@ -43,9 +45,9 @@
 }
 
 .CodeMirror pre {
-    /* In CM3 this went to 4px from 0 in CM2. We need the 0 value because of how we size */
-    /* .CodeMirror-lines */
-    padding: 0;
+    /* In CM3 this went to 4px from 0 in CM2. This sets horizontal padding only,
+    use .CodeMirror-lines for vertical */
+    padding: 0 @code_padding;
     border: 0;
     .border-radius(0)
 }


### PR DESCRIPTION
fixes #2869 (I hope!)
see https://github.com/codemirror/CodeMirror/issues/4042#issuecomment-332169162 for CodeMirror author's statement on how padding is expected to be arranged for proper layout of rulers (and possibly other stuff as well?!)