### PR TITLE
Fix clicking with modifiers, page title updates

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -412,6 +412,10 @@ define([
         $('body').attr('data-notebook-path', path);
         // Update the file tree list without reloading the page
         this.load_list();
+        // Update the page title so the browser tab reflects it
+        // Match how the title appears with a trailing slash or
+        // "Home" if the page loads from the server.
+        $('title').text(path ? path+'/' : i18n.msg._("Home"));
     };
 
     /**

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -365,6 +365,10 @@ define([
         breadcrumb.empty();
         var list_item = $('<li/>');
         var root = $('<li/>').append('<a href="/tree"><i class="fa fa-folder"></i></a>').click(function(e) {
+            // Allow the default browser action when the user holds a modifier (e.g., Ctrl-Click)
+            if(e.altKey || e.metaKey || e.shiftKey) {
+                return true;
+            }
             var path = '';
             window.history.pushState({
                 path: path
@@ -383,6 +387,10 @@ define([
                 utils.encode_uri_components(path)
             );
             var crumb = $('<li/>').append('<a href="' + url + '">' + path_part + '</a>').click(function(e) {
+                // Allow the default browser action when the user holds a modifier (e.g., Ctrl-Click)
+                if(e.altKey || e.metaKey || e.shiftKey) {
+                    return true;
+                }
                 window.history.pushState({
                     path: path
                 }, path, url);
@@ -810,8 +818,12 @@ define([
             link.attr('target', IPython._target);
         } else {
             // Replace with a click handler that will use the History API to
-            // push a new route without reloading the page
+            // push a new route without reloading the page if the click is
+            // not modified (e.g., Ctrl-Click)
             link.click(function (e) {
+                if(e.altKey || e.metaKey || e.shiftKey) {
+                    return true;
+                }
                 window.history.pushState({
                     path: model.path
                 }, model.path, utils.url_path_join(


### PR DESCRIPTION
* Allow the default browser behavior when the user is holding any modifier key while clicking on a folder or breadcrumb in the fileview.
* Update the page title when navigating via the History API

Fixes #3276, fixes #3277