### PR TITLE
allow setting token via JUPYTER_TOKEN env

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -662,6 +662,9 @@ class NotebookApp(JupyterApp):
 
     @default('token')
     def _token_default(self):
+        if os.getenv('JUPYTER_TOKEN'):
+            self._token_generated = False
+            return os.getenv('JUPYTER_TOKEN')
         if self.password:
             # no token if password is enabled
             self._token_generated = False


### PR DESCRIPTION
more convenient for certain deployments than CLI arguments