### PR TITLE
Send HTTP shutdown request on 'stop' subcommand

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -410,6 +410,9 @@ class NbserverStopApp(JupyterApp):
         if self.extra_args:
             self.port=int(self.extra_args[0])
 
+    def shutdown_server(self, server):
+        return shutdown_server(server, log=self.log)
+
     def start(self):
         servers = list(list_running_servers(self.runtime_dir))
         if not servers:
@@ -417,7 +420,7 @@ class NbserverStopApp(JupyterApp):
         for server in servers:
             if server['port'] == self.port:
                 print("Shutting down server on port", self.port, "...")
-                if not shutdown_server(server, log=self.log):
+                if not self.shutdown_server(server):
                     sys.exit("Could not stop server")
                 return
         else:

--- a/notebook/tests/test_notebookapp.py
+++ b/notebook/tests/test_notebookapp.py
@@ -140,6 +140,15 @@ def test_notebook_password():
             nt.assert_not_equal(nb.password, '')
             passwd_check(nb.password, password)
 
+class TestingStopApp(notebookapp.NbserverStopApp):
+    """For testing the logic of NbserverStopApp."""
+    def __init__(self, **kwargs):
+        super(TestingStopApp, self).__init__(**kwargs)
+        self.servers_shut_down = []
+
+    def shutdown_server(self, server):
+        self.servers_shut_down.append(server)
+        return True
 
 def test_notebook_stop():
     def list_running_servers(runtime_dir):
@@ -159,18 +168,18 @@ def test_notebook_stop():
     mock_servers = patch('notebook.notebookapp.list_running_servers', list_running_servers)
 
     # test stop with a match
-    with mock_servers, patch('os.kill') as os_kill:
-        app = notebookapp.NbserverStopApp()
+    with mock_servers:
+        app = TestingStopApp()
         app.initialize(['105'])
         app.start()
-    nt.assert_equal(os_kill.call_count, 1)
-    nt.assert_equal(os_kill.call_args, ((1105, signal.SIGTERM),))
+    nt.assert_equal(len(app.servers_shut_down), 1)
+    nt.assert_equal(app.servers_shut_down[0]['port'], 105)
 
     # test no match
     with mock_servers, patch('os.kill') as os_kill:
-        app = notebookapp.NbserverStopApp()
+        app = TestingStopApp()
         app.initialize(['999'])
         with nt.assert_raises(SystemExit) as exc:
             app.start()
-        nt.assert_equal(exc.exception.code, 1)
-    nt.assert_equal(os_kill.call_count, 0)
+        nt.assert_equal(exc.exception.exception_code, 1)
+    nt.assert_equal(len(app.servers_shut_down), 0)

--- a/notebook/tests/test_notebookapp.py
+++ b/notebook/tests/test_notebookapp.py
@@ -181,5 +181,5 @@ def test_notebook_stop():
         app.initialize(['999'])
         with nt.assert_raises(SystemExit) as exc:
             app.start()
-        nt.assert_equal(exc.exception.exception_code, 1)
+        nt.assert_equal(exc.exception.code, 1)
     nt.assert_equal(len(app.servers_shut_down), 0)


### PR DESCRIPTION
Signals don't work on Windows. This tries the HTTP shutdown request first. On Unix, it will try SIGTERM after 5 seconds, and SIGKILL after another 5, if the server didn't already exit.

Closes gh-2937