### PR TITLE
Prevent default event handling on new terminal

### DIFF
--- a/notebook/static/tree/js/terminallist.js
+++ b/notebook/static/tree/js/terminallist.js
@@ -42,7 +42,10 @@ define([
         $('#new-terminal').click($.proxy(this.new_terminal, this));
     };
 
-    TerminalList.prototype.new_terminal = function () {
+    TerminalList.prototype.new_terminal = function (event) {
+        if (event) {
+            event.preventDefault();
+        }
         var w = window.open('#', IPython._target);
         var base_url = this.base_url;
         var settings = {


### PR DESCRIPTION
Avoid resetting the directory navigation when you create a new terminal.

Closes gh-3496