### PR TITLE
Handle a compound extension in new_untitled

### DIFF
--- a/notebook/services/contents/manager.py
+++ b/notebook/services/contents/manager.py
@@ -4,7 +4,6 @@
 # Distributed under the terms of the Modified BSD License.
 
 from fnmatch import fnmatch
-import gettext
 import itertools
 import json
 import os
@@ -31,6 +30,7 @@ from traitlets import (
 )
 from ipython_genutils.py3compat import string_types
 from notebook.base.handlers import IPythonHandler
+
 
 copy_pat = re.compile(r'\-Copy\d*\.')
 
@@ -317,22 +317,31 @@ class ContentsManager(LoggingConfigurable):
             The name of a file, including extension
         path : unicode
             The API path of the target's directory
+        insert: unicode
+            The characters to insert after the base filename
 
         Returns
         -------
         name : unicode
             A filename that is unique, based on the input filename.
         """
-        path = path.strip('/')
-        basename, ext = os.path.splitext(filename)
+        # Extract the full suffix from the filename (e.g. .tar.gz)
+        dirname = os.path.dirname(filename)
+        basename = os.path.basename(filename)
+        parts = basename.split('.')
+        basename = os.path.join(dirname, parts[0])
+        suffix = '.' + '.'.join(parts[1:])
+        if suffix == '.':
+            suffix = ''
+
         for i in itertools.count():
             if i:
                 insert_i = '{}{}'.format(insert, i)
             else:
                 insert_i = ''
-            name = u'{basename}{insert}{ext}'.format(basename=basename,
-                insert=insert_i, ext=ext)
-            if not self.exists(u'{}/{}'.format(path, name)):
+            name = u'{basename}{insert}{suffix}'.format(basename=basename,
+                insert=insert_i, suffix=suffix)
+            if not self.exists(os.path.join(path, name)):
                 break
         return name
 

--- a/notebook/services/contents/manager.py
+++ b/notebook/services/contents/manager.py
@@ -327,9 +327,7 @@ class ContentsManager(LoggingConfigurable):
         """
         # Extract the full suffix from the filename (e.g. .tar.gz)
         path = path.strip('/')
-        dirname, basename = os.path.split(filename)
-        name, dot, ext = basename.partition('.')
-        basename = os.path.join(dirname, name)
+        name, dot, ext = filename.partition('.')
         suffix = dot + ext
 
         for i in itertools.count():
@@ -337,9 +335,9 @@ class ContentsManager(LoggingConfigurable):
                 insert_i = '{}{}'.format(insert, i)
             else:
                 insert_i = ''
-            name = u'{basename}{insert}{suffix}'.format(basename=basename,
+            name = u'{name}{insert}{suffix}'.format(name=name,
                 insert=insert_i, suffix=suffix)
-            if not self.exists(os.path.join(path, name)):
+            if not self.exists(u'{}/{}'.format(path, name)):
                 break
         return name
 

--- a/notebook/services/contents/manager.py
+++ b/notebook/services/contents/manager.py
@@ -327,7 +327,7 @@ class ContentsManager(LoggingConfigurable):
         """
         # Extract the full suffix from the filename (e.g. .tar.gz)
         path = path.strip('/')
-        name, dot, ext = filename.partition('.')
+        basename, dot, ext = filename.partition('.')
         suffix = dot + ext
 
         for i in itertools.count():
@@ -335,7 +335,7 @@ class ContentsManager(LoggingConfigurable):
                 insert_i = '{}{}'.format(insert, i)
             else:
                 insert_i = ''
-            name = u'{name}{insert}{suffix}'.format(name=name,
+            name = u'{basename}{insert}{suffix}'.format(basename=basename,
                 insert=insert_i, suffix=suffix)
             if not self.exists(u'{}/{}'.format(path, name)):
                 break

--- a/notebook/services/contents/manager.py
+++ b/notebook/services/contents/manager.py
@@ -328,11 +328,9 @@ class ContentsManager(LoggingConfigurable):
         # Extract the full suffix from the filename (e.g. .tar.gz)
         dirname = os.path.dirname(filename)
         basename = os.path.basename(filename)
-        parts = basename.split('.')
-        basename = os.path.join(dirname, parts[0])
-        suffix = '.' + '.'.join(parts[1:])
-        if suffix == '.':
-            suffix = ''
+        name, dot, ext = basename.partition('.')
+        basename = os.path.join(dirname, name)
+        suffix = dot + ext
 
         for i in itertools.count():
             if i:

--- a/notebook/services/contents/manager.py
+++ b/notebook/services/contents/manager.py
@@ -326,8 +326,8 @@ class ContentsManager(LoggingConfigurable):
             A filename that is unique, based on the input filename.
         """
         # Extract the full suffix from the filename (e.g. .tar.gz)
-        dirname = os.path.dirname(filename)
-        basename = os.path.basename(filename)
+        path = path.strip('/')
+        dirname, basename = os.path.split(filename)
         name, dot, ext = basename.partition('.')
         basename = os.path.join(dirname, name)
         suffix = dot + ext

--- a/notebook/services/contents/tests/test_manager.py
+++ b/notebook/services/contents/tests/test_manager.py
@@ -300,6 +300,12 @@ class TestContentsManager(TestCase):
         self.assertEqual(model['name'], 'untitled')
         self.assertEqual(model['path'], '%s/untitled' % sub_dir)
 
+        # Test with a compound extension
+        model = cm.new_untitled(path=sub_dir, ext='.foo.bar')
+        self.assertEqual(model['name'], 'untitled.foo.bar')
+        model = cm.new_untitled(path=sub_dir, ext='.foo.bar')
+        self.assertEqual(model['name'], 'untitled1.foo.bar')
+
     def test_modified_date(self):
 
         cm = self.contents_manager


### PR DESCRIPTION
This allows file names with compound extensions (e.g. `.tar.gz`) to be properly incremented when creating a new file.  Previously we would end up with `untitled.tar1.gz`.

cf https://github.com/jupyterlab/jupyterlab/issues/3113