### PR TITLE
Remove deprecated ANSI CSS styles

### DIFF
--- a/notebook/static/notebook/less/ansicolors.less
+++ b/notebook/static/notebook/less/ansicolors.less
@@ -25,28 +25,3 @@
 
 .ansi-bold { font-weight: bold; }
 .ansi-underline { text-decoration: underline; }
-
-/* The following styles are deprecated an will be removed in a future version */
-
-.ansibold {font-weight: bold;}
-.ansi-inverse { outline: 0.5px dotted; }
-
-/* use dark versions for foreground, to improve visibility */
-.ansiblack {color: black;}
-.ansired {color: darkred;}
-.ansigreen {color: darkgreen;}
-.ansiyellow {color: #c4a000;}
-.ansiblue {color: darkblue;}
-.ansipurple {color: darkviolet;}
-.ansicyan {color: steelblue;}
-.ansigray {color: gray;}
-
-/* and light for background, for the same reason */
-.ansibgblack {background-color: black;}
-.ansibgred {background-color: red;}
-.ansibggreen {background-color: green;}
-.ansibgyellow {background-color: yellow;}
-.ansibgblue {background-color: blue;}
-.ansibgpurple {background-color: magenta;}
-.ansibgcyan {background-color: cyan;}
-.ansibggray {background-color: gray;}


### PR DESCRIPTION
I'm not sure what the deprecation/removal policy is here ...

The new CSS styles have been released with `notebook` 5.0.0 in March 2017 an the deprecated styles are in the CSS CDN for up to version 5.4.0.

Feel free to merge this whenever appropriate!