### PR TITLE
Write notebook.json file atomically

### DIFF
--- a/notebook/config_manager.py
+++ b/notebook/config_manager.py
@@ -91,12 +91,16 @@ class BaseJSONConfigManager(LoggingConfigurable):
         filename = self.file_name(section_name)
         self.ensure_config_dir_exists()
 
+        # Generate the JSON up front, since it could raise an exception,
+        # in order to avoid writing half-finished corrupted data to disk.
+        json_content = json.dumps(data, indent=2)
+
         if PY3:
             f = io.open(filename, 'w', encoding='utf-8')
         else:
             f = open(filename, 'wb')
         with f:
-            json.dump(data, f, indent=2)
+            f.write(json_content)
 
     def update(self, section_name, new_data):
         """Modify the config section by recursively updating it with new_data.


### PR DESCRIPTION
The motivation for this was a [bug](https://github.com/mozilla/jupyter-notebook-gist/issues/53) in the jupyter-notebook-gist extension whereby a `LazyConfigValue` was being added to the JSON config tree in some cases.  That's definitely a bug on the part of the extension that needs to be fixed over there.

However, this caused the `notebook.json` writer to crash mid-writing, leaving a corrupted `notebook.json` on disk, eg.:

```
{
  "load_extensions": {
    "jupyter-notebook-gist/extension": true,
    "jupyter-js-widgets/extension": true
  },
  "oauth_client_id":
```

So on subsequent startups of the Jupyter notebook, parsing fails unless the user manually fixes the JSON file.  Potentially there could have been data loss in the config file if there were keys *after* `oauth_client_id` that failed to write.

I would argue that notebook shouldn't write the corrupted JSON to disk, but leave it in its last state if this happens.  Manual testing shows that if a rogue extension runs, subsequent extensions are still run and can successfully add their own values to the JSON.  In other words, only the data in single call to `set` or `update` is thrown out by this change.

I considered using the "write to a tempfile and replace" method for this.  That's complicated to get correct in a cross-platform way (requires `os.replace` on Windows, which is only in Python 3.3 and later, so would require a backfill for Python 2.7 etc.)  If streaming directly to disk is important, I'm happy to redo this that way, but I thought for config files that are generally quite small, doing this in-memory should be fine.