### PR TITLE
set the best monospaced font for users in advance

### DIFF
--- a/notebook/static/base/less/variables.less
+++ b/notebook/static/base/less/variables.less
@@ -3,7 +3,7 @@
 @black: #000;
 @text-color: @black;
 @font-size-base: 13px;
-@font-family-monospace: Menlo, Monaco, Consolas, 'Ubuntu Mono', 'Courier New', Courier, monospace;  // to allow user to customize their fonts
+@font-family-monospace: Menlo, Monaco, Consolas, 'Ubuntu Mono', 'Courier New', Courier, monospace;
 @navbar-height: 30px;
 @breadcrumb-color: darken(@border_color, 30%);
 @blockquote-font-size: inherit;

--- a/notebook/static/base/less/variables.less
+++ b/notebook/static/base/less/variables.less
@@ -3,7 +3,7 @@
 @black: #000;
 @text-color: @black;
 @font-size-base: 13px;
-@font-family-monospace: monospace;  // to allow user to customize their fonts
+@font-family-monospace: Menlo, Monaco, Consolas, 'Ubuntu Mono', 'Courier New', Courier, monospace;  // to allow user to customize their fonts
 @navbar-height: 30px;
 @breadcrumb-color: darken(@border_color, 30%);
 @blockquote-font-size: inherit;

--- a/notebook/static/notebook/less/codemirror.less
+++ b/notebook/static/notebook/less/codemirror.less
@@ -10,6 +10,7 @@
  */
 
 .CodeMirror {
+    font-family: @font-family-monospace;
     line-height: @code_line_height;  /* Changed from 1em to our global default */
     font-size: @notebook_font_size;
     height: auto;     /* Changed to auto to autogrow */

--- a/notebook/static/terminal/less/terminal.less
+++ b/notebook/static/terminal/less/terminal.less
@@ -9,7 +9,7 @@
   .terminal {
     width: 100%;
     float: left;
-    font-family: monospace;
+    font-family: @font-family-monospace;
     color: white;
     background: black;
     padding: @code_padding;

--- a/notebook/templates/terminal.html
+++ b/notebook/templates/terminal.html
@@ -14,8 +14,8 @@ data-ws-path="{{ws_path}}"
 
 {% block stylesheet %}
 {{super()}}
-<link rel="stylesheet" href="{{ static_url("terminal/css/override.css") }}" type="text/css" />
 <link rel="stylesheet" href="{{static_url("components/xterm.js-css/index.css") }}" type="text/css" />
+<link rel="stylesheet" href="{{ static_url("terminal/css/override.css") }}" type="text/css" />
 {% endblock %}
 
 {% block headercontainer %}

--- a/notebook/templates/terminal.html
+++ b/notebook/templates/terminal.html
@@ -14,8 +14,8 @@ data-ws-path="{{ws_path}}"
 
 {% block stylesheet %}
 {{super()}}
-<link rel="stylesheet" href="{{static_url("components/xterm.js-css/index.css") }}" type="text/css" />
 <link rel="stylesheet" href="{{ static_url("terminal/css/override.css") }}" type="text/css" />
+<link rel="stylesheet" href="{{static_url("components/xterm.js-css/index.css") }}" type="text/css" />
 {% endblock %}
 
 {% block headercontainer %}


### PR DESCRIPTION
I think that under normal circumstances, **most users will not actively set the font in the bowser**, so we should **set the best font for them in advance.**

I don't like css's default monospace font (usually the Courier New font), so I would like to set the best fonts under different systems (specifically, macOS' Menlo and Monaco, Ubuntu's Ubuntu Mono and Windows' Consolas ) to the default monospaced font for Jupyter notebook. The following is the display    on macOS after beautification.

<img width="423" alt="screen shot 2018-04-16 at 1 29 19 am" src="https://user-images.githubusercontent.com/23468295/38781914-01849a5e-411f-11e8-85c1-10e42a640032.png">
<img width="528" alt="screen shot 2018-04-16 at 1 29 53 am" src="https://user-images.githubusercontent.com/23468295/38781915-02d76396-411f-11e8-8540-7063fce03de6.png">
<img width="293" alt="screen shot 2018-04-16 at 1 30 21 am" src="https://user-images.githubusercontent.com/23468295/38781919-05adaf4e-411f-11e8-93bc-65418ce6e8a6.png">
