### PR TITLE
 Fix moment locale loading in bidi support

### DIFF
--- a/notebook/static/bidi/bidi.js
+++ b/notebook/static/bidi/bidi.js
@@ -5,7 +5,6 @@ define(['bidi/numericshaping'], function(numericshaping) {
   'use strict';
 
   var shaperType = '';
-  var textDir = '';
 
   var _uiLang = function() {
     return navigator.language.toLowerCase();
@@ -13,7 +12,7 @@ define(['bidi/numericshaping'], function(numericshaping) {
 
   var _loadLocale = function() {
     if (_isMirroringEnabled()) {
-      $('body').attr('dir', 'rtl');
+      document.body.dir = 'rtl';
     }
 
     require(['moment'], function (moment) {
@@ -26,11 +25,6 @@ define(['bidi/numericshaping'], function(numericshaping) {
   var _isMirroringEnabled = function() {
     return new RegExp('^(ar|he)').test(_uiLang());
   };
-
-  /**
-     * NS :  for digit Shaping.
-     * BTD : for future work in case of Base Text Direction Addition.
-     */
 
   /**
      * @param value : the string to apply the bidi-support on it.

--- a/notebook/static/bidi/bidi.js
+++ b/notebook/static/bidi/bidi.js
@@ -15,16 +15,10 @@ define(['bidi/numericshaping'], function(numericshaping) {
     if (_isMirroringEnabled()) {
       $('body').attr('dir', 'rtl');
     }
-    var uiLang = _uiLang();
 
-    if (uiLang !== 'en' && uiLang !== 'en-us') {
-      // moment does not ship with a separate file for locale/en or locale/en-us
-      // so we must skip dynamically requiring it
-      requirejs(['components/moment/locale/' + _uiLang()], function(err) {
-        console.warn('Error loading the required locale');
-        console.warn(err);
-      });
-    }
+    require(['moment'], function (moment) {
+      console.log('Loaded moment locale', moment.locale(_uiLang()));
+    });
 
     shaperType = _uiLang() == 'ar' ? 'national' : 'defaultNumeral';
   };


### PR DESCRIPTION
This is throwing errors like

```
Uncaught Error: Script error for "components/moment/locale/en-gb"
http://requirejs.org/docs/errors.html#scripterror
    at makeError (require.js?v=6da8be361b9ee26c5e721e76c6d4afce:165)
    at HTMLScriptElement.onScriptError (require.js?v=6da8be361b9ee26c5e721e76c6d4afce:1732)
makeError @ require.js?v=6da8be361b9ee26c5e721e76c6d4afce:165
onScriptError @ require.js?v=6da8be361b9ee26c5e721e76c6d4afce:1732
```
because of the way it's been implemented (issuing a require call to a presumed locale js file, which may not exist, especially since packaged versions of notebook are shipping without separate locale files). This PR does it in the correct way (getting moment to load it from its own internal set, if possible, also falling back to less-specific versions as necessary).