### PR TITLE
Color contrast improvements

### DIFF
--- a/notebook/static/base/less/variables.less
+++ b/notebook/static/base/less/variables.less
@@ -8,6 +8,7 @@
 @navbar-height: 30px;
 @brand-success: #006500;
 @brand-info: #165E73;
+@brand-warning: #923D00;
 @breadcrumb-color: darken(@border_color, 30%);
 @blockquote-font-size: inherit;
 @modal-inner-padding: 15px;

--- a/notebook/static/base/less/variables.less
+++ b/notebook/static/base/less/variables.less
@@ -7,6 +7,7 @@
 @link-color: #033EAF;
 @navbar-height: 30px;
 @brand-success: #006500;
+@brand-info: #165E73;
 @breadcrumb-color: darken(@border_color, 30%);
 @blockquote-font-size: inherit;
 @modal-inner-padding: 15px;

--- a/notebook/static/base/less/variables.less
+++ b/notebook/static/base/less/variables.less
@@ -4,6 +4,7 @@
 @text-color: @black;
 @font-size-base: 13px;
 @font-family-monospace: monospace;  // to allow user to customize their fonts
+@link-color: #033EAF;
 @navbar-height: 30px;
 @breadcrumb-color: darken(@border_color, 30%);
 @blockquote-font-size: inherit;
@@ -53,7 +54,7 @@ label {
 @page-backdrop-height: 100vh;
 /* Make the page itself atleast 70% the height of the view port */
 @page-min-height: 0;
-@page-backdrop-color: #EEE;
+@page-backdrop-color: #F7F7F7;
 @page-color: @body-bg;
 @page-padding: 15px;
 

--- a/notebook/static/base/less/variables.less
+++ b/notebook/static/base/less/variables.less
@@ -6,6 +6,7 @@
 @font-family-monospace: monospace;  // to allow user to customize their fonts
 @link-color: #033EAF;
 @navbar-height: 30px;
+@brand-success: #006500;
 @breadcrumb-color: darken(@border_color, 30%);
 @blockquote-font-size: inherit;
 @modal-inner-padding: 15px;

--- a/notebook/static/base/less/variables.less
+++ b/notebook/static/base/less/variables.less
@@ -4,11 +4,7 @@
 @text-color: @black;
 @font-size-base: 13px;
 @font-family-monospace: monospace;  // to allow user to customize their fonts
-@link-color: #033EAF;
 @navbar-height: 30px;
-@brand-success: #006500;
-@brand-info: #165E73;
-@brand-warning: #923D00;
 @breadcrumb-color: darken(@border_color, 30%);
 @blockquote-font-size: inherit;
 @modal-inner-padding: 15px;
@@ -21,6 +17,14 @@
 @grid-gutter-width: 0px;
 @kbd-color: #888;
 @kbd-bg: transparent;
+
+// For improved color contrast
+@link-color: #295982;
+@brand-success: #008A00;
+@brand-info: #165E73;
+@brand-warning: #FF9D58;
+@brand-danger: #9D3532;
+@btn-warning-color: #000000;
 
 @icon-font-path: "../components/bootstrap/fonts/";
 

--- a/notebook/static/notebook/less/notificationarea.less
+++ b/notebook/static/notebook/less/notificationarea.less
@@ -9,7 +9,7 @@
 
 .indicator_area {
     .pull-right();
-    color: @navbar-default-link-color;
+    color: darken(@navbar-default-link-color,20%);
     margin-left: 5px;
     margin-right: 5px;
     width: 11px;

--- a/notebook/static/tree/js/kernellist.js
+++ b/notebook/static/tree/js/kernellist.js
@@ -8,7 +8,7 @@ define([
     'base/js/i18n'
 ], function($, IPython, notebooklist, i18n) {
     "use strict";
-    
+
     var KernelList = function (selector, options) {
         /**
          * Constructor
@@ -35,7 +35,7 @@ define([
          * do nothing
          */
     };
-    
+
     KernelList.prototype._kernelspecs_loaded = function (event, kernelspecs) {
         this.kernelspecs = kernelspecs;
         if (this.sessions) {
@@ -43,7 +43,7 @@ define([
             this.sessions_loaded(this.sessions);
         }
     };
-    
+
     KernelList.prototype.sessions_loaded = function (d) {
         this.sessions = d;
         if (!this.kernelspecs) {
@@ -82,15 +82,16 @@ define([
             .appendTo(running_indicator);
 
         var shutdown_button = $('<button/>')
-            .addClass('btn btn-warning btn-xs')
+            .addClass('btn btn-default btn-xs')
             .text(i18n._('Shutdown'))
+            .prepend("<i class=\"fa fa-exclamation-triangle\"></i> ")
             .click(function() {
                 var path = $(this).parent().parent().parent().data('path');
                 that.shutdown_notebook(path);
             })
             .appendTo(running_indicator);
     };
-    
+
     // Backwards compatability.
     IPython.KernelList = KernelList;
 

--- a/notebook/static/tree/js/terminallist.js
+++ b/notebook/static/tree/js/terminallist.js
@@ -50,7 +50,7 @@ define([
             dataType: "json",
             success : function (data, status, xhr) {
                 var name = data.name;
-                w.location = utils.url_path_join(base_url, 'terminals', 
+                w.location = utils.url_path_join(base_url, 'terminals',
                     utils.encode_uri_components(name));
             },
             error : function(jqXHR, status, error){
@@ -64,7 +64,7 @@ define([
         );
         utils.ajax(url, settings);
     };
-    
+
     TerminalList.prototype.load_terminals = function() {
         var url = utils.url_path_join(this.base_url, 'api/terminals');
         utils.ajax(url, {
@@ -88,7 +88,7 @@ define([
         }
         $('#terminal_list_header').toggle(data.length === 0);
     };
-    
+
     TerminalList.prototype.add_link = function(name, item) {
         item.data('term-name', name);
         item.find(".item_name").text("terminals/" + name);
@@ -99,11 +99,14 @@ define([
         link.attr('target', IPython._target||'_blank');
         this.add_shutdown_button(name, item);
     };
-    
+
     TerminalList.prototype.add_shutdown_button = function(name, item) {
         var that = this;
-        var shutdown_button = $("<button/>").text(i18n._("Shutdown")).addClass("btn btn-xs btn-warning").
-            click(function (e) {
+        var shutdown_button = $("<button/>")
+            .text(i18n._("Shutdown"))
+            .prepend("<i class=\"fa fa-exclamation-triangle\"></i> ")
+            .addClass("btn btn-default btn-xs")
+            .click(function (e) {
                 var settings = {
                     processData : false,
                     type : "DELETE",

--- a/notebook/static/tree/less/tree.less
+++ b/notebook/static/tree/less/tree.less
@@ -179,7 +179,7 @@ ul.breadcrumb {
     }
     .running-indicator {
         padding-top: @dashboard_tb_pad;
-        color: darken(@brand-success,20%);
+        color: @brand-success;
     }
     .kernel-name {
         padding-top: @dashboard_tb_pad;

--- a/notebook/static/tree/less/tree.less
+++ b/notebook/static/tree/less/tree.less
@@ -180,6 +180,7 @@ ul.breadcrumb {
     .running-indicator {
         padding-top: @dashboard_tb_pad;
         color: @brand-success;
+        font-weight: bold;
     }
     .kernel-name {
         padding-top: @dashboard_tb_pad;

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -44,10 +44,10 @@ data-server-root="{{server_root}}"
                   <button title="{% trans %}Rename selected{% endtrans %}" aria-label="{% trans %}Rename selected{% endtrans %}" class="rename-button btn btn-default btn-xs">{% trans %}Rename{% endtrans %}</button>
                   <button title="{% trans %}Move selected{% endtrans %}" aria-label="{% trans %}Move selected{% endtrans %}" class="move-button btn btn-default btn-xs">{% trans %}Move{% endtrans %}</button>
                   <button title="{% trans %}Download selected{% endtrans %}" aria-label="{% trans %}Download selected{% endtrans %}" class="download-button btn btn-default btn-xs">{% trans %}Download{% endtrans %}</button>
-                  <button title="{% trans %}Shutdown selected notebook(s){% endtrans %}" aria-label="{% trans %}Shutdown selected notebook(s){% endtrans %}" class="shutdown-button btn btn-default btn-xs btn-warning">{% trans %}Shutdown{% endtrans %}</button>
                   <button title="{% trans %}View selected{% endtrans %}" aria-label="{% trans %}View selected{% endtrans %}" class="view-button btn btn-default btn-xs">{% trans %}View{% endtrans %}</button>
                   <button title="{% trans %}Edit selected{% endtrans %}" aria-label="{% trans %}Edit selected{% endtrans %}" class="edit-button btn btn-default btn-xs">{% trans %}Edit{% endtrans %}</button>
-                  <button title="{% trans %}Delete selected{% endtrans %}" aria-label="{% trans %}Delete selected{% endtrans %}" class="delete-button btn btn-default btn-xs btn-danger"><i class="fa fa-trash"></i></button>
+                  <button title="{% trans %}Shutdown selected notebook(s){% endtrans %}" aria-label="{% trans %}Shutdown selected notebook(s){% endtrans %}" class="shutdown-button btn btn-default btn-xs"><i class="fa fa-exclamation-triangle"></i> {% trans %}Shutdown{% endtrans %}</button>
+                  <button title="{% trans %}Delete selected{% endtrans %}" aria-label="{% trans %}Delete selected{% endtrans %}" class="delete-button btn btn-default btn-xs"><i class="fa fa-trash"></i> {% trans %}Delete{% endtrans %}</button>
               </div>
             </div>
             <div class="col-sm-4 no-padding tree-buttons">


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/3218

- [x] From localhost/tree/docs the contrast between the word docs against the gray background fails. Change the color on line 1094 from 337ab7 to 336db7 or darker passes.
- [x] Create a new notebook and go back to localhost/tree/docs. The word "running" appears next to the file name of the new notebook, but the color green used for the word "running" fails color contrast. Changing the color on line 9812 from 5cb85c to 5c7f5c or darker passes.
- [x] From localhost/tree#running (a new notebook is running) the contrast for line 3278 kernel-name #foad4e needs to be darker.
- [x] From localhost/tree#running (a new notebook is running) the contrast for line 9814 btn-warning #5bc0de needs to be darker.
- [x] From a new notebook (http://localhost/notebooks/docs/Untitled.ipynb) the contrast for line 11978 kernel_indicator `#777` needs to be darker.

### Notes

- I've chosen colors which pass at least [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast7) standards for color contrast.
- The Shutdown and Delete buttons were being used at very small sizes, and contrast was a big issue with both of these. Prior to this change, these were being called out with orange and red, respectively. I'm recommending in some cases to swap the colors for icons instead, so that contrast can remain high, with clear indicators for all users.


## Before

- The orange Shutdown and red Delete buttons have poor contrast, especially at such a small size
- Trash can may be difficult to parse, especially at this size
- Blue links and green icons/labels could have improved contrast (less severe than the buttons)

![screenshot 2018-04-14 11 49 12](https://user-images.githubusercontent.com/72936/38766984-907b6ba2-3fda-11e8-8cb2-d5498c98ac18.png)

![screenshot 2018-04-14 11 49 27](https://user-images.githubusercontent.com/72936/38766985-95a7e3da-3fda-11e8-95a3-3793476260a9.png)


## After

- Shutdown and Delete buttons use icons to stand out. (They are also adjacent to keep high-stakes actions together)
- Delete button includes a text label for clarity
- Blue and green have been tweaked for better contrast

![screenshot 2018-04-14 11 52 23](https://user-images.githubusercontent.com/72936/38766993-c99d9946-3fda-11e8-825f-40239810db97.png)

![screenshot 2018-04-14 11 52 45](https://user-images.githubusercontent.com/72936/38766994-ce4824c0-3fda-11e8-9a66-1c7c0b8eb245.png)

