### PR TITLE
set cookie on base_url

### DIFF
--- a/notebook/auth/login.py
+++ b/notebook/auth/login.py
@@ -94,6 +94,7 @@ class LoginHandler(IPythonHandler):
         # 'secure' kwarg is passed to set_secure_cookie
         if handler.settings.get('secure_cookie', handler.request.protocol == 'https'):
             cookie_options.setdefault('secure', True)
+        cookie_options.setdefault('path', handler.base_url)
         handler.set_secure_cookie(handler.cookie_name, user_id, **cookie_options)
         return user_id
 

--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -89,10 +89,16 @@ class AuthenticatedHandler(web.RequestHandler):
                 # if method is unsupported (websocket and Access-Control-Allow-Origin
                 # for example, so just ignore)
                 self.log.debug(e)
-    
+
     def clear_login_cookie(self):
-        self.clear_cookie(self.cookie_name)
-    
+        cookie_options = self.settings.get('cookie_options', {})
+        path = cookie_options.setdefault('path', self.base_url)
+        self.clear_cookie(self.cookie_name, path=path)
+        if path and path != '/':
+            # also clear cookie on / to ensure old cookies
+            # are cleared after the change in path behavior.
+            self.clear_cookie(self.cookie_name)
+
     def get_current_user(self):
         if self.login_handler is None:
             return 'anonymous'


### PR DESCRIPTION
avoids clobbering cookies when multiple notebook servers are run on one host (e.g. binder)

Users can override `cookie_options.path = '/'` if they *want* cookies to be shared across notebooks on one host.