### PR TITLE
Hover Error of UPDATE and NEW button on home page (FIXED)

### DIFF
--- a/notebook/static/tree/less/tree.less
+++ b/notebook/static/tree/less/tree.less
@@ -33,6 +33,10 @@ ul#tabs a {
     padding-right: 0;
 }
 
+.btn-group {
+    z-index: 10;
+}
+
 ul.breadcrumb {
     a:focus, a:hover {
         text-decoration: none;


### PR DESCRIPTION
I found there was a hover error in home page in which whenever i hover over the "New" button by first going through the "Upload" button the "Upload" remains highlighted until i have traveled half of the "New" button as seen in the below image which i have also fixed by adding some code in the tree.less file.

![bug1](https://user-images.githubusercontent.com/23234874/33806584-800bbb1a-ddf0-11e7-96fd-8aa41afade55.png)
