### PR TITLE
log OSErrors failing to create less-critical files during startup

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -711,13 +711,15 @@ class NotebookApp(JupyterApp):
         h.update(self.password.encode())
         return h.digest()
 
-
-    
     def _write_cookie_secret_file(self, secret):
         """write my secret to my secret_file"""
         self.log.info(_("Writing notebook server cookie secret to %s"), self.cookie_secret_file)
-        with io.open(self.cookie_secret_file, 'wb') as f:
-            f.write(secret)
+        try:
+            with io.open(self.cookie_secret_file, 'wb') as f:
+                f.write(secret)
+        except OSError as e:
+            self.log.error(_("Failed to write cookie secret to %s: %s"),
+                           self.cookie_secret_file, e)
         try:
             os.chmod(self.cookie_secret_file, 0o600)
         except OSError:
@@ -1554,12 +1556,16 @@ class NotebookApp(JupyterApp):
 
     def write_server_info_file(self):
         """Write the result of server_info() to the JSON file info_file."""
-        with open(self.info_file, 'w') as f:
-            json.dump(self.server_info(), f, indent=2, sort_keys=True)
+        try:
+            with open(self.info_file, 'w') as f:
+                json.dump(self.server_info(), f, indent=2, sort_keys=True)
+        except OSError as e:
+            self.log.error(_("Failed to write server-info to %s: %s"),
+                           self.info_file, e)
 
     def remove_server_info_file(self):
         """Remove the nbserver-<pid>.json file created for this server.
-        
+
         Ignores the error raised when the file has already been removed.
         """
         try:


### PR DESCRIPTION
rather than fatal errors

we can't solve every problem (e.g. the nbsignature db is required to function properly), but this makes it a little less likely to give up when the disk is full, giving users a better chance to recover space by launching a terminal.

coming up with full disks in jupyterhub deployments: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/518