### PR TITLE
Bugfix for manager.py

### DIFF
--- a/notebook/services/contents/manager.py
+++ b/notebook/services/contents/manager.py
@@ -67,7 +67,7 @@ class ContentsManager(LoggingConfigurable):
         Glob patterns to hide in file and directory listings.
     """)
 
-    untitled_notebook = Unicode(_("Untitled"), config=True,
+    untitled_notebook = Unicode("Untitled", config=True,
         help="The base name used when creating untitled notebooks."
     )
 


### PR DESCRIPTION
Attempt to resolve the following error,

```bash
  File "/home/ubuntu/miniconda3/envs/gluon_zh_docs/lib/python3.6/site-packages/notebook/services/contents/filemanager.py", line 21, in <module>
    from .manager import ContentsManager
  File "/home/ubuntu/miniconda3/envs/gluon_zh_docs/lib/python3.6/site-packages/notebook/services/contents/manager.py", line 37, in <module>
    class ContentsManager(LoggingConfigurable):
  File "/home/ubuntu/miniconda3/envs/gluon_zh_docs/lib/python3.6/site-packages/notebook/services/contents/manager.py", line 69, in ContentsManager
    untitled_notebook = Unicode(_("Untitled"), config=True,
NameError: name '_' is not defined
```