### PR TITLE
Disable cache when downloading file

### DIFF
--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -141,9 +141,6 @@ class NbconvertFileHandler(IPythonHandler):
         self.set_header('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
         self.finish(output)
 
-    def compute_etag(self):
-        return None
-
 class NbconvertPostHandler(IPythonHandler):
     SUPPORTED_METHODS = ('POST',)
 

--- a/notebook/nbconvert/handlers.py
+++ b/notebook/nbconvert/handlers.py
@@ -40,6 +40,7 @@ def respond_zip(handler, name, output, resources):
     zip_filename = os.path.splitext(name)[0] + '.zip'
     handler.set_attachment_header(zip_filename)
     handler.set_header('Content-Type', 'application/zip')
+    handler.set_header('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
 
     # Prepare the zip file
     buffer = io.BytesIO()


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/3251

The route handler (`NbconvertFileHandler`) that processes a download request did not have cache-control header so this adds the header so ensure that the downloaded pdf / markdown etc. file will always be the most recent (not cached).