### PR TITLE
Add any extra installed nbconvert exporters to the "Download as" menu

### DIFF
--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -189,32 +189,8 @@ define([
             that._nbconvert('html', false);
         });
 
-        this.element.find('#download_html').click(function () {
-            that._nbconvert('html', true);
-        });
-
-        this.element.find('#download_slides').click(function () {
-            that._nbconvert('slides', true);
-        });
-
-        this.element.find('#download_markdown').click(function () {
-            that._nbconvert('markdown', true);
-        });
-
-        this.element.find('#download_rst').click(function () {
-            that._nbconvert('rst', true);
-        });
-
-        this.element.find('#download_pdf').click(function () {
-            that._nbconvert('pdf', true);
-        });
-        
-        this.element.find('#download_latex').click(function () {
-            that._nbconvert('latex', true);
-        });
-
-        this.element.find('#download_script').click(function () {
-            that._nbconvert('script', true);
+        this.element.find('#download_menu li').click(function (ev) {
+            that._nbconvert(ev.target.parentElement.getAttribute('id').substring(9), true);
         });
 
         this.events.on('trust_changed.Notebook', function (event, trusted) {

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -118,7 +118,6 @@ data-notebook-path="{{notebook_path | urlencode}}"
                                 <li id="download_{{ exporter.name }}">
                                     <a href="#">{{ exporter.display }}</a>
                                 </li>
-                                </span>
                                 {% endfor %}
                             </ul>
                         </li>

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -114,6 +114,12 @@ data-notebook-path="{{notebook_path | urlencode}}"
                                 <li id="download_rst"><a href="#">{% trans %}reST (.rst){% endtrans %}</a></li>
                                 <li id="download_latex"><a href="#">{% trans %}LaTeX (.tex){% endtrans %}</a></li>
                                 <li id="download_pdf"><a href="#">{% trans %}PDF via LaTeX (.pdf){% endtrans %}</a></li>
+                                {% for exporter in get_custom_frontend_exporters() %}
+                                <li id="download_{{ exporter.name }}">
+                                    <a href="#">{{ exporter.display }}</a>
+                                </li>
+                                </span>
+                                {% endfor %}
                             </ul>
                         </li>
                         <li class="dropdown-submenu hidden"><a href="#">{% trans %}Deploy as{% endtrans %}</a>


### PR DESCRIPTION
It would be nice if extra `nbconvert` exporters show up on the "File -> Download as" menu, without the need to write a custom Javascript extension.

Of course, some exporters will have required parameters, so this system is opt-in -- the exporter must define the `export_from_notebook` menu to provide a friendly (and possibly translatable) name to the menu.