### PR TITLE
Add toolbar icon to restart and run all

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -117,6 +117,7 @@ define([
             }
         },
         'confirm-restart-kernel-and-run-all-cells': {
+            icon: 'fa-recycle',
             cmd: i18n.msg._('confirm restart kernel and run all cells'),
             help: i18n.msg._('restart the kernel, then re-run the whole notebook (with dialog)'),
             handler: function (env) {

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -117,7 +117,7 @@ define([
             }
         },
         'confirm-restart-kernel-and-run-all-cells': {
-            icon: 'fa-recycle',
+            icon: 'fa-forward',
             cmd: i18n.msg._('confirm restart kernel and run all cells'),
             help: i18n.msg._('restart the kernel, then re-run the whole notebook (with dialog)'),
             handler: function (env) {

--- a/notebook/static/notebook/js/maintoolbar.js
+++ b/notebook/static/notebook/js/maintoolbar.js
@@ -53,7 +53,8 @@ define([
           [ [new toolbar.Button('jupyter-notebook:run-cell-and-select-next',
                 {label: i18n.msg._('Run')}),
              'jupyter-notebook:interrupt-kernel',
-             'jupyter-notebook:confirm-restart-kernel'
+             'jupyter-notebook:confirm-restart-kernel',
+             'jupyter-notebook:confirm-restart-kernel-and-run-all-cells'
             ],
             'run_int'],
          ['<add_celltype_list>'],
@@ -61,7 +62,7 @@ define([
         ];
         this.construct(grps);
     };
-   
+
     MainToolBar.prototype._pseudo_actions = {};
 
     // add a cell type drop down to the maintoolbar.


### PR DESCRIPTION
With notebooks you can become a victim of your own interactive exploration aka re-running cells in a wild, non linear order. The advice for avoiding this is to (frequently) "run it from the top" by hitting restart and run all. I think it would be useful to have an icon on the toolbar to do this as a way to encourage this behaviour.

What do you think?

The icon is not ideal, maybe some FA magic of combining the play and restart icon would be better?