### PR TITLE
Add slides exportation/download to the menu

### DIFF
--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -193,6 +193,10 @@ define([
             that._nbconvert('html', true);
         });
 
+        this.element.find('#download_slides').click(function () {
+            that._nbconvert('slides', true);
+        });
+
         this.element.find('#download_markdown').click(function () {
             that._nbconvert('markdown', true);
         });

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -109,7 +109,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
                                 <li id="download_ipynb"><a href="#">{% trans %}Notebook (.ipynb){% endtrans %}</a></li>
                                 <li id="download_script"><a href="#">{% trans %}Script{% endtrans %}</a></li>
                                 <li id="download_html"><a href="#">{% trans %}HTML (.html){% endtrans %}</a></li>
-                                <li id="download_slides"><a href="#">{% trans %}Reveal.js Slides (.html){% endtrans %}</a></li>
+                                <li id="download_slides"><a href="#">{% trans %}Reveal.js slides (.html){% endtrans %}</a></li>
                                 <li id="download_markdown"><a href="#">{% trans %}Markdown (.md){% endtrans %}</a></li>
                                 <li id="download_rst"><a href="#">{% trans %}reST (.rst){% endtrans %}</a></li>
                                 <li id="download_latex"><a href="#">{% trans %}LaTeX (.tex){% endtrans %}</a></li>

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -109,6 +109,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
                                 <li id="download_ipynb"><a href="#">{% trans %}Notebook (.ipynb){% endtrans %}</a></li>
                                 <li id="download_script"><a href="#">{% trans %}Script{% endtrans %}</a></li>
                                 <li id="download_html"><a href="#">{% trans %}HTML (.html){% endtrans %}</a></li>
+                                <li id="download_slides"><a href="#">{% trans %}Reveal.js Slides (.html){% endtrans %}</a></li>
                                 <li id="download_markdown"><a href="#">{% trans %}Markdown (.md){% endtrans %}</a></li>
                                 <li id="download_rst"><a href="#">{% trans %}reST (.rst){% endtrans %}</a></li>
                                 <li id="download_latex"><a href="#">{% trans %}LaTeX (.tex){% endtrans %}</a></li>


### PR DESCRIPTION
This is something missing for a long time.
JupyterLab offers it as well.
And with the upcoming change in nbconvert about catching `reveal.js` from the CDN (by default), you get an exported/downloaded html file that you can open immediately to surf the slides.