### PR TITLE
Config option to shut down server after N seconds with no kernels

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1070,6 +1070,14 @@ class NotebookApp(JupyterApp):
     rate_limit_window = Float(3, config=True, help=_("""(sec) Time window used to 
         check the message and data rate limits."""))
 
+    shutdown_no_kernels_timeout = Integer(0, config=True,
+        help=("Use a positive integer, to shut down the server after N "
+             "seconds with no kernels running. This can be used together with "
+             "culling idle kernels (MappingKernelManager.cull_idle_timeout) to "
+              "shutdown the notebook server when it's not in use. "
+              "Do not rely on this being accurately timed.")
+    )
+
     def parse_command_line(self, argv=None):
         super(NotebookApp, self).parse_command_line(argv)
 
@@ -1357,6 +1365,26 @@ class NotebookApp(JupyterApp):
         # mimetype always needs to be text/css, so we override it here.
         mimetypes.add_type('text/css', '.css')
 
+    def shutdown_no_kernels(self):
+        """Shutdown server on timeout when there are no kernels."""
+        km = self.kernel_manager
+        if len(km) == 0:
+            seconds_since_kernel = \
+                (utcnow() - km.last_kernel_activity).total_seconds()
+            self.log.debug("No kernels for %d seconds.",
+                           seconds_since_kernel)
+            if seconds_since_kernel > self.shutdown_no_kernels_timeout:
+                self.log.info("No kernels for %d seconds; shutting down.",
+                              seconds_since_kernel)
+                self.stop()
+
+    def init_shutdown_no_kernels(self):
+        if self.shutdown_no_kernels_timeout > 0:
+            self.log.info("Will shut down after %d seconds with no kernels.",
+                          self.shutdown_no_kernels_timeout)
+            pc = ioloop.PeriodicCallback(self.shutdown_no_kernels, 60000)
+            pc.start()
+
     @catch_config_error
     def initialize(self, argv=None):
         super(NotebookApp, self).initialize(argv)
@@ -1370,6 +1398,7 @@ class NotebookApp(JupyterApp):
         self.init_signal()
         self.init_server_extensions()
         self.init_mime_overrides()
+        self.init_shutdown_no_kernels()
 
     def cleanup_kernels(self):
         """Shutdown all kernels.

--- a/notebook/services/api/handlers.py
+++ b/notebook/services/api/handlers.py
@@ -33,14 +33,11 @@ class APIStatusHandler(APIHandler):
     def get(self):
         # if started was missing, use unix epoch
         started = self.settings.get('started', utcfromtimestamp(0))
-        # if we've never seen API activity, use started date
-        api_last_activity = self.settings.get('api_last_activity', started)
         started = isoformat(started)
-        api_last_activity = isoformat(api_last_activity)
 
         kernels = yield gen.maybe_future(self.kernel_manager.list_kernels())
         total_connections = sum(k['connections'] for k in kernels)
-        last_activity = max(chain([api_last_activity], [k['last_activity'] for k in kernels]))
+        last_activity = isoformat(self.application.last_activity())
         model = {
             'started': started,
             'last_activity': last_activity,

--- a/notebook/terminal/handlers.py
+++ b/notebook/terminal/handlers.py
@@ -6,6 +6,7 @@
 
 from tornado import web
 import terminado
+from notebook._tz import utcnow
 from ..base.handlers import IPythonHandler
 from ..base.zmqhandlers import WebSocketMixin
 
@@ -31,4 +32,11 @@ class TermSocket(WebSocketMixin, IPythonHandler, terminado.TermSocket):
         if not self.get_current_user():
             raise web.HTTPError(403)
         return super(TermSocket, self).get(*args, **kwargs)
-    
+
+    def on_message(self, message):
+        super(TermSocket, self).on_message(message)
+        self.application.settings['terminal_last_activity'] = utcnow()
+
+    def write_message(self, message, binary=False):
+        super(TermSocket, self).write_message(message, binary=binary)
+        self.application.settings['terminal_last_activity'] = utcnow()


### PR DESCRIPTION
This is something I was discussing with @minrk yesterday: allow the notebook server to shut down automatically after some time with no kernels active. This could be useful with nbopen: a notebook server can be started automatically when you double-click a notebook file, and then clean itself up automatically when you've finished using it.

This is not yet ready for merge: I think it should take all activity into account for the timeout, not just kernel activity, so it doesn't shut down while you're editing a file or using a terminal. It will probably be a few days before I have time to finish it off.