### PR TITLE
Add Jupyter action for CodeMirror indentAuto command

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -684,6 +684,16 @@ define([
                 }
             }
         },
+        'auto-indent': {
+            cmd: i18n.msg._('automatically indent selection'),
+            help : i18n.msg._('automatically indent selection'),
+            handler : function(env) {
+              // Get selected cell
+              var selected_cell = env.notebook.get_selected_cell();
+              // Execute a CM command
+              selected_cell.code_mirror.execCommand('indentAuto');
+            }
+        }
     };
 
     /**


### PR DESCRIPTION
Closes https://github.com/jupyter/notebook/issues/2591

Adds a shortcut for CodeMirror’s `indentAuto` command that doesn’t collide with special characters on French/German keyboards (https://github.com/jupyter/notebook/pull/2535) and also adds it to both the cell editor and text/file editor.