### PR TITLE
Switch to jupyter_core implementation of ensure_dir_exists

### DIFF
--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -24,7 +24,7 @@ from jupyter_core.paths import (
     jupyter_data_dir, jupyter_config_path, jupyter_path,
     SYSTEM_JUPYTER_PATH, ENV_JUPYTER_PATH,
 )
-from ipython_genutils.path import ensure_dir_exists
+from jupyter_core.utils import ensure_dir_exists
 from ipython_genutils.py3compat import string_types, cast_unicode_py2
 from ipython_genutils.tempdir import TemporaryDirectory
 from ._version import __version__

--- a/notebook/services/contents/filecheckpoints.py
+++ b/notebook/services/contents/filecheckpoints.py
@@ -12,7 +12,7 @@ from .checkpoints import (
 )
 from .fileio import FileManagerMixin
 
-from ipython_genutils.path import ensure_dir_exists
+from jupyter_core.utils import ensure_dir_exists
 from ipython_genutils.py3compat import getcwd
 from traitlets import Unicode
 

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ install_requires = [
     'tornado>=4',
     'ipython_genutils',
     'traitlets>=4.2.1',
-    'jupyter_core',
+    'jupyter_core>=4.4.0',
     'jupyter_client',
     'nbformat',
     'nbconvert',


### PR DESCRIPTION
Closes gh-2858

Requires jupyter_core 4.4.0, which I just released.