### PR TITLE
Only check links when build is trigger by Travis Cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,11 @@ script:
       if [[ $GROUP == docs ]]; then
         EXIT_STATUS=0
         make -C docs/ html || EXIT_STATUS=$?
-        'if [[ $TRAVIS_EVENT_TYPE == cron ]]; then make -C docs/ linkcheck || EXIT_STATUS=$?; fi'
+
+        if [[ $TRAVIS_EVENT_TYPE == cron ]]; then
+          make -C docs/ linkcheck || EXIT_STATUS=$?;
+        fi
+
         pytest --nbval --current-env docs || EXIT_STATUS=$?
         exit $EXIT_STATUS
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
       if [[ $GROUP == docs ]]; then
         EXIT_STATUS=0
         make -C docs/ html || EXIT_STATUS=$?
-        make -C docs/ linkcheck || EXIT_STATUS=$?
+        'if [[ $TRAVIS_EVENT_TYPE == cron ]]; then make -C docs/ linkcheck || EXIT_STATUS=$?; fi'
         pytest --nbval --current-env docs || EXIT_STATUS=$?
         exit $EXIT_STATUS
       fi


### PR DESCRIPTION
Addresses https://github.com/jupyter/notebook/issues/3292

This line `make -C docs/ linkcheck || EXIT_STATUS=$?;` that does the link checking will only run if the build is triggered by a cron job.

Let me know if there are any changes to be made!
