### PR TITLE
Change the path to create notebooks in when navigating directories

### DIFF
--- a/notebook/static/tree/js/newnotebook.js
+++ b/notebook/static/tree/js/newnotebook.js
@@ -13,7 +13,6 @@ define([
     var NewNotebookWidget = function (selector, options) {
         this.selector = selector;
         this.base_url = options.base_url;
-        this.notebook_path = options.notebook_path;
         this.contents = options.contents;
         this.events = options.events;
         this.default_kernel = null;
@@ -79,7 +78,8 @@ define([
         var that = this;
         kernel_name = kernel_name || this.default_kernel;
         var w = window.open(undefined, IPython._target);
-        this.contents.new_untitled(that.notebook_path, {type: "notebook"}).then(
+        var dir_path = $('body').attr('data-notebook-path');
+        this.contents.new_untitled(dir_path, {type: "notebook"}).then(
             function (data) {
                 var url = utils.url_path_join(
                     that.base_url, 'notebooks',

--- a/notebook/static/tree/js/newnotebook.js
+++ b/notebook/static/tree/js/newnotebook.js
@@ -73,7 +73,7 @@ define([
         this.events.trigger('kernelspecs_loaded.KernelSpec', data.kernelspecs);
     };
     
-    NewNotebookWidget.prototype.new_notebook = function (kernel_name) {
+    NewNotebookWidget.prototype.new_notebook = function (kernel_name, evt) {
         /** create and open a new notebook */
         var that = this;
         kernel_name = kernel_name || this.default_kernel;
@@ -107,6 +107,9 @@ define([
                 }
             });
         });
+        if (evt !== undefined) {
+            evt.preventDefault();
+        }
     };
     
     return {'NewNotebookWidget': NewNotebookWidget};

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -169,6 +169,7 @@ define([
                     console.warn('Error during New file creation', e);
                 });
                 that.load_sessions();
+                e.preventDefault();
             });
             $('#new-folder').click(function(e) {
                 that.contents.new_untitled(that.notebook_path || '', {type: 'directory'})
@@ -189,6 +190,7 @@ define([
                     console.warn('Error during New directory creation', e);
                 });
                 that.load_sessions();
+                e.preventDefault();
             });
 
             // Bind events for action buttons.
@@ -373,8 +375,8 @@ define([
         breadcrumb.append(root);
         var path_parts = [];
         this.notebook_path.split('/').forEach(function(path_part) {
-            path_parts.push(path_part)
-            var path = path_parts.join('/')
+            path_parts.push(path_part);
+            var path = path_parts.join('/');
             var url = utils.url_path_join(
                 that.base_url,
                 '/tree',

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -399,6 +399,7 @@ define([
     
     NotebookList.prototype.update_location = function (path) {
         this.notebook_path = path;
+        $('body').attr('data-notebook-path', path);
         // Update the file tree list without reloading the page
         this.load_list();
     };


### PR DESCRIPTION
Closes gh-3263
Closes gh-3248

There's still an issue where the dashboard goes back to showing the root directory when you create a notebook. I'll look into that later.