### PR TITLE
Add a /metrics endpoint for Prometheus Metrics

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -28,6 +28,7 @@ except ImportError:
 from jinja2 import TemplateNotFound
 from tornado import web, gen, escape, httputil
 from tornado.log import app_log
+import prometheus_client
 
 from notebook._sysinfo import get_sys_info
 
@@ -809,6 +810,16 @@ class RedirectWithParams(web.RequestHandler):
         url = sep.join([self._url, self.request.query])
         self.redirect(url, permanent=self._permanent)
 
+class PrometheusMetricsHandler(IPythonHandler):
+    """
+    Return prometheus metrics for this notebook server
+    """
+    @web.authenticated
+    def get(self):
+        self.set_header('Content-Type', prometheus_client.CONTENT_TYPE_LATEST)
+        self.write(prometheus_client.generate_latest(prometheus_client.REGISTRY))
+
+
 #-----------------------------------------------------------------------------
 # URL pattern fragments for re-use
 #-----------------------------------------------------------------------------
@@ -825,4 +836,5 @@ default_handlers = [
     (r".*/", TrailingSlashHandler),
     (r"api", APIVersionHandler),
     (r'/(robots\.txt|favicon\.ico)', web.StaticFileHandler),
+    (r'/metrics', PrometheusMetricsHandler)
 ]

--- a/notebook/log.py
+++ b/notebook/log.py
@@ -7,6 +7,7 @@
 
 import json
 from tornado.log import access_log
+from .metrics import prometheus_log_method
 
 def log_request(handler):
     """log a bit more information about each request than tornado's default
@@ -45,4 +46,4 @@ def log_request(handler):
         # log all headers if it caused an error
         log_method(json.dumps(dict(request.headers), indent=2))
     log_method(msg.format(**ns))
-
+    prometheus_log_method(handler)

--- a/notebook/metrics.py
+++ b/notebook/metrics.py
@@ -2,14 +2,12 @@
 Prometheus metrics exported by Jupyter Notebook Server
 
 Read https://prometheus.io/docs/practices/naming/ for naming
-conventions for metrics & labels. We generally prefer naming them
-`<noun>_<verb>_<type_suffix>`. So a histogram that's tracking
-the duration (in seconds) of servers spawning would be called
-SERVER_SPAWN_DURATION_SECONDS.
+conventions for metrics & labels.
 """
 
 from prometheus_client import Histogram
 
+# This is a fairly standard name for HTTP request latency reporting.
 REQUEST_DURATION_SECONDS = Histogram(
     'request_duration_seconds',
     'request duration for all HTTP requests',

--- a/notebook/metrics.py
+++ b/notebook/metrics.py
@@ -7,11 +7,11 @@ conventions for metrics & labels.
 
 from prometheus_client import Histogram
 
-# This is a fairly standard name for HTTP request latency reporting.
-REQUEST_DURATION_SECONDS = Histogram(
-    'request_duration_seconds',
-    'request duration for all HTTP requests',
-    ['method', 'handler', 'code'],
+# This is a fairly standard name for HTTP duration latency reporting
+HTTP_REQUEST_DURATION_SECONDS = Histogram(
+    'http_request_duration_seconds',
+    'duration in seconds for all HTTP requests',
+    ['method', 'handler', 'status_code'],
 )
 
 def prometheus_log_method(handler):
@@ -30,8 +30,8 @@ def prometheus_log_method(handler):
     that is the 'log_function' tornado setting. This makes it get called
     at the end of every request, allowing us to record the metrics we need.
     """
-    REQUEST_DURATION_SECONDS.labels(
+    HTTP_REQUEST_DURATION_SECONDS.labels(
         method=handler.request.method,
         handler='{}.{}'.format(handler.__class__.__module__, type(handler).__name__),
-        code=handler.get_status()
+        status_code=handler.get_status()
     ).observe(handler.request.request_time())

--- a/notebook/metrics.py
+++ b/notebook/metrics.py
@@ -1,0 +1,39 @@
+"""
+Prometheus metrics exported by Jupyter Notebook Server
+
+Read https://prometheus.io/docs/practices/naming/ for naming
+conventions for metrics & labels. We generally prefer naming them
+`<noun>_<verb>_<type_suffix>`. So a histogram that's tracking
+the duration (in seconds) of servers spawning would be called
+SERVER_SPAWN_DURATION_SECONDS.
+"""
+
+from prometheus_client import Histogram
+
+REQUEST_DURATION_SECONDS = Histogram(
+    'request_duration_seconds',
+    'request duration for all HTTP requests',
+    ['method', 'handler', 'code'],
+)
+
+def prometheus_log_method(handler):
+    """
+    Tornado log handler for recording RED metrics.
+
+    We record the following metrics:
+       Rate – the number of requests, per second, your services are serving.
+       Errors – the number of failed requests per second.
+       Duration – The amount of time each request takes expressed as a time interval.
+
+    We use a fully qualified name of the handler as a label,
+    rather than every url path to reduce cardinality.
+
+    This function should be either the value of or called from a function
+    that is the 'log_function' tornado setting. This makes it get called
+    at the end of every request, allowing us to record the metrics we need.
+    """
+    REQUEST_DURATION_SECONDS.labels(
+        method=handler.request.method,
+        handler='{}.{}'.format(handler.__class__.__module__, type(handler).__name__),
+        code=handler.get_status()
+    ).observe(handler.request.request_time())

--- a/notebook/metrics.py
+++ b/notebook/metrics.py
@@ -21,9 +21,9 @@ def prometheus_log_method(handler):
     Tornado log handler for recording RED metrics.
 
     We record the following metrics:
-       Rate – the number of requests, per second, your services are serving.
-       Errors – the number of failed requests per second.
-       Duration – The amount of time each request takes expressed as a time interval.
+       Rate - the number of requests, per second, your services are serving.
+       Errors - the number of failed requests per second.
+       Duration - The amount of time each request takes expressed as a time interval.
 
     We use a fully qualified name of the handler as a label,
     rather than every url path to reduce cardinality.

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,8 @@ for more information.
         'nbconvert',
         'ipykernel', # bless IPython kernel for now
         'Send2Trash',
-        'terminado>=0.8.1'
+        'terminado>=0.8.1',
+        'prometheus_client'
     ],
     extras_require = {
         'test:python_version == "2.7"': ['mock'],


### PR DESCRIPTION
[Prometheus](https://prometheus.io/) provides a standard
metrics format that can be collected and used in many contexts.

- From the browser
  to drive 'current resource usage' displays, such
  as https://github.com/yuvipanda/nbresuse
- From a prometheus server
  to collect historical data for operational analysis and
  performance monitoring
  Example: https://grafana.mybinder.org/dashboard/db/1-overview?refresh=1m&orgId=1
  for mybinder.org metrics from JupyterHub and BinderHub,
  via prometheus server at https://prometheus.mybinder.org

The JupyterHub and BinderHub projects already expose Prometheus
metrics natively. Adding this to the Jupyter notebook server
allows us to instrument the code easily and in
a standard format that has lots of 3rd party tooling for it.

This commit does the following:

- Introduce the `prometheus_client` library as a dependency.
  This library has no dependencies of its own and is pure python.
- Add an authenticated `/metrics` endpoint to the server,
  which returns metrics in Prometheus Text Format
- Expose the default process metrics from `prometheus_client`,
  which include memory usage and CPU usage info (for just the
  notebook process)
- Expose per-handler HTTP metrics using the [RED method](https://rancher.com/red-method-for-prometheus-3-key-metrics-for-monitoring/)