### PR TITLE
[WIP] [1009] Making the prompt clickable

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -478,7 +478,7 @@ define([
         } else {
             ns = encodeURIComponent(prompt_value);
         }
-        return '<bdi>'+i18n.msg._('In')+'</bdi>&nbsp;[' + ns + ']:';
+        return '<bdi>'+i18n.msg._('In')+'</bdi>&nbsp;<prompt id="clickable_prompt" onclick="Jupyter.notebook.get_selected_cell().execute()">[' + ns + ']</prompt>:';
     };
 
     CodeCell.input_prompt_continuation = function (prompt_value, lines_number) {

--- a/notebook/static/notebook/less/codecell.less
+++ b/notebook/static/notebook/less/codecell.less
@@ -27,6 +27,9 @@ div.input_prompt {
     border-top: 1px solid transparent;
 }
 
+#clickable_prompt {
+   cursor: pointer;
+}
 // The styles related to div.highlight are for nbconvert HTML output only. This works
 // because the .highlight div isn't present in the live notebook. We could put this into
 // nbconvert, but it easily falls out of sync, can't use our less variables and doesn't


### PR DESCRIPTION
Made changes to make the prompt clickable. Only the portion between "[ ]" on the prompt becomes clickable. Also, cursor turns into a pointer to hint user that the portion is clickable.

Issue link: https://github.com/jupyter/notebook/issues/1009

Please provide further guidance on how can we improve the changes.

![screen shot 2018-03-16 at 5 27 28 pm](https://user-images.githubusercontent.com/4410397/37550023-13b8ae10-2944-11e8-9c6a-c35c3ac467c8.png)
