### PR TITLE
Patch out bootstrap rule forcing black and white printing

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -398,6 +398,28 @@ class Bower(Command):
         update_package_data(self.distribution)
 
 
+def patch_out_bootstrap_bw_print():
+    """Hack! Manually patch out the bootstrap rule that forces printing in B&W.
+
+    We haven't found a way to override this rule with another one.
+    """
+    print_less = pjoin(static, 'components', 'bootstrap', 'less', 'print.less')
+    with open(print_less) as f:
+        lines = f.readlines()
+
+    for ix, line in enumerate(lines):
+        if 'Black prints faster' in line:
+            break
+    else:
+        return  # Already patched out, nothing to do.
+
+    rmed = lines.pop(ix)
+    print("Removed line", ix, "from bootstrap print.less:")
+    print("-", rmed)
+    print()
+    with open(print_less, 'w') as f:
+        f.writelines(lines)
+
 class CompileCSS(Command):
     """Recompile Notebook CSS
     
@@ -424,6 +446,8 @@ class CompileCSS(Command):
         self.run_command('jsdeps')
         env = os.environ.copy()
         env['PATH'] = npm_path
+
+        patch_out_bootstrap_bw_print()
         
         for src, dst in zip(self.sources, self.targets):
             try:


### PR DESCRIPTION
A thoroughly ugly hack. Bootstrap forces all text to be black when printing, resulting in a long running issue (#840). I tried to override it with `color: inherit !important`, but that didn't produce the right results. I can't find any way to tell LESS to remove a rule or act as if it didn't exist. So the only thing I can think to do is to patch the source we get from bootstrap to get rid of the rule entirely.

Frustratingly, it looks like bootstrap is fixing this (getting rid of the rule) for v4, but it's also moving from LESS to SCSS, so we can't easily switch to the new version.

Closes gh-840