### PR TITLE
Whitelist <a knowl="..."> for including knowls

### DIFF
--- a/notebook/static/base/js/security.js
+++ b/notebook/static/base/js/security.js
@@ -37,6 +37,7 @@ define([
         // disable the check
         // https://www.owasp.org/index.php/Script_in_IMG_tags
         ATTRIBS['img::src'] = 0;
+        ATTRIBS['a::knowl'] = 0;
         return caja.sanitizeAttribs(tagName, attribs, opt_naiveUriRewriter, opt_nmTokenPolicy, opt_logger);
     };
     


### PR DESCRIPTION
At the workshop in Simula, @rbeezer is interested in using [knowls](https://www.aimath.org/knowlepedia/) in Jupyter. These work with a tag `<a knowl="foo.html">`,  which Javascript turns into a clickable thing to open a knowl.

The `knowl=` attribute is currently getting sanitized in markdown cells. It seems likely that it's safe in general; it doesn't do anything without the Javascript to process it. However, we should consider this carefully - if a Jupyter deployment includes the knowl JS to allow knowls in notebooks, could a maliciously coded knowl execute code on your kernel? It doesn't look like it's using an iframe by default.
