### PR TITLE
Use CSP header to treat served files as belonging to a separate origin

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -629,6 +629,10 @@ class AuthenticatedFileHandler(IPythonHandler, web.StaticFileHandler):
         # disable browser caching, rely on 304 replies for savings
         if "v" not in self.request.arguments:
             self.add_header("Cache-Control", "no-cache")
+
+        # In case we're serving HTML/SVG, confine any Javascript to a unique
+        # origin so it can't interact with the notebook server.
+        self.set_header('Content-Security-Policy', 'sandbox allow-scripts')
     
     def compute_etag(self):
         return None

--- a/notebook/files/handlers.py
+++ b/notebook/files/handlers.py
@@ -26,6 +26,13 @@ class FilesHandler(IPythonHandler):
     a subclass of StaticFileHandler.
     """
 
+    @property
+    def content_security_policy(self):
+        # In case we're serving HTML/SVG, confine any Javascript to a unique
+        # origin so it can't interact with the notebook server.
+        return super(FilesHandler, self).content_security_policy + \
+               "; sandbox allow-scripts"
+
     @web.authenticated
     def head(self, path):
         self.get(path, include_body=False)
@@ -63,10 +70,6 @@ class FilesHandler(IPythonHandler):
                     self.set_header('Content-Type', 'application/octet-stream')
                 else:
                     self.set_header('Content-Type', 'text/plain; charset=UTF-8')
-
-        # In case we're serving HTML/SVG, confine any Javascript to a unique
-        # origin so it can't interact with the notebook server.
-        self.set_header('Content-Security-Policy', 'sandbox allow-scripts')
 
         if include_body:
             if model['format'] == 'base64':

--- a/notebook/files/handlers.py
+++ b/notebook/files/handlers.py
@@ -64,6 +64,10 @@ class FilesHandler(IPythonHandler):
                 else:
                     self.set_header('Content-Type', 'text/plain; charset=UTF-8')
 
+        # In case we're serving HTML/SVG, confine any Javascript to a unique
+        # origin so it can't interact with the notebook server.
+        self.set_header('Content-Security-Policy', 'sandbox allow-scripts')
+
         if include_body:
             if model['format'] == 'base64':
                 b64_bytes = model['content'].encode('ascii')


### PR DESCRIPTION
We already contain these files using the `/view/` handler, which displays them inside an iframe with the same sandboxing. This PR ensures that if a user ends up viewing an untrusted HTML/SVG file at a `/files/` URL (instead of `/view/`), it will still be sandboxed, using the [Content-Security Policy: sandbox](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox) header.

The browser then treats the page as having a unique origin, so cross-origin protection prevents any Javascript from communicating with the notebook server. 