### PR TITLE
Update jQuery to version 2.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "font-awesome": "components/font-awesome#~4.7.0",
     "google-caja": "5669",
     "jed": "~1.1.1",
-    "jquery": "components/jquery#~2.0",
+    "jquery": "components/jquery#~2.2",
     "jquery-typeahead": "~2.0.0",
     "jquery-ui": "components/jqueryui#~1.10",
     "marked": "~0.3",


### PR DESCRIPTION
So we can take advantage of some slightly newer features in jQuery. The last 2.x release is 2.2.4.

The 3.0 [release notes](http://blog.jquery.com/2016/06/09/jquery-3-0-final-released/) say that it shouldn't cause many breakagaes, but there are still quite a few [breaking changes](http://jquery.com/upgrade-guide/3.0/), so for now I'm sticking to 2.x for now.