### PR TITLE
Use `/files` prefix for PDF-like files

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -563,6 +563,12 @@ define([
       return model.mimetype === 'text/html' 
         || includes_extension(model.path, viewable_extensions);
     };
+    
+    // Files like PDF that should be opened using `/files` prefix
+    NotebookList.prototype._is_pdflike = function(model) {
+      var pdflike_extensions = ['pdf'];
+      return includes_extension(model.path, pdflike_extensions);
+    };
 
     /**
      * Handles when any row selector checkbox is toggled.
@@ -731,6 +737,10 @@ define([
         if (model.type === 'file' && this._is_viewable(model))
         {
             uri_prefix = 'view';
+        }
+        if (model.type === 'file' && this._is_pdflike(model))
+        {
+            uri_prefix = 'files';
         }
         if (model.type === 'file' && this._is_notebook(model))
         {


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/pull/2911#issuecomment-343301587

This adds one more conditional for PDF-like files (currently only PDF) that can be viewed (opened) in the browser but don't work with:

```html
<iframe id="iframe" sandbox="allow-scripts" src="{{file_url}}"></iframe>`
```

Other file extensions that are like this (off the top of my head) are office files (`.doc`, `.xls`, `.docx`, `.xls`, `.xlsx`, `.ppt`) (at least using Chrome).