### PR TITLE
Improve Edit/View behavior

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -721,17 +721,9 @@ define([
             icon = 'running_' + icon;
         }
         var uri_prefix = NotebookList.uri_prefixes[model.type];
-        if (model.type === 'file' && !this._is_editable(model))
-        {
-            uri_prefix = 'files';
-        }
         if (model.type === 'file' && this._is_viewable(model))
         {
             uri_prefix = 'view';
-        }
-        if (model.type === 'file' && this._is_editable(model))
-        {
-            uri_prefix = 'edit';
         }
         if (model.type === 'file' && this._is_notebook(model))
         {

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -540,10 +540,9 @@ define([
         this._selection_changed();
     };
 
-    NotebookList.ipynb_extensions = ['ipynb'];
-
     NotebookList.prototype._is_notebook = function(model) {
-      return includes_extension(model.path, NotebookList.ipynb_extensions);
+      var ipynb_extensions = ['ipynb'];
+      return includes_extension(model.path, ipynb_extensions);
     };
     
     NotebookList.prototype._is_editable = function(model) {

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -541,7 +541,6 @@ define([
     };
 
     NotebookList.ipynb_extensions = ['ipynb'];
-    NotebookList.viewable_extensions = ['htm', 'html', 'xhtml', 'mht', 'mhtml'];
 
     NotebookList.prototype._is_notebook = function(model) {
       return includes_extension(model.path, NotebookList.ipynb_extensions);
@@ -557,8 +556,15 @@ define([
     };
     
     NotebookList.prototype._is_viewable = function(model) {
+      var html_types = ['htm', 'html', 'xhtml', 'xml', 'mht', 'mhtml'];
+      var media_extension = ['3gp', 'avi', 'mov', 'mp4', 'm4v', 'm4a', 'mp3', 'mkv', 'ogv', 'ogm', 'ogg', 'oga', 'webm', 'wav'];
+      var image_type = ['bmp', 'gif', 'jpg', 'jpeg', 'png', 'webp'];
+      var archive_type = ['zip', 'rar'];
+      var other_type = ['txt', 'pdf', 'ico'];
+      var office_types = ['doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx'];
+      var viewable_extensions = [].concat(html_types, media_extension, image_type, archive_type, other_type, office_types);
       return model.mimetype === 'text/html' 
-        || includes_extension(model.path, NotebookList.viewable_extensions);
+        || includes_extension(model.path, viewable_extensions);
     };
 
     /**

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -537,10 +537,6 @@ define([
     };
 
     NotebookList.ipynb_extensions = ['ipynb'];
-    // List of text file extensions from
-    // https://github.com/sindresorhus/text-extensions/blob/master/text-extensions.json
-    var editable_extensions = ['applescript', 'asp', 'aspx', 'atom', 'bashrc', 'bat', 'bbcolors', 'bib', 'bowerrc', 'c', 'cc', 'cfc', 'cfg', 'cfm', 'cmd', 'cnf', 'coffee', 'conf', 'cpp', 'cson', 'css', 'csslintrc', 'csv', 'curlrc', 'cxx', 'diff', 'eco', 'editorconfig', 'ejs', 'emacs', 'eml', 'erb', 'erl', 'eslintignore', 'eslintrc', 'gemrc', 'gitattributes', 'gitconfig', 'gitignore', 'go', 'gvimrc', 'h', 'haml', 'hbs', 'hgignore', 'hpp', 'htaccess', 'htm', 'html', 'iced', 'ini', 'ino', 'irbrc', 'itermcolors', 'jade', 'js', 'jscsrc', 'jshintignore', 'jshintrc', 'json', 'jsonld', 'jsx', 'less', 'log', 'ls', 'm', 'markdown', 'md', 'mdown', 'mdwn', 'mht', 'mhtml', 'mkd', 'mkdn', 'mkdown', 'nfo', 'npmignore', 'npmrc', 'nvmrc', 'patch', 'pbxproj', 'pch', 'php', 'phtml', 'pl', 'pm', 'properties', 'py', 'rb', 'rdoc', 'rdoc_options', 'ron', 'rss', 'rst', 'rtf', 'rvmrc', 'sass', 'scala', 'scss', 'seestyle', 'sh', 'sls', 'sql', 'sss', 'strings', 'styl', 'stylus', 'sub', 'sublime-build', 'sublime-commands', 'sublime-completions', 'sublime-keymap', 'sublime-macro', 'sublime-menu', 'sublime-project', 'sublime-settings', 'sublime-workspace', 'svg', 'terminal', 'tex', 'text', 'textile', 'tmLanguage', 'tmTheme', 'tsv', 'txt', 'vbs', 'vim', 'viminfo', 'vimrc', 'webapp', 'xht', 'xhtml', 'xml', 'xsl', 'yaml', 'yml', 'zsh', 'zshrc'];
-    NotebookList.editable_extensions = editable_extensions.concat(['ipynb', 'geojson', 'plotly', 'plotly.json', 'vg', 'vg.json', 'vl', 'vl.json']);
     NotebookList.viewable_extensions = ['htm', 'html', 'xhtml', 'mht', 'mhtml'];
 
     NotebookList.prototype._is_notebook = function(model) {
@@ -548,13 +544,12 @@ define([
     };
     
     NotebookList.prototype._is_editable = function(model) {
-      // Editable: any text/ mimetype, specific mimetypes defined as editable,
-      // +json and +xml mimetypes, specific extensions listed as editable.
-      return model.mimetype &&
-          (model.mimetype.indexOf('text/') === 0
-           || item_in(model.mimetype, this.EDIT_MIMETYPES)
-           || json_or_xml_container_mimetype(model.mimetype))
-        || includes_extension(model.path, NotebookList.editable_extensions);
+      // Allow any file to be "edited"
+      // Non-text files will display the following error:
+      //   Error: [FILE] is not UTF-8 encoded
+      //   Saving is disabled.
+      //   See Console for more details.
+      return true;
     };
     
     NotebookList.prototype._is_viewable = function(model) {

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -25,7 +25,11 @@ define([
     };
 
     var item_in = function(item, list) {
-      return list.indexOf(item) != -1;
+      // Normalize list and item to lowercase
+      var normalized_list = list.map(function(_item) {
+        return _item.toLowerCase();
+      });
+      return normalized_list.indexOf(item.toLowerCase()) != -1;
     };
 
     var includes_extension = function(filepath, extensionslist) {


### PR DESCRIPTION
Follow up from https://github.com/jupyter/notebook/issues/2203#issuecomment-334607372

This makes the default path `edit` for files so that all files can edited. If a file is binary or otherwise uneditable, a user can still edit it and they will see the following error:

```
Error: [FILE] is not UTF-8 encoded
Saving is disabled.
See Console for more details.
```

They're browser won't crash or anything, so no harm, no foul.

If a file's MIME type matches `text/html` or the whitelist of viewable extensions (a list of browser-supported extensions borrowed from https://support.google.com/chromebook/answer/183093?hl=en), then it will use the `view` path by default.