### PR TITLE
stat symlink to determine access

### DIFF
--- a/notebook/utils.py
+++ b/notebook/utils.py
@@ -140,7 +140,7 @@ def is_file_hidden_posix(abs_path, stat_res=None):
     if os.path.basename(abs_path).startswith('.'):
         return True
 
-    if stat_res is None:
+    if stat_res is None or stat.S_ISLNK(stat_res.st_mode):
         try:
             stat_res = os.stat(abs_path)
         except OSError as e:


### PR DESCRIPTION
A symlink pointing to a directory where you have no access permissions will result in a 404 for the entire directory containing the symlink.
This could also be fixed in FileContentsManager._dir_model() but I don't know what the implications on  Windows would be.