### PR TITLE
Always use setuptools in setup.py

### DIFF
--- a/scripts/jupyter-bundlerextension
+++ b/scripts/jupyter-bundlerextension
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-# Copyright (c) Jupyter Development Team.
-# Distributed under the terms of the Modified BSD License.
-
-from notebook.bundler.bundlerextensions import main
-
-if __name__ == '__main__':
-    main()

--- a/scripts/jupyter-nbextension
+++ b/scripts/jupyter-nbextension
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-
-from notebook.nbextensions import main
-
-if __name__ == '__main__':
-    main()

--- a/scripts/jupyter-notebook
+++ b/scripts/jupyter-notebook
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-
-from notebook.notebookapp import main
-
-if __name__ == '__main__':
-    main()

--- a/scripts/jupyter-serverextension
+++ b/scripts/jupyter-serverextension
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-
-from notebook.serverextensions import main
-
-if __name__ == '__main__':
-    main()

--- a/setup.py
+++ b/setup.py
@@ -13,40 +13,25 @@
 
 from __future__ import print_function
 
-name = "notebook"
-
-#-----------------------------------------------------------------------------
-# Minimal Python version sanity check
-#-----------------------------------------------------------------------------
-
+import os
 import sys
 
+name = "notebook"
+
+# Minimal Python version sanity check
 v = sys.version_info
 if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,3)):
     error = "ERROR: %s requires Python version 2.7 or 3.3 or above." % name
     print(error, file=sys.stderr)
     sys.exit(1)
 
-PY3 = (sys.version_info[0] >= 3)
-
 # At least we're on the python version we need, move on.
-
-
-#-------------------------------------------------------------------------------
-# Imports
-#-------------------------------------------------------------------------------
-
-import os
-
-from glob import glob
 
 # BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
 # update it when the contents of directories change.
 if os.path.exists('MANIFEST'): os.remove('MANIFEST')
 
-from distutils.core import setup
-
-# Our own imports
+from setuptools import setup
 
 from setupbase import (
     version,
@@ -59,9 +44,6 @@ from setupbase import (
     JavascriptVersion,
     css_js_prerelease,
 )
-
-isfile = os.path.isfile
-pjoin = os.path.join
 
 setup_args = dict(
     name            = name,
@@ -76,7 +58,6 @@ Read `the documentation <https://jupyter-notebook.readthedocs.io>`_
 for more information.
     """,
     version         = version,
-    scripts         = glob(pjoin('scripts', '*')),
     packages        = find_packages(),
     package_data    = find_package_data(),
     author          = 'Jupyter Development Team',
@@ -94,105 +75,70 @@ for more information.
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
     ],
-)
-
-
-
-#---------------------------------------------------------------------------
-# Find all the packages, package data, and data_files
-#---------------------------------------------------------------------------
-
-packages = find_packages()
-package_data = find_package_data()
-
-#---------------------------------------------------------------------------
-# custom distutils commands
-#---------------------------------------------------------------------------
-# imports here, so they are after setuptools import if there was one
-from distutils.command.build_py import build_py
-from distutils.command.sdist import sdist
-
-
-setup_args['cmdclass'] = {
-    'build_py': css_js_prerelease(
-            check_package_data_first(build_py)),
-    'sdist' : css_js_prerelease(sdist, strict=True),
-    'css' : CompileCSS,
-    'js' : CompileJS,
-    'jsdeps' : Bower,
-    'jsversion' : JavascriptVersion,
-}
-
-
-
-#---------------------------------------------------------------------------
-# Handle scripts, dependencies, and setuptools specific things
-#---------------------------------------------------------------------------
-
-if any(arg.startswith('bdist') for arg in sys.argv):
-    import setuptools
-
-# This dict is used for passing extra arguments that are setuptools
-# specific to setup
-setuptools_extra_args = {}
-
-# setuptools requirements
-
-pyzmq = 'pyzmq>=13'
-
-setup_args['scripts'] = glob(pjoin('scripts', '*'))
-
-install_requires = [
-    'jinja2',
-    'tornado>=4',
-    'ipython_genutils',
-    'traitlets>=4.2.1',
-    'jupyter_core>=4.4.0',
-    'jupyter_client>=5.2.0',
-    'nbformat',
-    'nbconvert',
-    'ipykernel', # bless IPython kernel for now
-    'Send2Trash',
-    'terminado>=0.8.1'
-]
-extras_require = {
-    'test:python_version == "2.7"': ['mock'],
-    'test': ['nose', 'coverage', 'requests', 'nose_warnings_filters', 'nbval'],
-    'test:sys_platform == "win32"': ['nose-exclude'],
-}
-
-if 'setuptools' in sys.modules:
-    # setup.py develop should check for submodules
-    from setuptools.command.develop import develop
-    setup_args['cmdclass']['develop'] = css_js_prerelease(develop)
-
-    try:
-        from wheel.bdist_wheel import bdist_wheel
-    except ImportError:
-        pass
-    else:
-        setup_args['cmdclass']['bdist_wheel'] = css_js_prerelease(bdist_wheel)
-
-    setuptools_extra_args['zip_safe'] = False
-    setup_args['extras_require'] = extras_require
-    requires = setup_args['install_requires'] = install_requires
-
-    setup_args['entry_points'] = {
+    zip_safe = False,
+    install_requires = [
+        'jinja2',
+        'tornado>=4',
+        'ipython_genutils',
+        'traitlets>=4.2.1',
+        'jupyter_core>=4.4.0',
+        'jupyter_client>=5.2.0',
+        'nbformat',
+        'nbconvert',
+        'ipykernel', # bless IPython kernel for now
+        'Send2Trash',
+        'terminado>=0.8.1'
+    ],
+    extras_require = {
+        'test:python_version == "2.7"': ['mock'],
+        'test': ['nose', 'coverage', 'requests', 'nose_warnings_filters', 'nbval'],
+        'test:sys_platform == "win32"': ['nose-exclude'],
+    },
+    entry_points = {
         'console_scripts': [
             'jupyter-notebook = notebook.notebookapp:main',
             'jupyter-nbextension = notebook.nbextensions:main',
             'jupyter-serverextension = notebook.serverextensions:main',
             'jupyter-bundlerextension = notebook.bundler.bundlerextensions:main',
         ]
-    }
-    setup_args.pop('scripts', None)
+    },
+)
 
-#---------------------------------------------------------------------------
-# Do the actual setup now
-#---------------------------------------------------------------------------
+# Custom distutils/setuptools commands ----------
+from distutils.command.build_py import build_py
+from distutils.command.sdist import sdist
+from setuptools.command.bdist_egg import bdist_egg
+from setuptools.command.develop import develop
 
-setup_args.update(setuptools_extra_args)
+class bdist_egg_disabled(bdist_egg):
+    """Disabled version of bdist_egg
 
+    Prevents setup.py install from performing setuptools' default easy_install,
+    which it should never ever do.
+    """
+    def run(self):
+        sys.exit("Aborting implicit building of eggs. Use `pip install .` to install from source.")
+
+setup_args['cmdclass'] = {
+    'build_py': css_js_prerelease(
+            check_package_data_first(build_py)),
+    'sdist' : css_js_prerelease(sdist, strict=True),
+    'develop': css_js_prerelease(develop),
+    'css' : CompileCSS,
+    'js' : CompileJS,
+    'jsdeps' : Bower,
+    'jsversion' : JavascriptVersion,
+    'bdist_egg': bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled,
+}
+
+try:
+    from wheel.bdist_wheel import bdist_wheel
+except ImportError:
+    pass
+else:
+    setup_args['cmdclass']['bdist_wheel'] = css_js_prerelease(bdist_wheel)
+
+# Run setup --------------------
 def main():
     setup(**setup_args)
 


### PR DESCRIPTION
This copies what we've already done for some other packages: always use setuptools but disable its implicit egg building which causes so many headaches. The setup code can be significantly simpler if it's not trying to handle the case where setuptools isn't in use.