### PR TITLE
Add shutdown button option

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1025,8 +1025,8 @@ class NotebookApp(JupyterApp):
     def _update_mathjax_config(self, change):
         self.log.info(_("Using MathJax configuration file: %s"), change['new'])
         
-    shutdown_button = Bool(False, config=True,
-        help="""Whether or not to display a shutdown server button in the dashboard"""
+    shutdown_button = Bool(True, config=True,
+        help="""If True, display a button in the dashboard to shutdown the server"""
     )
 
     contents_manager_class = Type(

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -273,6 +273,7 @@ class NotebookWebApplication(web.Application):
             websocket_url=jupyter_app.websocket_url,
             mathjax_url=jupyter_app.mathjax_url,
             mathjax_config=jupyter_app.mathjax_config,
+            shutdown_button=jupyter_app.shutdown_button,
             config=jupyter_app.config,
             config_dir=jupyter_app.config_dir,
             allow_password_change=jupyter_app.allow_password_change,
@@ -1023,6 +1024,10 @@ class NotebookApp(JupyterApp):
     @observe('mathjax_config')
     def _update_mathjax_config(self, change):
         self.log.info(_("Using MathJax configuration file: %s"), change['new'])
+        
+    shutdown_button = Bool(False, config=True,
+        help="""Whether or not to display a shutdown server button in the dashboard"""
+    )
 
     contents_manager_class = Type(
         default_value=LargeFileManager,

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -273,7 +273,7 @@ class NotebookWebApplication(web.Application):
             websocket_url=jupyter_app.websocket_url,
             mathjax_url=jupyter_app.mathjax_url,
             mathjax_config=jupyter_app.mathjax_config,
-            shutdown_button=jupyter_app.shutdown_button,
+            shutdown_button=jupyter_app.quit_button,
             config=jupyter_app.config,
             config_dir=jupyter_app.config_dir,
             allow_password_change=jupyter_app.allow_password_change,
@@ -1025,8 +1025,9 @@ class NotebookApp(JupyterApp):
     def _update_mathjax_config(self, change):
         self.log.info(_("Using MathJax configuration file: %s"), change['new'])
         
-    shutdown_button = Bool(True, config=True,
-        help="""If True, display a button in the dashboard to shutdown the server"""
+    quit_button = Bool(True, config=True,
+        help="""If True, display a button in the dashboard to quit
+        (shutdown the notebook server)."""
     )
 
     contents_manager_class = Type(

--- a/notebook/static/base/less/page.less
+++ b/notebook/static/base/less/page.less
@@ -124,9 +124,10 @@ span#login_widget {
 }
 
 span#login_widget > .button,
-#logout
+#logout, #shutdown
 {
     .btn-default();
+    margin-left: 10px;
 }
 
 .nav-header {

--- a/notebook/static/tree/js/main.js
+++ b/notebook/static/tree/js/main.js
@@ -209,4 +209,21 @@ requirejs([
     if (window.location.hash) {
         $("#tabs").find("a[href=" + window.location.hash + "]").click();
     }
+    
+    // Add shutdown button
+    $("button#shutdown").click(function () {
+        utils.ajax(utils.url_path_join(
+            utils.get_body_data("baseUrl"),
+            "api",
+            "shutdown"
+        ), {
+            type: "POST",
+            success: function() {
+                console.log('server shutdown');
+            },
+            error: function(error) {
+                console.log(error);
+            }
+        });
+    });
 });

--- a/notebook/static/tree/js/main.js
+++ b/notebook/static/tree/js/main.js
@@ -35,6 +35,7 @@ requirejs([
     'tree/js/kernellist',
     'tree/js/terminallist',
     'tree/js/newnotebook',
+    'tree/js/shutdownbutton',
     'auth/js/loginwidget',
     'bidi/bidi',
 ], function(
@@ -52,6 +53,7 @@ requirejs([
     kernellist,
     terminallist,
     newnotebook,
+    shutdownbutton,
     loginwidget,
     bidi){
     "use strict";
@@ -210,20 +212,5 @@ requirejs([
         $("#tabs").find("a[href=" + window.location.hash + "]").click();
     }
     
-    // Add shutdown button
-    $("button#shutdown").click(function () {
-        utils.ajax(utils.url_path_join(
-            utils.get_body_data("baseUrl"),
-            "api",
-            "shutdown"
-        ), {
-            type: "POST",
-            success: function() {
-                console.log('server shutdown');
-            },
-            error: function(error) {
-                console.log(error);
-            }
-        });
-    });
+    shutdownbutton.activate();
 });

--- a/notebook/static/tree/js/shutdownbutton.js
+++ b/notebook/static/tree/js/shutdownbutton.js
@@ -1,0 +1,52 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+define([
+    'jquery',
+    'base/js/dialog',
+    'base/js/events',
+    'base/js/promises',
+    'base/js/page',
+    'base/js/utils'
+], function(
+    $,
+    dialog,
+    events,
+    promises,
+    page,
+    utils
+){
+    "use strict";
+
+    function display_shutdown_dialog() {
+        var body = $('<div/>').append(
+            $('<p/>').text("You have shut down Jupyter. You can now close this tab.")
+        ).append(
+            $('<p/>').text("To use Jupyter again, you will need to relaunch it.")
+        );
+
+        dialog.modal({
+            title: "Server stopped",
+            body: body
+        })
+    }
+
+    function activate() {
+        // Add shutdown button
+        $("button#shutdown").click(function () {
+            utils.ajax(utils.url_path_join(
+                utils.get_body_data("baseUrl"),
+                "api",
+                "shutdown"
+            ), {
+                type: "POST",
+                success: display_shutdown_dialog,
+                error: function (error) {
+                    console.log(error);
+                }
+            });
+        });
+    }
+
+    return {activate: activate}
+});

--- a/notebook/static/tree/js/shutdownbutton.js
+++ b/notebook/static/tree/js/shutdownbutton.js
@@ -4,29 +4,25 @@
 define([
     'jquery',
     'base/js/dialog',
-    'base/js/events',
-    'base/js/promises',
-    'base/js/page',
+    'base/js/i18n',
     'base/js/utils'
 ], function(
     $,
     dialog,
-    events,
-    promises,
-    page,
+    i18n,
     utils
 ){
     "use strict";
 
     function display_shutdown_dialog() {
         var body = $('<div/>').append(
-            $('<p/>').text("You have shut down Jupyter. You can now close this tab.")
+            $('<p/>').text(i18n.msg._("You have shut down Jupyter. You can now close this tab."))
         ).append(
-            $('<p/>').text("To use Jupyter again, you will need to relaunch it.")
+            $('<p/>').text(i18n.msg._("To use Jupyter again, you will need to relaunch it."))
         );
 
         dialog.modal({
-            title: "Server stopped",
+            title: i18n.msg._("Server stopped"),
             body: body
         })
     }

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -15,7 +15,10 @@ data-server-root="{{server_root}}"
   <span class="flex-spacer"></span>
   {% if shutdown_button %}
     <span id="shutdown_widget">
-      <button id="shutdown" class="btn btn-sm navbar-btn">Shutdown</button>
+      <button id="shutdown" class="btn btn-sm navbar-btn"
+              title="{% trans %}Stop the Jupyter server{% endtrans %}">
+          {% trans %}Quit{% endtrans %}
+      </button>
     </span>
   {% endif %}
 {% endblock %}

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -12,7 +12,12 @@ data-server-root="{{server_root}}"
 {% endblock %}
 
 {% block headercontainer %}
-<span class="flex-spacer"></span>
+  <span class="flex-spacer"></span>
+  {% if shutdown_button %}
+    <span id="shutdown_widget">
+      <button id="shutdown" class="btn btn-sm navbar-btn">Shutdown</button>
+    </span>
+  {% endif %}
 {% endblock %}
 
 {% block site %}

--- a/notebook/tree/handlers.py
+++ b/notebook/tree/handlers.py
@@ -51,6 +51,7 @@ class TreeHandler(IPythonHandler):
                 breadcrumbs=breadcrumbs,
                 terminals_available=self.settings['terminals_available'],
                 server_root=self.settings['server_root_dir'],
+                shutdown_button=self.settings.get('shutdown_button', False)
             ))
         elif cm.file_exists(path):
             # it's not a directory, we have redirecting to do


### PR DESCRIPTION
Closes https://github.com/jupyter/notebook/issues/1530

Introduces a new option `--NotebookApp.shutdown_button` which will add a button to the dashboard header that when clicked will shutdown the notebook server.

![](http://g.recordit.co/clpbqxgy2s.gif)