### PR TITLE
Lay base for structured Logging.

### DIFF
--- a/notebook/i18n/notebook.pot
+++ b/notebook/i18n/notebook.pot
@@ -1,145 +1,150 @@
 # Translations template for Jupyter.
-# Copyright (C) 2017 ORGANIZATION
+# Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the Jupyter project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Jupyter VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-07-08 21:52-0500\n"
+"POT-Creation-Date: 2018-04-17 17:58-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.5.1\n"
 
-#: notebook/notebookapp.py:53
+#: notebook/notebookapp.py:52
 msgid "The Jupyter Notebook requires tornado >= 4.0"
 msgstr ""
 
-#: notebook/notebookapp.py:57
+#: notebook/notebookapp.py:56
 msgid "The Jupyter Notebook requires tornado >= 4.0, but you have < 1.1.0"
 msgstr ""
 
-#: notebook/notebookapp.py:59
+#: notebook/notebookapp.py:58
 #, python-format
 msgid "The Jupyter Notebook requires tornado >= 4.0, but you have %s"
 msgstr ""
 
-#: notebook/notebookapp.py:209
+#: notebook/notebookapp.py:208
 msgid "The `ignore_minified_js` flag is deprecated and no longer works."
 msgstr ""
 
-#: notebook/notebookapp.py:210
+#: notebook/notebookapp.py:209
 #, python-format
 msgid "Alternatively use `%s` when working on the notebook's Javascript and LESS"
 msgstr ""
 
-#: notebook/notebookapp.py:211
+#: notebook/notebookapp.py:210
 msgid "The `ignore_minified_js` flag is deprecated and will be removed in Notebook 6.0"
 msgstr ""
 
-#: notebook/notebookapp.py:389
+#: notebook/notebookapp.py:470
 msgid "List currently running notebook servers."
 msgstr ""
 
-#: notebook/notebookapp.py:393
-msgid "Produce machine-readable JSON output."
+#: notebook/notebookapp.py:474
+msgid "Produce machine-readable JSON list output."
 msgstr ""
 
-#: notebook/notebookapp.py:397
-msgid "If True, each line of output will be a JSON object with the details from the server info file."
+#: notebook/notebookapp.py:476
+msgid "Produce machine-readable JSON object on each line of output."
 msgstr ""
 
-#: notebook/notebookapp.py:402
-msgid "Currently running servers:"
+#: notebook/notebookapp.py:480
+msgid "If True, the output will be a JSON list of objects, one per active notebook server, each with the details from the relevant server info file."
 msgstr ""
 
-#: notebook/notebookapp.py:419
+#: notebook/notebookapp.py:484
+msgid "If True, each line of output will be a JSON object with the details from the server info file. For a JSON list output, see the NbserverListApp.jsonlist configuration value"
+msgstr ""
+
+#: notebook/notebookapp.py:510
 msgid "Don't open the notebook in a browser after startup."
 msgstr ""
 
-#: notebook/notebookapp.py:423
+#: notebook/notebookapp.py:514
 msgid "DISABLED: use %pylab or %matplotlib in the notebook to enable matplotlib."
 msgstr ""
 
-#: notebook/notebookapp.py:439
+#: notebook/notebookapp.py:530
 msgid "Allow the notebook to be run from root user."
 msgstr ""
 
-#: notebook/notebookapp.py:470
+#: notebook/notebookapp.py:561
 msgid ""
 "The Jupyter HTML Notebook.\n"
 "    \n"
 "    This launches a Tornado based HTML Notebook Server that serves up an HTML5/Javascript Notebook client."
 msgstr ""
 
-#: notebook/notebookapp.py:509
+#: notebook/notebookapp.py:600
 msgid "Deprecated: Use minified JS file or not, mainly use during dev to avoid JS recompilation"
 msgstr ""
 
-#: notebook/notebookapp.py:540
+#: notebook/notebookapp.py:631
 msgid "Set the Access-Control-Allow-Credentials: true header"
 msgstr ""
 
-#: notebook/notebookapp.py:544
+#: notebook/notebookapp.py:635
 msgid "Whether to allow the user to run the notebook as root."
 msgstr ""
 
-#: notebook/notebookapp.py:548
+#: notebook/notebookapp.py:639
 msgid "The default URL to redirect to from `/`"
 msgstr ""
 
-#: notebook/notebookapp.py:552
+#: notebook/notebookapp.py:643
 msgid "The IP address the notebook server will listen on."
 msgstr ""
 
-#: notebook/notebookapp.py:565
-#, python-format
+#: notebook/notebookapp.py:656
 msgid ""
 "Cannot bind to localhost, using 127.0.0.1 as default ip\n"
-"%s"
+"error"
 msgstr ""
 
-#: notebook/notebookapp.py:579
+#: notebook/notebookapp.py:670
 msgid "The port the notebook server will listen on."
 msgstr ""
 
-#: notebook/notebookapp.py:583
+#: notebook/notebookapp.py:674
 msgid "The number of additional ports to try if the specified port is not available."
 msgstr ""
 
-#: notebook/notebookapp.py:587
+#: notebook/notebookapp.py:678
 msgid "The full path to an SSL/TLS certificate file."
 msgstr ""
 
-#: notebook/notebookapp.py:591
+#: notebook/notebookapp.py:682
 msgid "The full path to a private key file for usage with SSL/TLS."
 msgstr ""
 
-#: notebook/notebookapp.py:595
+#: notebook/notebookapp.py:686
 msgid "The full path to a certificate authority certificate for SSL/TLS client authentication."
 msgstr ""
 
-#: notebook/notebookapp.py:599
+#: notebook/notebookapp.py:690
 msgid "The file where the cookie secret is stored."
 msgstr ""
 
-#: notebook/notebookapp.py:628
-#, python-format
-msgid "Writing notebook server cookie secret to %s"
+#: notebook/notebookapp.py:721
+msgid "Writing notebook server cookie secret to {file_path}"
 msgstr ""
 
-#: notebook/notebookapp.py:635
-#, python-format
-msgid "Could not set permissions on %s"
+#: notebook/notebookapp.py:726
+msgid "Failed to write cookie secret to {file_path}: {error}"
 msgstr ""
 
-#: notebook/notebookapp.py:640
+#: notebook/notebookapp.py:732
+msgid "Could not set permissions on {file_path}"
+msgstr ""
+
+#: notebook/notebookapp.py:737
 msgid ""
 "Token used for authenticating first-time connections to the server.\n"
 "\n"
@@ -150,41 +155,43 @@ msgid ""
 "        "
 msgstr ""
 
-#: notebook/notebookapp.py:650
+#: notebook/notebookapp.py:747
 msgid ""
 "One-time token used for opening a browser.\n"
 "        Once used, this token cannot be used again.\n"
 "        "
 msgstr ""
 
-#: notebook/notebookapp.py:726
+#: notebook/notebookapp.py:838
 msgid ""
 "Specify Where to open the notebook on startup. This is the\n"
 "        `new` argument passed to the standard library method `webbrowser.open`.\n"
 "        The behaviour is not guaranteed, but depends on browser support. Valid\n"
 "        values are:\n"
-"            2 opens a new tab,\n"
-"            1 opens a new window,\n"
-"            0 opens in an existing window.\n"
+"\n"
+"         - 2 opens a new tab,\n"
+"         - 1 opens a new window,\n"
+"         - 0 opens in an existing window.\n"
+"\n"
 "        See the `webbrowser.open` documentation for details.\n"
 "        "
 msgstr ""
 
-#: notebook/notebookapp.py:737
+#: notebook/notebookapp.py:851
 msgid "DEPRECATED, use tornado_settings"
 msgstr ""
 
-#: notebook/notebookapp.py:742
+#: notebook/notebookapp.py:856
 msgid ""
 "\n"
 "    webapp_settings is deprecated, use tornado_settings.\n"
 msgstr ""
 
-#: notebook/notebookapp.py:746
+#: notebook/notebookapp.py:860
 msgid "Supply overrides for the tornado.web.Application that the Jupyter notebook uses."
 msgstr ""
 
-#: notebook/notebookapp.py:750
+#: notebook/notebookapp.py:864
 msgid ""
 "\n"
 "        Set the tornado compression options for websocket connections.\n"
@@ -197,284 +204,294 @@ msgid ""
 "        "
 msgstr ""
 
-#: notebook/notebookapp.py:761
+#: notebook/notebookapp.py:875
 msgid "Supply overrides for terminado. Currently only supports \"shell_command\"."
 msgstr ""
 
-#: notebook/notebookapp.py:764
+#: notebook/notebookapp.py:878
 msgid "Extra keyword arguments to pass to `set_secure_cookie`. See tornado's set_secure_cookie docs for details."
 msgstr ""
 
-#: notebook/notebookapp.py:768
+#: notebook/notebookapp.py:882
 msgid ""
 "Supply SSL options for the tornado HTTPServer.\n"
 "            See the tornado docs for details."
 msgstr ""
 
-#: notebook/notebookapp.py:772
+#: notebook/notebookapp.py:886
 msgid "Supply extra arguments that will be passed to Jinja environment."
 msgstr ""
 
-#: notebook/notebookapp.py:776
+#: notebook/notebookapp.py:890
 msgid "Extra variables to supply to jinja templates when rendering."
 msgstr ""
 
-#: notebook/notebookapp.py:812
+#: notebook/notebookapp.py:926
 msgid "DEPRECATED use base_url"
 msgstr ""
 
-#: notebook/notebookapp.py:816
+#: notebook/notebookapp.py:930
 msgid "base_project_url is deprecated, use base_url"
 msgstr ""
 
-#: notebook/notebookapp.py:832
+#: notebook/notebookapp.py:946
 msgid "Path to search for custom.js, css"
 msgstr ""
 
-#: notebook/notebookapp.py:844
+#: notebook/notebookapp.py:958
 msgid ""
 "Extra paths to search for serving jinja templates.\n"
 "\n"
 "        Can be used to override templates from notebook.templates."
 msgstr ""
 
-#: notebook/notebookapp.py:855
+#: notebook/notebookapp.py:969
 msgid "extra paths to look for Javascript notebook extensions"
 msgstr ""
 
-#: notebook/notebookapp.py:900
-#, python-format
-msgid "Using MathJax: %s"
+#: notebook/notebookapp.py:973
+msgid "handlers that should be loaded at higher priority than the default services"
 msgstr ""
 
-#: notebook/notebookapp.py:903
+#: notebook/notebookapp.py:1018
+msgid "Using MathJax: {url}"
+msgstr ""
+
+#: notebook/notebookapp.py:1021
 msgid "The MathJax.js configuration file that is to be used."
 msgstr ""
 
-#: notebook/notebookapp.py:908
-#, python-format
-msgid "Using MathJax configuration file: %s"
+#: notebook/notebookapp.py:1026
+msgid "Using MathJax configuration file: {file_path}"
 msgstr ""
 
-#: notebook/notebookapp.py:914
+#: notebook/notebookapp.py:1037
 msgid "The notebook manager class to use."
 msgstr ""
 
-#: notebook/notebookapp.py:920
+#: notebook/notebookapp.py:1043
 msgid "The kernel manager class to use."
 msgstr ""
 
-#: notebook/notebookapp.py:926
+#: notebook/notebookapp.py:1049
 msgid "The session manager class to use."
 msgstr ""
 
-#: notebook/notebookapp.py:932
+#: notebook/notebookapp.py:1055
 msgid "The config manager class to use"
 msgstr ""
 
-#: notebook/notebookapp.py:953
+#: notebook/notebookapp.py:1076
 msgid "The login handler class to use."
 msgstr ""
 
-#: notebook/notebookapp.py:960
+#: notebook/notebookapp.py:1083
 msgid "The logout handler class to use."
 msgstr ""
 
-#: notebook/notebookapp.py:964
+#: notebook/notebookapp.py:1087
 msgid "Whether to trust or not X-Scheme/X-Forwarded-Proto and X-Real-Ip/X-Forwarded-For headerssent by the upstream reverse proxy. Necessary if the proxy handles SSL"
 msgstr ""
 
-#: notebook/notebookapp.py:976
+#: notebook/notebookapp.py:1099
 msgid ""
 "\n"
 "        DISABLED: use %pylab or %matplotlib in the notebook to enable matplotlib.\n"
 "        "
 msgstr ""
 
-#: notebook/notebookapp.py:988
+#: notebook/notebookapp.py:1111
 msgid "Support for specifying --pylab on the command line has been removed."
 msgstr ""
 
-#: notebook/notebookapp.py:990
+#: notebook/notebookapp.py:1113
 msgid "Please use `%pylab{0}` or `%matplotlib{0}` in the notebook itself."
 msgstr ""
 
-#: notebook/notebookapp.py:995
+#: notebook/notebookapp.py:1118
 msgid "The directory to use for notebooks and kernels."
 msgstr ""
 
-#: notebook/notebookapp.py:1018
+#: notebook/notebookapp.py:1141
 #, python-format
 msgid "No such notebook dir: '%r'"
 msgstr ""
 
-#: notebook/notebookapp.py:1031
+#: notebook/notebookapp.py:1154
 msgid "DEPRECATED use the nbserver_extensions dict instead"
 msgstr ""
 
-#: notebook/notebookapp.py:1036
+#: notebook/notebookapp.py:1159
 msgid "server_extensions is deprecated, use nbserver_extensions"
 msgstr ""
 
-#: notebook/notebookapp.py:1040
+#: notebook/notebookapp.py:1163
 msgid "Dict of Python modules to load as notebook server extensions.Entry values can be used to enable and disable the loading ofthe extensions. The extensions will be loaded in alphabetical order."
 msgstr ""
 
-#: notebook/notebookapp.py:1049
+#: notebook/notebookapp.py:1172
 msgid "Reraise exceptions encountered loading server extensions?"
 msgstr ""
 
-#: notebook/notebookapp.py:1052
+#: notebook/notebookapp.py:1175
 msgid ""
 "(msgs/sec)\n"
 "        Maximum rate at which messages can be sent on iopub before they are\n"
 "        limited."
 msgstr ""
 
-#: notebook/notebookapp.py:1056
+#: notebook/notebookapp.py:1179
 msgid ""
 "(bytes/sec)\n"
 "        Maximum rate at which stream output can be sent on iopub before they are\n"
 "        limited."
 msgstr ""
 
-#: notebook/notebookapp.py:1060
+#: notebook/notebookapp.py:1183
 msgid ""
 "(sec) Time window used to \n"
 "        check the message and data rate limits."
 msgstr ""
 
-#: notebook/notebookapp.py:1071
-#, python-format
-msgid "No such file or directory: %s"
+#: notebook/notebookapp.py:1197
+msgid ""
+"Set to False to disable terminals.\n"
+"\n"
+"         This does *not* make the notebook server more secure by itself.\n"
+"         Anything the user can in a terminal, they can also do in a notebook.\n"
+"\n"
+"         Terminals may also be automatically disabled if the terminado package\n"
+"         is not available.\n"
+"         "
 msgstr ""
 
-#: notebook/notebookapp.py:1141
+#: notebook/notebookapp.py:1214
+msgid "No such file or directory: {file_path}"
+msgstr ""
+
+#: notebook/notebookapp.py:1284
 msgid "Notebook servers are configured to only be run with a password."
 msgstr ""
 
-#: notebook/notebookapp.py:1142
+#: notebook/notebookapp.py:1285
 msgid "Hint: run the following command to set a password"
 msgstr ""
 
-#: notebook/notebookapp.py:1143
+#: notebook/notebookapp.py:1286
 msgid "\t$ python -m notebook.auth password"
 msgstr ""
 
-#: notebook/notebookapp.py:1181
-#, python-format
-msgid "The port %i is already in use, trying another port."
+#: notebook/notebookapp.py:1324
+msgid "The port {port} is already in use, trying another port."
 msgstr ""
 
-#: notebook/notebookapp.py:1184
-#, python-format
-msgid "Permission to listen on port %i denied"
+#: notebook/notebookapp.py:1327
+msgid "Permission to listen on port {port} denied"
 msgstr ""
 
-#: notebook/notebookapp.py:1193
+#: notebook/notebookapp.py:1336
 msgid "ERROR: the notebook server could not be started because no available port could be found."
 msgstr ""
 
-#: notebook/notebookapp.py:1199
-msgid "[all ip addresses on your system]"
+#: notebook/notebookapp.py:1372
+msgid "Terminals not available (error was {error})"
 msgstr ""
 
-#: notebook/notebookapp.py:1223
-#, python-format
-msgid "Terminals not available (error was %s)"
-msgstr ""
-
-#: notebook/notebookapp.py:1259
+#: notebook/notebookapp.py:1407
 msgid "interrupted"
 msgstr ""
 
-#: notebook/notebookapp.py:1261
+#: notebook/notebookapp.py:1409
 msgid "y"
 msgstr ""
 
-#: notebook/notebookapp.py:1262
+#: notebook/notebookapp.py:1410
 msgid "n"
 msgstr ""
 
-#: notebook/notebookapp.py:1263
+#: notebook/notebookapp.py:1411
 #, python-format
 msgid "Shutdown this notebook server (%s/[%s])? "
 msgstr ""
 
-#: notebook/notebookapp.py:1269
+#: notebook/notebookapp.py:1417
 msgid "Shutdown confirmed"
 msgstr ""
 
-#: notebook/notebookapp.py:1273
+#: notebook/notebookapp.py:1423
 msgid "No answer for 5s:"
 msgstr ""
 
-#: notebook/notebookapp.py:1274
+#: notebook/notebookapp.py:1424
 msgid "resuming operation..."
 msgstr ""
 
-#: notebook/notebookapp.py:1282
-#, python-format
-msgid "received signal %s, stopping"
+#: notebook/notebookapp.py:1432
+msgid "received signal {unix_signal}, stopping"
 msgstr ""
 
-#: notebook/notebookapp.py:1338
-#, python-format
-msgid "Error loading server extension %s"
+#: notebook/notebookapp.py:1488
+msgid "Error loading server extension {module_name}"
 msgstr ""
 
-#: notebook/notebookapp.py:1369
+#: notebook/notebookapp.py:1551
 #, python-format
-msgid "Shutting down %d kernels"
-msgstr ""
+msgid "Shutting down %d kernel"
+msgid_plural "Shutting down %d kernels"
+msgstr[0] ""
+msgstr[1] ""
 
-#: notebook/notebookapp.py:1375
+#: notebook/notebookapp.py:1559
 #, python-format
 msgid "%d active kernel"
 msgid_plural "%d active kernels"
 msgstr[0] ""
 msgstr[1] ""
 
-#: notebook/notebookapp.py:1379
+#: notebook/notebookapp.py:1563
 #, python-format
 msgid ""
 "The Jupyter Notebook is running at:\n"
-"\r"
 "%s"
 msgstr ""
 
-#: notebook/notebookapp.py:1426
+#: notebook/notebookapp.py:1585
+#, python-format
+msgid "Failed to write server-info to %s: %s"
+msgstr ""
+
+#: notebook/notebookapp.py:1614
 msgid "Running as root is not recommended. Use --allow-root to bypass."
 msgstr ""
 
-#: notebook/notebookapp.py:1432
+#: notebook/notebookapp.py:1620
 msgid "Use Control-C to stop this server and shut down all kernels (twice to skip confirmation)."
 msgstr ""
 
-#: notebook/notebookapp.py:1434
-msgid "Welcome to Project Jupyter! Explore the various tools available and their corresponding documentation. If you are interested in contributing to the platform, please visit the communityresources section at http://jupyter.org/community.html."
+#: notebook/notebookapp.py:1622
+msgid "Welcome to Project Jupyter! Explore the various tools available and their corresponding documentation. If you are interested in contributing to the platform, please visit the communityresources section at https://jupyter.org/community.html."
 msgstr ""
 
-#: notebook/notebookapp.py:1445
+#: notebook/notebookapp.py:1633
 #, python-format
 msgid "No web browser found: %s."
 msgstr ""
 
-#: notebook/notebookapp.py:1450
+#: notebook/notebookapp.py:1638
 #, python-format
 msgid "%s does not exist"
 msgstr ""
 
-#: notebook/notebookapp.py:1484
+#: notebook/notebookapp.py:1672
 msgid "Interrupted..."
 msgstr ""
 
-#: notebook/services/contents/filemanager.py:506
+#: notebook/services/contents/filemanager.py:559
 #, python-format
 msgid "Serving notebooks from local directory: %s"
 msgstr ""
 
-#: notebook/services/contents/manager.py:68
+#: notebook/services/contents/manager.py:74
 msgid "Untitled"
 msgstr ""
 

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -384,7 +384,7 @@ class NotebookPasswordApp(JupyterApp):
     def start(self):
         from .auth.security import set_password
         set_password(config_file=self.config_file)
-        self.log.info("Wrote hashed password to {path}", path=self.config_file)
+        self.log.info("Wrote hashed password to {path}", extra={'path':self.config_file})
 
 def shutdown_server(server_info, timeout=5, log=None):
     """Shutdown a notebook server in a separate process.
@@ -653,7 +653,7 @@ class NotebookApp(JupyterApp):
         try:
             s.bind(('localhost', 0))
         except socket.error as e:
-            self.log.warning(_("Cannot bind to localhost, using 127.0.0.1 as default ip\nerror"), error=e)
+            self.log.warning(_("Cannot bind to localhost, using 127.0.0.1 as default ip\nerror"), extra={'error':e})
             return '127.0.0.1'
         else:
             s.close()
@@ -718,19 +718,19 @@ class NotebookApp(JupyterApp):
 
     def _write_cookie_secret_file(self, secret):
         """write my secret to my secret_file"""
-        self.log.info(_("Writing notebook server cookie secret to {file_path}"), file_path=self.cookie_secret_file)
+        self.log.info(_("Writing notebook server cookie secret to {file_path}"), extra={'file_path':self.cookie_secret_file})
         try:
             with io.open(self.cookie_secret_file, 'wb') as f:
                 f.write(secret)
         except OSError as e:
             self.log.error(_("Failed to write cookie secret to {file_path}: {error}"),
-                           file_path=self.cookie_secret_file, error=e)
+                           extra={'file_path':self.cookie_secret_file,' error':e})
         try:
             os.chmod(self.cookie_secret_file, 0o600)
         except OSError:
             self.log.warning(
                 _("Could not set permissions on {file_path}"),
-                file_path=self.cookie_secret_file
+                extra={ 'file_path':self.cookie_secret_file}
             )
 
     token = Unicode('<generated>',
@@ -1015,7 +1015,7 @@ class NotebookApp(JupyterApp):
             # enable_mathjax=False overrides mathjax_url
             self.mathjax_url = u''
         else:
-            self.log.info(_("Using MathJax: {url}"), url=new)
+            self.log.info(_("Using MathJax: {url}"), extra={'url':new})
 
     mathjax_config = Unicode("TeX-AMS-MML_HTMLorMML-full,Safe", config=True,
         help=_("""The MathJax.js configuration file that is to be used.""")
@@ -1023,7 +1023,7 @@ class NotebookApp(JupyterApp):
 
     @observe('mathjax_config')
     def _update_mathjax_config(self, change):
-        self.log.info(_("Using MathJax configuration file: {file_path}"), file_path=change['new'])
+        self.log.info(_("Using MathJax configuration file: {file_path}"), extra={'file_path':change['new']})
         
     quit_button = Bool(True, config=True,
         help="""If True, display a button in the dashboard to quit
@@ -1211,7 +1211,7 @@ class NotebookApp(JupyterApp):
             f = os.path.abspath(arg0)
             self.argv.remove(arg0)
             if not os.path.exists(f):
-                self.log.critical(_("No such file or directory: {file_path}"), file_path=f)
+                self.log.critical(_("No such file or directory: {file_path}"), extra={'file_path':f})
                 self.exit(1)
             
             # Use config here, to ensure that it takes higher priority than
@@ -1321,10 +1321,10 @@ class NotebookApp(JupyterApp):
                 self.http_server.listen(port, self.ip)
             except socket.error as e:
                 if e.errno == errno.EADDRINUSE:
-                    self.log.info(_('The port {port} is already in use, trying another port.'), port=port)
+                    self.log.info(_('The port {port} is already in use, trying another port.'), extra={'port':port})
                     continue
                 elif e.errno in (errno.EACCES, getattr(errno, 'WSAEACCES', errno.EACCES)):
-                    self.log.warning(_("Permission to listen on port {port} denied"), port=port)
+                    self.log.warning(_("Permission to listen on port {port} denied"), extra={'port':port})
                     continue
                 else:
                     raise
@@ -1369,7 +1369,7 @@ class NotebookApp(JupyterApp):
             initialize(self.web_app, self.notebook_dir, self.connection_url, self.terminado_settings)
             self.web_app.settings['terminals_available'] = True
         except ImportError as e:
-            self.log.warning(_("Terminals not available (error was {error})"), error=e)
+            self.log.warning(_("Terminals not available (error was {error})"), extra={'error':e})
 
     def init_signal(self):
         if not sys.platform.startswith('win') and sys.stdin and sys.stdin.isatty():
@@ -1429,7 +1429,7 @@ class NotebookApp(JupyterApp):
         self.io_loop.add_callback_from_signal(self._restore_sigint_handler)
     
     def _signal_stop(self, sig, frame):
-        self.log.critical(_("received signal {unix_signal}, stopping"), unix_signal=sig)
+        self.log.critical(_("received signal {unix_signal}, stopping"), extra={'unix_signal':sig})
         self.io_loop.add_callback_from_signal(self.io_loop.stop)
 
     def _signal_info(self, sig, frame):
@@ -1485,7 +1485,7 @@ class NotebookApp(JupyterApp):
                 except Exception:
                     if self.reraise_server_extension_failures:
                         raise
-                    self.log.warning(_("Error loading server extension {module_name}"), module_name=modulename,
+                    self.log.warning(_("Error loading server extension {module_name}"), extra={'module_name':modulename},
                                   exc_info=True)
 
     def init_mime_overrides(self):
@@ -1513,16 +1513,16 @@ class NotebookApp(JupyterApp):
         seconds_since_active = \
             (utcnow() - self.web_app.last_activity()).total_seconds()
         self.log.debug("No activity for {duration_seconds} seconds.",
-                       duration_seconds=seconds_since_active)
+                       extra={'duration_seconds':seconds_since_active})
         if seconds_since_active > self.shutdown_no_activity_timeout:
             self.log.info("No kernels or terminals for {duration_seconds} seconds; shutting down.",
-                          duration_seconds=seconds_since_active)
+                          extra={'duration_seconds':seconds_since_active})
             self.stop()
 
     def init_shutdown_no_activity(self):
         if self.shutdown_no_activity_timeout > 0:
             self.log.info("Will shut down after {duration_seconds} seconds with no kernels or terminals.",
-                          duration_seconds=self.shutdown_no_activity_timeout)
+                          extra={'duration_seconds':self.shutdown_no_activity_timeout})
             pc = ioloop.PeriodicCallback(self.shutdown_no_activity, 60000)
             pc.start()
 


### PR DESCRIPTION
This is an attempt at modifying the log calls in order to prepare for
Structured logging. Structured logging should push us to not format the
string at log time but to actually be able to send logs for example as
JSON.

This is necessary – or at least highly useful – in the contex of
GDPR/Hippa... etc where logs can contain sensitive informations and
should be treated adequately (that is to say anonymisation,
pseudonymisation, encrypted storage with acces control... etc).

It is hard to do with unstructured logging.

By forcing the logs to be structured, with `{name}` formatting and
passing explicit keywords, this will allow a potential structured logger
to be further process and be triggered on specific key names.

Consistency in key names is critical to know what is "sensitive".
Example of sensitive info are user-id, user-name, can be contained in
url, and filepath, and may be sensitive. Error in general can contain
snippets of code, so even more.

That will affect translation, as right now it seem to heavily use %x
syntax that should be avoided to match specific keys.

-- 

cc @yuvipanda thoughts ?
