### PR TITLE
Use the system UI font as the base font

### DIFF
--- a/notebook/static/base/less/variables.less
+++ b/notebook/static/base/less/variables.less
@@ -3,6 +3,9 @@
 @black: #000;
 @text-color: @black;
 @font-size-base: 13px;
+@font-family-sans-serif: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
+    "Droid Sans", "Helvetica Neue", sans-serif;
 @font-family-monospace: monospace;  // to allow user to customize their fonts
 @navbar-height: 30px;
 @breadcrumb-color: darken(@border_color, 30%);


### PR DESCRIPTION
For your consideration: It's increasingly common to use a system UI font for web-based apps, since each font may be more optimized to a user's system, and also "fits in" with the surrounding OS user interface elements.

No performance gains, just thought it provide be a nice subtle facelift.