### PR TITLE
Add a output_updated.OutputArea event

### DIFF
--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -631,6 +631,10 @@ define([
             (json.data[MIME_MARKDOWN] !== undefined)) {
             this.typeset();
         }
+        this.events.trigger('output_updated.OutputArea', {
+            output: json,
+            output_area: this,
+        });
     };
 
     OutputArea.prototype._record_display_id = function (json, element) {


### PR DESCRIPTION
As outlined in https://github.com/jupyter/notebook/issues/3557 this PR adds a ``output_updated.OutputArea`` event, triggered by ``update_display_data`` messages, to match the existing ``output_added.OutputArea`` event which is triggered when ``execute_result`` and ``display_data`` messages are received. Like the ``output_added`` event this allows registering callbacks which are given the entire mime bundle and the OutputArea, matching the capability of JupyterLab MIME renderers which are also given the entire mime bundle when ``update_display_data`` messages are received.

Let me know if there is some place to document this new event and/or add some kind of test for it (couldn't find either in a cursory search). As an aside, very happy about my first ever contribution to the notebook.