### PR TITLE
make js-generated UUIDs lowercase

### DIFF
--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -208,7 +208,7 @@ define([
          * http://www.ietf.org/rfc/rfc4122.txt
          */
         var s = [];
-        var hexDigits = "0123456789ABCDEF";
+        var hexDigits = "0123456789abcdef";
         for (var i = 0; i < 32; i++) {
             s[i] = hexDigits.substr(Math.floor(Math.random() * 0x10), 1);
         }


### PR DESCRIPTION
so it's a bit less shouty when debugging messages

We don't ever need official UUIDs as specified, just sufficiently random strings.