### PR TITLE
Fix leak of iopub object in activity monitoring

### DIFF
--- a/notebook/services/kernels/kernelmanager.py
+++ b/notebook/services/kernels/kernelmanager.py
@@ -261,6 +261,7 @@ class MappingKernelManager(MultiKernelManager):
         self._check_kernel_id(kernel_id)
         kernel = self._kernels[kernel_id]
         kernel._activity_stream.close()
+        kernel._activity_stream = None
         self.stop_buffering(kernel_id)
         self._kernel_connections.pop(kernel_id, None)
         self.last_kernel_activity = utcnow()


### PR DESCRIPTION
After analyzing various leaked items when running either Notebook or
Jupyter Kernel Gateway, one item that recurred across each kernel
startup and shutdown sequence was the a zmq socket instance associated
with the iopub port.  The leaked instance occurs because the activity
monitor and normal port creation logic both call `create_iopub`.

Although this ends up creating a _wrapper_ around the same port, the
object (i.e., wrapper) created by the activity monitor is leaked.  By
setting the kernel manager's `_activity_stream` member to `None` when
the kernel is shutdown, cleanup of the iopub wrapper object will take
place.