### PR TITLE
Find available kernelspecs more efficiently

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ install_requires = [
     'ipython_genutils',
     'traitlets>=4.2.1',
     'jupyter_core>=4.4.0',
-    'jupyter_client>=4.2.0',
+    'jupyter_client>=5.2.0',
     'nbformat',
     'nbconvert',
     'ipykernel', # bless IPython kernel for now

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ install_requires = [
     'ipython_genutils',
     'traitlets>=4.2.1',
     'jupyter_core>=4.4.0',
-    'jupyter_client',
+    'jupyter_client>=4.2.0',
     'nbformat',
     'nbconvert',
     'ipykernel', # bless IPython kernel for now


### PR DESCRIPTION
Using `find_kernel_specs()` followed by `get_kernel_spec()` has quadratic performance with the number of available kernels, because it effectively rescans for each available kernel. Hands up, I designed this, and I can't think why I did it this way.

I thought this was going to require some ugly workaround, but thankfully @captainsafia was on the case two years ago, adding the `get_all_specs()` method (https://github.com/jupyter/jupyter_client/pull/93). So all I've done here is switch the notebook code to use it.

This should improve performance loading pages for anyone with several kernels installed.

Closes gh-3135