### PR TITLE
When login-in via token, let a chance for user to set the password

### DIFF
--- a/docs/source/public_server.rst
+++ b/docs/source/public_server.rst
@@ -63,15 +63,28 @@ using the following command::
 
   $ jupyter notebook --generate-config
 
-.. _hashed-pw:
 
-Preparing a hashed password
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Automatic Password setup
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-As of notebook version 5.0, you can enter and store a password for your
-notebook server with a single command.
-:command:`jupyter notebook password` will prompt you for your password
-and record the hashed password in your :file:`jupyter_notebook_config.json`.
+As of notebook 5.3, the first time you log-in using a token, the notebook server
+should give you the opportunity to setup a password from the user interface.
+
+You will be presented with a form asking for the current _token_, as well as
+your _new_ _password_ ; enter both and click on ``Login and setup new password``.
+
+Next time you need to log in you'll be able to use the new password instead of
+the login token, otherwise follow the procedure to set a password from the
+command line.
+
+The ability to change the password at first login time may be disabled by
+integrations by setting the ``--NotebookApp.allow_password_change=True``
+
+
+Starting at notebook version 5.0, you can enter and store a password for your
+notebook server with a single command. :command:`jupyter notebook password` will
+prompt you for your password and record the hashed password in your
+:file:`jupyter_notebook_config.json`.
 
 .. code-block:: bash
 
@@ -79,6 +92,15 @@ and record the hashed password in your :file:`jupyter_notebook_config.json`.
     Enter password:  ****
     Verify password: ****
     [NotebookPasswordApp] Wrote hashed password to /Users/you/.jupyter/jupyter_notebook_config.json
+
+This can be used to reset a lost password; or if you believe your credentials
+have been leaked and desire to change your password. Changing your password will
+invalidate all logged-in sessions after a server restart.
+
+.. _hashed-pw:
+
+Preparing a hashed password
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can prepare a hashed password manually, using the function
 :func:`notebook.auth.security.passwd`:
@@ -108,6 +130,12 @@ You can then add the hashed password to your
 directory, ``~/.jupyter``, e.g.::
 
     c.NotebookApp.password = u'sha1:67c9e60bb8b6:9ffede0825894254b2e042ea597d771089e11aed'
+
+Automatic password setup will store the hash in ``jupyter_notebook_config.json``
+while this method store in in ``jupyter_notebook_config.py``. The ``.json``
+configuration options take precedence over the ``.py`` one, thus the manual
+password may not take effect if the Json file as a password set.
+
 
 Using SSL for encrypted communication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/public_server.rst
+++ b/docs/source/public_server.rst
@@ -78,7 +78,7 @@ the login token, otherwise follow the procedure to set a password from the
 command line.
 
 The ability to change the password at first login time may be disabled by
-integrations by setting the ``--NotebookApp.allow_password_change=True``
+integrations by setting the ``--NotebookApp.allow_password_change=False``
 
 
 Starting at notebook version 5.0, you can enter and store a password for your

--- a/notebook/auth/login.py
+++ b/notebook/auth/login.py
@@ -82,7 +82,7 @@ class LoginHandler(IPythonHandler):
                 self.set_login_cookie(self, uuid.uuid4().hex)
             elif self.token and self.token == typed_password:
                 self.set_login_cookie(self, uuid.uuid4().hex)
-                if self.new_password:
+                if self.new_password and self.settings.get('allow_password_change'):
                     config_dir = self.settings.get('config_dir')
                     config_file = os.path.join(config_dir, 'jupyter_notebook_config.json')
                     set_password(new_password, config_file=config_file)

--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -400,6 +400,7 @@ class IPythonHandler(AuthenticatedHandler):
             default_url=self.default_url,
             ws_url=self.ws_url,
             logged_in=self.logged_in,
+            allow_password_change=self.settings.get('allow_password_change'),
             login_available=self.login_available,
             token_available=bool(self.token or self.one_time_token),
             static_url=self.static_url,

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -267,6 +267,7 @@ class NotebookWebApplication(web.Application):
             mathjax_config=jupyter_app.mathjax_config,
             config=jupyter_app.config,
             config_dir=jupyter_app.config_dir,
+            allow_password_change=jupyter_app.allow_password_change,
             server_root_dir=root_dir,
             jinja2_env=env,
             terminals_available=False,  # Set later if terminals are available
@@ -749,6 +750,18 @@ class NotebookApp(JupyterApp):
 
                       """
     )
+
+    allow_password_change = Bool(True, config=True, 
+                    help="""Allow password to be changed at login for the notebook server. 
+
+                    While loggin in with a token, the notebook server UI will give the opportunity to
+                    the user to enter a new password at the same time that will replace
+                    the token login mechanism. 
+
+                    This can be set to false to prevent changing password from the UI/API.
+                    """
+    )
+
 
     disable_check_xsrf = Bool(False, config=True,
         help="""Disable cross-site-request-forgery protection

--- a/notebook/templates/login.html
+++ b/notebook/templates/login.html
@@ -85,6 +85,22 @@ http://localhost:8888/?token=c8de56fa... :: /Users/you/notebooks
       <p>
         Cookies are required for authenticated access to notebooks.
       </p>
+      <h3>{% trans %}Setup a Password{% endtrans %}</h3>
+      <p> You can setup a password by entering your token and a new password
+      on the fields below:</p>
+      <form action="{{base_url}}login?next={{next}}" method="post" class="">
+              {{ xsrf_form_html() | safe }}
+        <div class="form-group">
+          <input type="password" name="password" id="password_input" class="form-control" placeholder="Token">
+        </div>
+        <div class="form-group">
+          <input type="password" name="new_password" id="new_password_input"
+          class="form-control" placeholder="New password" required>
+        </div>
+        <div class="form-group">
+          <button type="submit" id="login_submit">{% trans %}Log in and set new password{% endtrans %}</button>
+        </div>
+      </form>
 
     </div>
     {% endblock token_message %}

--- a/notebook/templates/login.html
+++ b/notebook/templates/login.html
@@ -85,22 +85,24 @@ http://localhost:8888/?token=c8de56fa... :: /Users/you/notebooks
       <p>
         Cookies are required for authenticated access to notebooks.
       </p>
-      <h3>{% trans %}Setup a Password{% endtrans %}</h3>
-      <p> You can setup a password by entering your token and a new password
-      on the fields below:</p>
-      <form action="{{base_url}}login?next={{next}}" method="post" class="">
-              {{ xsrf_form_html() | safe }}
-        <div class="form-group">
-          <input type="password" name="password" id="password_input" class="form-control" placeholder="Token">
-        </div>
-        <div class="form-group">
-          <input type="password" name="new_password" id="new_password_input"
-          class="form-control" placeholder="New password" required>
-        </div>
-        <div class="form-group">
-          <button type="submit" id="login_submit">{% trans %}Log in and set new password{% endtrans %}</button>
-        </div>
-      </form>
+      {% if allow_password_change %}
+        <h3>{% trans %}Setup a Password{% endtrans %}</h3>
+        <p> You can also setup a password by entering your token and a new password
+        on the fields below:</p>
+        <form action="{{base_url}}login?next={{next}}" method="post" class="">
+                {{ xsrf_form_html() | safe }}
+          <div class="form-group">
+            <input type="password" name="password" id="password_input" class="form-control" placeholder="Token">
+          </div>
+          <div class="form-group">
+            <input type="password" name="new_password" id="new_password_input"
+            class="form-control" placeholder="New password" required>
+          </div>
+          <div class="form-group">
+            <button type="submit" id="login_submit">{% trans %}Log in and set new password{% endtrans %}</button>
+          </div>
+        </form>
+      {% endif %}
 
     </div>
     {% endblock token_message %}


### PR DESCRIPTION
When token is enabled, the login page will present a form to the user
asking them if they want to set a password at the same time. This is
almost equivalent to running `jupyter notebook password` on the command
line.

The experience can likely be better, but just submitting that as a POC
for feedback