### PR TITLE
"Require" pyzmq>=17

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,9 @@ for more information.
     install_requires = [
         'jinja2',
         'tornado>=4',
+        # pyzmq>=17 is not technically necessary,
+        # but hopefully avoids incompatibilities with Tornado 5. April 2018
+        'pyzmq>=17',
         'ipython_genutils',
         'traitlets>=4.2.1',
         'jupyter_core>=4.4.0',


### PR DESCRIPTION
Not really a requirement, but explaining about the pyzmq/tornado incompatibility gets old fast.

Closes gh-3579