### PR TITLE
Hash cookie secret with user hashed password.

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -27,6 +27,7 @@ import threading
 import time
 import warnings
 import webbrowser
+import hmac
 
 try: #PY3
     from base64 import encodebytes
@@ -674,11 +675,16 @@ class NotebookApp(JupyterApp):
     def _default_cookie_secret(self):
         if os.path.exists(self.cookie_secret_file):
             with io.open(self.cookie_secret_file, 'rb') as f:
-                return f.read()
+                key =  f.read()
         else:
-            secret = encodebytes(os.urandom(1024))
-            self._write_cookie_secret_file(secret)
-            return secret
+            key = encodebytes(os.urandom(1024))
+            self._write_cookie_secret_file(key)
+        h = hmac.HMAC(key)
+        h.digest_size = len(key)
+        h.update(self.password.encode())
+        return h.digest()
+
+
     
     def _write_cookie_secret_file(self, secret):
         """write my secret to my secret_file"""


### PR DESCRIPTION
Currently changing the password does not revoke current session:

  - jupyter notebook password <password1>
  - jupyter notebook
  - Logging in
  - Kill server
  - jupyter notebook password <other password>
  - jupyter notebook
  - Oh ! I'm still logged in.

With this, as the "effective" secret depends on the (hashed) password,
changing it void any existing session (which I believe is the goal of
most password change)

cc @minrk, @rgbkrk, and @yuvipanda for review. 