### PR TITLE
ConfigManager should not write out default values found in the .d directory

### DIFF
--- a/notebook/config_manager.py
+++ b/notebook/config_manager.py
@@ -36,10 +36,11 @@ def recursive_update(target, new):
         else:
             target[k] = v
 
+
 def remove_defaults(data, defaults):
     """Recursively remove items from dict that are already in defaults"""
-    for key, value in list(data.items()):  # copy the iterator, since data will be modified
-        new_value = None
+    # copy the iterator, since data will be modified
+    for key, value in list(data.items()):
         if key in defaults:
             if isinstance(value, dict):
                 remove_defaults(data[key], defaults[key])
@@ -52,7 +53,7 @@ def remove_defaults(data, defaults):
 
 class BaseJSONConfigManager(LoggingConfigurable):
     """General JSON config manager
-    
+
     Deals with persisting/storing config in a json file with optionally
     default values in a {section_name}.d directory.
     """
@@ -82,8 +83,8 @@ class BaseJSONConfigManager(LoggingConfigurable):
         Returns the data as a dictionary, or an empty dictionary if the file
         doesn't exist.
 
-        When include_root is False, it will not read the root .json file, effectively
-        returning the default values.
+        When include_root is False, it will not read the root .json file,
+        effectively returning the default values.
         """
         paths = [self.file_name(section_name)] if include_root else []
         if self.read_directory:
@@ -91,7 +92,7 @@ class BaseJSONConfigManager(LoggingConfigurable):
             # These json files should be processed first so that the
             # {section_name}.json take precedence.
             # The idea behind this is that installing a Python package may
-            # put a json file somewhere in the a .d directory, while the 
+            # put a json file somewhere in the a .d directory, while the
             # .json file is probably a user configuration.
             paths = sorted(glob.glob(pattern)) + paths
         self.log.debug('Paths used for configuration of %s: \n\t%s', section_name, '\n\t'.join(paths))

--- a/notebook/config_manager.py
+++ b/notebook/config_manager.py
@@ -108,11 +108,11 @@ class BaseJSONConfigManager(LoggingConfigurable):
         filename = self.file_name(section_name)
         self.ensure_config_dir_exists()
 
-        # we will modify data in place, so make a copy
-        data = copy.deepcopy(data)
-        defaults = self.get(section_name, include_root=False)
-        print(data, defaults)
-        remove_defaults(data, defaults)
+        if self.read_directory:
+            # we will modify data in place, so make a copy
+            data = copy.deepcopy(data)
+            defaults = self.get(section_name, include_root=False)
+            remove_defaults(data, defaults)
 
         # Generate the JSON up front, since it could raise an exception,
         # in order to avoid writing half-finished corrupted data to disk.

--- a/notebook/tests/test_config_manager.py
+++ b/notebook/tests/test_config_manager.py
@@ -9,20 +9,27 @@ from notebook.config_manager import BaseJSONConfigManager
 def test_json():
     tmpdir = tempfile.mkdtemp()
     try:
+        root_data = dict(a=1, x=2, nest={'a':1, 'x':2})
         with open(os.path.join(tmpdir, 'foo.json'), 'w') as f:
-            json.dump(dict(a=1), f)
+            json.dump(root_data, f)
         # also make a foo.d/ directory with multiple json files
         os.makedirs(os.path.join(tmpdir, 'foo.d'))
         with open(os.path.join(tmpdir, 'foo.d', 'a.json'), 'w') as f:
-            json.dump(dict(a=2, b=1), f)
+            json.dump(dict(a=2, b=1, nest={'a':2, 'b':1}), f)
         with open(os.path.join(tmpdir, 'foo.d', 'b.json'), 'w') as f:
-            json.dump(dict(a=3, b=2, c=3), f)
+            json.dump(dict(a=3, b=2, c=3, nest={'a':3, 'b':2, 'c':3}, only_in_b={'x':1}), f)
         manager = BaseJSONConfigManager(config_dir=tmpdir, read_directory=False)
         data = manager.get('foo')
         assert 'a' in data
+        assert 'x' in data
         assert 'b' not in data
         assert 'c' not in data
         assert data['a'] == 1
+        assert 'x' in data['nest']
+        # if we write it out, it also shouldn't pick up the subdirectoy
+        manager.set('foo', data)
+        data = manager.get('foo')
+        assert data == root_data
 
         manager = BaseJSONConfigManager(config_dir=tmpdir, read_directory=True)
         data = manager.get('foo')
@@ -33,6 +40,17 @@ def test_json():
         assert data['a'] == 1
         assert data['b'] == 2
         assert data['c'] == 3
+        assert data['nest']['a'] == 1
+        assert data['nest']['b'] == 2
+        assert data['nest']['c'] == 3
+        assert data['nest']['x'] == 2
+
+        # when writing out, we don't want foo.d/*.json data to be included in the root foo.json
+        manager.set('foo', data)
+        manager = BaseJSONConfigManager(config_dir=tmpdir, read_directory=False)
+        data = manager.get('foo')
+        assert data == root_data
+
     finally:
         shutil.rmtree(tmpdir)
 


### PR DESCRIPTION
This is a followup of #3116.
When the config manager reads the `.json` + `.d/*.json` files, all the data gets merged into one dict. When writted out again, everything ends on in the root `.json` file. Here I remove all entries that are already present in the `.d/*.json` files.

For instance, when installing ipyvolume, you end up with the file `{prefix}/etc/jupyter/nbconfig/notebook.d/ipyvolume.json`. If you now run `jupyter nbextension ...` for anything, all the data from the `ipyvolume.json` file ends up in `{prefix}/etc/jupyter/nbconfig/notebook.d`. Uninstalling ipyvolume will never clean this up, so it will always stay around. This is now avoided by this PR.