### PR TITLE
Allow programmatic copy to clipboard

### DIFF
--- a/notebook/static/notebook/js/clipboard.js
+++ b/notebook/static/notebook/js/clipboard.js
@@ -34,10 +34,18 @@ function load_json(clipboard) {
   return JSON.parse(s.slice(pix + jcbprefix.length, six));
 }
 
+function isProgrammaticCopy(event) {
+  return (typeof(event.target.selectionStart) !== 'undefined'
+    && typeof(event.target.selectionEnd) !== 'undefined'
+    && ((event.target.selectionEnd - event.target.selectionStart) > 0));
+}
+
 function copy(event) {
   if ((Jupyter.notebook.mode !== 'command') ||
         // window.getSelection checks if text is selected, e.g. in output
-        !window.getSelection().isCollapsed) {
+        !window.getSelection().isCollapsed ||
+        // Allow programmatic copy
+        isProgrammaticCopy(event)) {
     return;
   }
   var selecn = Jupyter.notebook.get_selected_cells().map(


### PR DESCRIPTION
Trying to close #2975.

@takluyver I did not go with ``document.execCommand`` because it does not allow you to set a mime-types like html, json, etc. (or I couldn't find a way to do that anyway) and I see you need that.

Let me know if these changes are okay.  