### PR TITLE
Include moment locales in package_data

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -157,6 +157,7 @@ def find_package_data():
         pjoin(components, "underscore", "underscore-min.js"),
         pjoin(components, "moment", "moment.js"),
         pjoin(components, "moment", "min", "*.js"),
+        pjoin(components, "moment", "locale", "*.js"),
         pjoin(components, "xterm.js", "dist", "xterm.js"),
         pjoin(components, "xterm.js", "dist", "xterm.css"),
         pjoin(components, "text-encoding", "lib", "encoding.js"),


### PR DESCRIPTION
Closes gh-2953

I'm not quite sure how this interacts with minification, but it appears that in at least some circumstances it expects these files.