### PR TITLE
Display hostname when running remotely

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1323,7 +1323,6 @@ class NotebookApp(JupyterApp):
         else:
             ip = hostname
         url = self._url(ip)
-        self.log.info(ip, url)
         if self.token:
             # Don't log full token if it came from config
             token = self.token if self._token_generated else '...'

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1317,8 +1317,13 @@ class NotebookApp(JupyterApp):
     
     @property
     def display_url(self):
-        ip = self.ip if self.ip else _('[all ip addresses on your system]')
+        hostname = socket.gethostname()
+        if self.ip in ('localhost', '127.0.0.1', hostname):
+            ip = self.ip
+        else:
+            ip = hostname
         url = self._url(ip)
+        self.log.info(ip, url)
         if self.token:
             # Don't log full token if it came from config
             token = self.token if self._token_generated else '...'
@@ -1625,7 +1630,7 @@ class NotebookApp(JupyterApp):
                 '\n',
                 'Copy/paste this URL into your browser when you connect for the first time,',
                 'to login with a token:',
-                '    %s' % url_concat(self.connection_url, {'token': self.token}),
+                '    %s' % url_concat(self.display_url, {'token': self.token}),
             ]))
 
         self.io_loop = ioloop.IOLoop.current()


### PR DESCRIPTION
My team often runs Jupyter notebooks on a remote server, but 'localhost' is always displayed when running with an option like `--ip '*'` or `--ip 0.0.0.0`, meaning the link isn't copy-and-pasteable when trying to connect from another machine.

This change checks if you are running locally (either the current hostname, `localhost`, or `127.0.0.1`) and displays `localhost` as expected, but otherwise provides the server name.

Hopefully this is the right way to go about proposing a change!