### PR TITLE
update version to dev version for master to not overwrite editable installs

### DIFF
--- a/notebook/_version.py
+++ b/notebook/_version.py
@@ -9,5 +9,5 @@ store the current version info of the notebook.
 
 # Next beta/alpha/rc release: The version number for beta is X.Y.ZbN **without dots**. 
 
-version_info = (5, 2, 0)
+version_info = (5, 3, 0, ".dev0")
 __version__ = '.'.join(map(str, version_info[:3])) + ''.join(version_info[3:])

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -73,7 +73,7 @@ define(function(){
     // tree
     jglobal('SessionList','tree/js/sessionlist');
 
-    Jupyter.version = "5.2.0";
+    Jupyter.version = "5.3.0.dev0";
     Jupyter._target = '_blank';
     return Jupyter;
 });


### PR DESCRIPTION
Return to a dev version number so that it gets precedence when doing `pip install -U ___` for other packages that have the notebook as a dependency.