### PR TITLE
Add link to Korean Version of Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If you are interested in contributing to the project, see [`CONTRIBUTING.rst`](C
 - [Project Jupyter website](https://jupyter.org)
 - [Online Demo at try.jupyter.org](https://try.jupyter.org)
 - [Documentation for Jupyter notebook](https://jupyter-notebook.readthedocs.io/en/latest/) [[PDF](https://media.readthedocs.org/pdf/jupyter-notebook/latest/jupyter-notebook.pdf)]
+- [Korean Version of Installation](https://github.com/ChungJooHo/Jupyter_Kor_doc/)
 - [Documentation for Project Jupyter](https://jupyter.readthedocs.io/en/latest/index.html) [[PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)]
 - [Issues](https://github.com/jupyter/notebook/issues)
 - [Technical support - Jupyter Google Group](https://groups.google.com/forum/#!forum/jupyter)


### PR DESCRIPTION
I add my repo link on README so that people who wants to read it
translated version of Korean.

As I heared your idea, I made new repo. And I will continue to translate such docs as soon as I can.
The link I added is a link to my repo, so people who wants to read it can see Korean version.

I will update my repo steadily. Thank you.