### PR TITLE
Adding description for 'Trusted' widgets

### DIFF
--- a/notebook/static/notebook/js/notificationarea.js
+++ b/notebook/static/notebook/js/notificationarea.js
@@ -399,7 +399,7 @@ define([
                 }, {'title':'Javascript enabled for notebook display'});
                 // don't allow 'Trusted' button to be clicked
                 $(tnw.selector).attr('disabled', true)
-                $(tnw.selector).css( 'cursor', 'help');
+                $(tnw.selector).css('cursor', 'help');
             } else {
                 tnw.set_message(i18n.msg._("Not Trusted"), undefined, function() {
                   that.notebook.trust_notebook();

--- a/notebook/static/notebook/js/notificationarea.js
+++ b/notebook/static/notebook/js/notificationarea.js
@@ -394,12 +394,17 @@ define([
         // Notebook trust events
         this.events.on('trust_changed.Notebook', function (event, trusted) {
             if (trusted) {
-                tnw.set_message(i18n.msg._("Trusted"));
+                tnw.set_message(i18n.msg._("Trusted"), undefined, function() {
+                  return false;
+                }, {'title':'Javascript enabled for notebook display'});
+                // don't allow 'Trusted' button to be clicked
+                $(tnw.selector).attr('disabled', true)
+                $(tnw.selector).css( 'cursor', 'help');
             } else {
                 tnw.set_message(i18n.msg._("Not Trusted"), undefined, function() {
                   that.notebook.trust_notebook();
                   return false;
-                });
+                }, {'title':'Javascript disabled for notebook display'});
             }
         });
     };


### PR DESCRIPTION
This PR fixes https://github.com/jupyter/notebook/issues/2707

- Trusted and Untrusted widgets have `title` attributes which describe what they mean
- Trusted widgets now have their clicks disabled

<img width="1179" alt="screen shot 2018-02-28 at 10 13 38 pm" src="https://user-images.githubusercontent.com/11889765/36825318-aa3198ec-1cd4-11e8-8963-235ae73da073.png">
