### PR TITLE
Fix for reload button no longer works Issue

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -2761,6 +2761,8 @@ define([
                         if (that._changed_on_disk_dialog !== null) {
                             // update save callback on the confirmation button
                             that._changed_on_disk_dialog.find('.save-confirm-btn').click(_save);
+                            //Rebind Click Event on Reload
+                            that._changed_on_disk_dialog.find('.btn-warning').click(function () {window.location.reload()});
                             // redisplay existing dialog
                             that._changed_on_disk_dialog.modal('show');
                         } else {


### PR DESCRIPTION
Fix for the issue "Issue #2793:After closing the overwrite modal, reload button no longer works".
This PR fixes the above mentioned issue.
