### PR TITLE
Improve kernel restart logic to reestablish ZMQ connection when a kernel is restarted with new ports

### DIFF
--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -490,11 +490,9 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
         logging.warn("kernel %s restarted", self.kernel_id)
         self._send_status_message('restarting')
 
-
     def on_restart_failed(self):
         logging.error("kernel %s restarted failed!", self.kernel_id)
         self._send_status_message('dead')
-
 
 
 #-----------------------------------------------------------------------------

--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -463,9 +463,10 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
 
     def on_kernel_restarted(self, **kwargs):
         if 'newports' in kwargs:
+            self.log.debug("Kernel restarted with new ports")
             newports = kwargs['newports']
         else:
-            self.log.warning('newports parameter is not defined, setting default to False')
+            self.log.debug('newports parameter is not defined, setting default to False')
             newports = False
         logging.info("Restarting kernel with new ports: {}".format(newports))
         if newports:


### PR DESCRIPTION
This proposal is based on https://github.com/jupyter/jupyter_client/pull/348.

This proposal defines the logic for creating new ZMQ connection without closing existing websocket connection if a kernel was restarted with new ports (e.g. when the kernel is not responding during initial startup).
The following changes were added to the `on_kernel_restarted` function:
- `kwargs` support
- `newports` parameter from `kwargs` used if it is defined. If the parameter is not in `kwargs` set it to `False`
- If `newports == True` then existing ZMQ connection to the kernel is closed and new stream with updated ports is opened.
- If `newports == False` then client is notified that the kernel was restarted
This proposal solves the issue described in https://github.com/jupyter/jupyter_client/issues/347