### PR TITLE
Compare non-specific language code when choosing to use Arabic numerals

### DIFF
--- a/notebook/static/bidi/bidi.js
+++ b/notebook/static/bidi/bidi.js
@@ -19,7 +19,7 @@ define(['bidi/numericshaping'], function(numericshaping) {
       console.log('Loaded moment locale', moment.locale(_uiLang()));
     });
 
-    shaperType = _uiLang() == 'ar' ? 'national' : 'defaultNumeral';
+    shaperType = _uiLang().split('-')[0] == 'ar' ? 'national' : 'defaultNumeral';
   };
 
   var _isMirroringEnabled = function() {


### PR DESCRIPTION
As discussed in https://github.com/jupyter/notebook/pull/3048#issuecomment-344905231,

Currently, country-specific locales like `ar-sa` (Arabic, Saudi Arabia), end up using the default numerals. This PR alters the comparison to only use the part of the locale before any `-`.