### PR TITLE
Alignment issue [FIXED]

### DIFF
--- a/notebook/static/base/js/page.js
+++ b/notebook/static/base/js/page.js
@@ -74,7 +74,21 @@ define([
         if (!(e && e.target && e.target.tagName)) {
             $('div#site').height($(window).height() - $('#header').height());
         }
+        this._align_header_site();
     };
+
+
+
+    Page.prototype._align_header_site = function(e) {
+        /**
+         * Align the site and header divs
+         */
+        var header_div_element_width = this.header_div_element.outerWidth();
+        var header_container_width = $('div#header-container').outerWidth();
+        var margin_left = (header_div_element_width - header_container_width) / 2;
+
+        this.site_div_element.find('.container').css('margin-left', margin_left);
+    }
 
     return {'Page': Page};
 });


### PR DESCRIPTION
To fix the alignment issue which was found out to occur in most of the browsers including Chrome and Firefox because of the scroll bar becoming visible and invisible whichever is required.

The main problem this was being caused was because of 'margin-left' property being set to 'auto' as well as the 'overflow' property being set to 'auto'.

So, to fix this issue I updated the 'margin-left' property to align it with the header of the page whenever changes like page reload, resize, etc occurs.

closes #3109 