### PR TITLE
Make buffer time between last modified on disk and last modified on last save configurable

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -2738,11 +2738,11 @@ define([
             return this.contents.get(this.notebook_path, {content: false}).then(
                 function (data) {
                     var last_modified = new Date(data.last_modified);
-                    var difference_buffer = that.config.data['last_modified_buffer'] || 500; // 500 ms
+                    var last_modified_check_margin = (that.config.data['last_modified_check_margin'] || 0.5) * 1000; // 500 ms
                     // We want to check last_modified (disk) > that.last_modified (our last save)
                     // In some cases the filesystem reports an inconsistent time,
                     // so we allow 0.5 seconds (configurable in nbconfig/notebook.json as `last_modified_buffer`) difference before complaining.
-                    if ((last_modified.getTime() - that.last_modified.getTime()) > difference_buffer) {  
+                    if ((last_modified.getTime() - that.last_modified.getTime()) > last_modified_check_margin) {  
                         console.warn("Last saving was done on `"+that.last_modified+"`("+that._last_modified+"), "+
                                     "while the current file seem to have been saved on `"+data.last_modified+"`");
                         if (that._changed_on_disk_dialog !== null) {

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -2738,10 +2738,11 @@ define([
             return this.contents.get(this.notebook_path, {content: false}).then(
                 function (data) {
                     var last_modified = new Date(data.last_modified);
+                    var difference_buffer = that.config.data['last_modified_buffer'] || 500; // 500 ms
                     // We want to check last_modified (disk) > that.last_modified (our last save)
                     // In some cases the filesystem reports an inconsistent time,
-                    // so we allow 0.5 seconds difference before complaining.
-                    if ((last_modified.getTime() - that.last_modified.getTime()) > 500) {  // 500 ms
+                    // so we allow 0.5 seconds (configurable in nbconfig/notebook.json as `last_modified_buffer`) difference before complaining.
+                    if ((last_modified.getTime() - that.last_modified.getTime()) > difference_buffer) {  
                         console.warn("Last saving was done on `"+that.last_modified+"`("+that._last_modified+"), "+
                                     "while the current file seem to have been saved on `"+data.last_modified+"`");
                         if (that._changed_on_disk_dialog !== null) {

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -2741,7 +2741,8 @@ define([
                     var last_modified_check_margin = (that.config.data['last_modified_check_margin'] || 0.5) * 1000; // 500 ms
                     // We want to check last_modified (disk) > that.last_modified (our last save)
                     // In some cases the filesystem reports an inconsistent time,
-                    // so we allow 0.5 seconds (configurable in nbconfig/notebook.json as `last_modified_buffer`) difference before complaining.
+                    // so we allow 0.5 seconds difference before complaining.
+                    // This is configurable in nbconfig/notebook.json as `last_modified_check_margin`.
                     if ((last_modified.getTime() - that.last_modified.getTime()) > last_modified_check_margin) {  
                         console.warn("Last saving was done on `"+that.last_modified+"`("+that._last_modified+"), "+
                                     "while the current file seem to have been saved on `"+data.last_modified+"`");


### PR DESCRIPTION
Suggested by https://github.com/jupyter/notebook/issues/484#issuecomment-359508990

This will look in `notebook.json` in `~/.jupyter/nbconfig/notebook.json` for a `last_modified_buffer` value. For example:

```json
{
  "Notebook": {
    "Header": false,
    "Toolbar": true
  },
  "Cell": {
    "cm_config": {
      "lineNumbers": false
    }
  },
  "last_modified_buffer": 600
}
```

Can anyone think of better name than `last_modified_buffer`?