### PR TITLE
Add remote installation guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Launch with:
 
     $ jupyter notebook
 
+### Running in a remote installation
+
+You need some configuration before starting Jupyter notebook remotely. See [Running a notebook server](http://jupyter-notebook.readthedocs.io/en/stable/public_server.html).
+
 ## Development Installation
 
 See [`CONTRIBUTING.rst`](CONTRIBUTING.rst) for how to set up a local development installation.


### PR DESCRIPTION
I have installed and launched with reference to README.md, and then have accessed Jupyter notebook remotely. But, since a default URL starts with http://localhost or http://127.0.0.1, I could not access there. And I had a hard time finding the document for remote access.
So, I'd like to add URL of the document for it. It is kind information for beginners.