### PR TITLE
Show edit shortcuts modal after shortcuts modal is hidden

### DIFF
--- a/notebook/static/notebook/js/quickhelp.js
+++ b/notebook/static/notebook/js/quickhelp.js
@@ -286,8 +286,11 @@ define([
                 // close this dialog
                 $(that.shortcut_dialog).modal("toggle");
                 // and open the next one
-                that.keyboard_manager.actions.call(
-                    'jupyter-notebook:edit-command-mode-keyboard-shortcuts');
+                $(that.shortcut_dialog).on('hidden.bs.modal', function (e) {
+                    that.keyboard_manager.actions.call(
+                        'jupyter-notebook:edit-command-mode-keyboard-shortcuts'
+                    );
+                });
             });
         div.find('h4').append(edit_button);
         return div;


### PR DESCRIPTION
Closes https://github.com/jupyter/notebook/issues/2904