### PR TITLE
Don't install gettext into builtins

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -51,7 +51,7 @@ help:
 
 clean:
 	rm -rf $(BUILDDIR)/*
-	rm -rf config.rst
+	rm -rf source/config.rst
 
 html: source/config.rst
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,3 +1,3 @@
 sphinx>=1.3.6
 sphinx-rtd-theme
-nbsphinx==0.2.14
+nbsphinx

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,7 @@ For more detailed information, see
      upgrade to the latest release.
 
 .. we push for pip 9+ or it will break for Python 2 users when IPython 6 is out.
+
 We strongly recommend that you upgrade to version 9+ of pip before upgrading ``notebook``.
 
 .. tip::

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -832,9 +832,11 @@ class NotebookApp(JupyterApp):
         `new` argument passed to the standard library method `webbrowser.open`.
         The behaviour is not guaranteed, but depends on browser support. Valid
         values are:
-            2 opens a new tab,
-            1 opens a new window,
-            0 opens in an existing window.
+
+         - 2 opens a new tab,
+         - 1 opens a new window,
+         - 0 opens in an existing window.
+
         See the `webbrowser.open` documentation for details.
         """))
 

--- a/notebook/transutils.py
+++ b/notebook/transutils.py
@@ -10,5 +10,4 @@ import gettext
 # Set up message catalog access
 base_dir = os.path.realpath(os.path.join(__file__, '..', '..'))
 trans = gettext.translation('notebook', localedir=os.path.join(base_dir, 'notebook/i18n'), fallback=True)
-trans.install()
 _ = trans.gettext


### PR DESCRIPTION
With the merge of #3326, I think this is no longer needed. Having `_` in builtins seems convenient, but it turns out that most of the code using it is in a few files, and breaking the normal namespacing rules has caused various problems and confusions.