### PR TITLE
tornado 5: PeriodicCallback loop arg will be removed

### DIFF
--- a/notebook/base/zmqhandlers.py
+++ b/notebook/base/zmqhandlers.py
@@ -158,14 +158,14 @@ class WebSocketMixin(object):
 
     def open(self, *args, **kwargs):
         self.log.debug("Opening websocket %s", self.request.path)
-        
+
         # start the pinging
         if self.ping_interval > 0:
             loop = ioloop.IOLoop.current()
             self.last_ping = loop.time()  # Remember time of last ping
             self.last_pong = self.last_ping
             self.ping_callback = ioloop.PeriodicCallback(
-                self.send_ping, self.ping_interval, io_loop=loop,
+                self.send_ping, self.ping_interval,
             )
             self.ping_callback.start()
         return super(WebSocketMixin, self).open(*args, **kwargs)
@@ -175,7 +175,7 @@ class WebSocketMixin(object):
         if self.stream.closed() and self.ping_callback is not None:
             self.ping_callback.stop()
             return
-        
+
         # check for timeout on pong.  Make sure that we really have sent a recent ping in
         # case the machine with both server and client has been suspended since the last ping.
         now = ioloop.IOLoop.current().time()

--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -449,10 +449,8 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
         for channel, stream in self.channels.items():
             if stream is not None and not stream.closed():
                 stream.on_recv(None)
-                # close the socket directly, don't wait for the stream
-                socket = stream.socket
                 stream.close()
-        
+
         self.channels = {}
         self._close_future.set_result(None)
 

--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -452,7 +452,6 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
                 # close the socket directly, don't wait for the stream
                 socket = stream.socket
                 stream.close()
-                socket.close()
         
         self.channels = {}
         self._close_future.set_result(None)

--- a/notebook/services/kernels/kernelmanager.py
+++ b/notebook/services/kernels/kernelmanager.py
@@ -386,7 +386,7 @@ class MappingKernelManager(MultiKernelManager):
                         self.cull_interval, self.cull_interval_default)
                     self.cull_interval = self.cull_interval_default
                 self._culler_callback = PeriodicCallback(
-                    self.cull_kernels, 1000*self.cull_interval, loop)
+                    self.cull_kernels, 1000*self.cull_interval)
                 self.log.info("Culling kernels with idle durations > %s seconds at %s second intervals ...",
                     self.cull_idle_timeout, self.cull_interval)
                 if self.cull_busy:

--- a/notebook/services/kernels/kernelmanager.py
+++ b/notebook/services/kernels/kernelmanager.py
@@ -241,7 +241,6 @@ class MappingKernelManager(MultiKernelManager):
         for stream in buffer_info['channels'].values():
             if not stream.closed():
                 stream.on_recv(None)
-                stream.socket.close()
                 stream.close()
 
         msg_buffer = buffer_info['buffer']


### PR DESCRIPTION
PCs are always run with the current eventloop, which is what the loop we have been passing explicitly already is.

Also fixed a case where we were closing ZMQStream and socket separately,
which may have been safe in the past, but can raise errors due to trying to unregister a closed socket with zmq.