### PR TITLE
update conda after selecting conda-forge

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,9 @@ build: off
 
 install:
   - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-  - cmd: conda update --yes --quiet conda
   - cmd: conda config --set show_channel_urls true
   - cmd: conda config --add channels conda-forge
+  - cmd: conda update --yes --quiet conda
   - cmd: conda install -y pyzmq tornado jupyter_client nbformat nbconvert ipykernel pip nodejs nose
   - cmd: pip install .[test]
 


### PR DESCRIPTION
avoids updating conda from defaults, then downgrading from conda-forge during big install

this appears to fix AppVeyor for now

Merging once it works so that tests can get back to passing. I'll continue debugging in #2998 to figure out the real cause, which may be a bug in conda 4.3.30.