### PR TITLE
Get tests running with tornado 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ before_install:
       if [[ $GROUP == js* ]]; then
         npm install -g casperjs@1.1.3 phantomjs-prebuilt@2.1.7
       fi
-    - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
     - |
       if [[ $GROUP == docs ]]; then
         pip install -r docs/doc-requirements.txt
@@ -50,7 +49,7 @@ before_install:
       fi
 
 install:
-    - pip install -f travis-wheels/wheelhouse file://$PWD#egg=notebook[test]
+    - pip install --pre .[test]
     - wget https://github.com/jgm/pandoc/releases/download/1.19.1/pandoc-1.19.1-1-amd64.deb && sudo dpkg -i pandoc-1.19.1-1-amd64.deb
 
 

--- a/notebook/services/kernels/tests/test_kernels_api.py
+++ b/notebook/services/kernels/tests/test_kernels_api.py
@@ -53,11 +53,12 @@ class KernelAPI(object):
 
     def websocket(self, id):
         loop = IOLoop()
+        loop.make_current()
         req = HTTPRequest(
             url_path_join(self.base_url.replace('http', 'ws', 1), 'api/kernels', id, 'channels'),
             headers=self.headers,
         )
-        f = websocket_connect(req, io_loop=loop)
+        f = websocket_connect(req)
         return loop.run_sync(lambda : f)
 
 

--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -135,6 +135,9 @@ class NotebookTestBase(TestCase):
 
         started = Event()
         def start_thread():
+            if 'asyncio' in sys.modules:
+                import asyncio
+                asyncio.set_event_loop(asyncio.new_event_loop())
             app = cls.notebook = NotebookApp(
                 port=cls.port,
                 port_retries=0,


### PR DESCRIPTION
tornado 5 has just been released. The notebook itself has been updated to work with tornado 5 in the latest releases, but we never ran the tests for this repo with `--pre` dependencies, so the last remaining compatibility fixes which were only in the tests themselves never got caught.

Actual fixes:

- ensure asyncio eventloop is running in the test thread (tornado 4.x creates per-thread loops as needed, asyncio must be asked)
- one last io_loop= arg that's been removed

While at it, update test installation so this should be caught sooner:

- install test dependencies with `--pre` to get more warning about upcoming releases that might cause breakages
- remove use of old 'travis-wheels' repo which only has out-of-date packages at this point

cc @blink1073