### PR TITLE
Limit length of GUI autocomplete to 1000

### DIFF
--- a/notebook/static/notebook/js/completer.js
+++ b/notebook/static/notebook/js/completer.js
@@ -306,7 +306,8 @@ define([
     };
 
     Completer.prototype.build_gui_list = function (completions) {
-        for (var i = 0; i < completions.length; ++i) {
+        var MAXIMUM_GUI_LIST_LENGTH = 1000;
+        for (var i = 0; i < completions.length && i < MAXIMUM_GUI_LIST_LENGTH; ++i) {
             var opt = $('<option/>').text(completions[i].str).addClass(completions[i].type);
             this.sel.append(opt);
         }


### PR DESCRIPTION
 If an object's dir() call returns a long list (greater than a few thousand), the UI locks up while it is creating this long list of <option> elements. This just limits the maximum length to 1000 elements.