### PR TITLE
Undo patches in teardown before attempting to delete files

### DIFF
--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -178,9 +178,9 @@ class NotebookTestBase(TestCase):
     def teardown_class(cls):
         cls.notebook.stop()
         cls.wait_until_dead()
-        cls.tmp_dir.cleanup()
         cls.env_patch.stop()
         cls.path_patch.stop()
+        cls.tmp_dir.cleanup()
         # cleanup global zmq Context, to ensure we aren't leaving dangling sockets
         def cleanup_zmq():
             zmq.Context.instance().term()

--- a/notebook/tree/tests/test_tree_handler.py
+++ b/notebook/tree/tests/test_tree_handler.py
@@ -4,6 +4,10 @@ import io
 from notebook.utils import url_path_join
 from nbformat import write
 from nbformat.v4 import new_notebook
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 import requests
 
@@ -28,5 +32,7 @@ class TreeTest(NotebookTestBase):
         r = self.request('GET', 'tree/foo/bar.ipynb')
         self.assertEqual(r.url, self.base_url() + 'notebooks/foo/bar.ipynb')
 
-        r = self.request('GET', 'tree/foo/baz.txt')
-        self.assertEqual(r.url, url_path_join(self.base_url(), 'files/foo/baz.txt'))
+        r = self.request('GET', 'tree/foo/baz.txt', allow_redirects=False)
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(r.headers['Location'],
+             urlparse(url_path_join(self.base_url(), 'files/foo/baz.txt')).path)


### PR DESCRIPTION
Deleting the directory can fail on windows, which leaves the patches in place for other tests which run afterwards. Unfortunately we can't use `addCleanup()` with class-level setup/teardown, AFAIK.

This will probably still fail at first (unless the original issue is random), but it should see one test failure on Appveyor rather than 5.