### PR TITLE
Tweak the vertical margin of #select-all to fix its vertical position

### DIFF
--- a/notebook/static/tree/less/tree.less
+++ b/notebook/static/tree/less/tree.less
@@ -257,7 +257,8 @@ ul.breadcrumb {
 #select-all {
     margin-left: @dashboard_lr_pad;
     margin-right: 2px;
-    margin-top: 2px;
+    margin-top: 5px;
+    margin-bottom: -3px;
 
     height: 16px;
 }


### PR DESCRIPTION
I want to fix the vertical position of the select-all checkbox.

| Before | After|
| --- | --- |
| ![screenshot 2018-03-23 22 24 37](https://user-images.githubusercontent.com/3959/37831570-583697fa-2ee9-11e8-8f19-67330eb5e187.png) | ![screenshot 2018-03-23 22 24 22](https://user-images.githubusercontent.com/3959/37831577-5f5445be-2ee9-11e8-86f3-a20e192e85c0.png) |

