### PR TITLE
Update to jQuery 3.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "font-awesome": "components/font-awesome#~4.7.0",
     "google-caja": "5669",
     "jed": "~1.1.1",
-    "jquery": "components/jquery#~2.2",
+    "jquery": "components/jquery#~3.3",
     "jquery-typeahead": "~2.0.0",
     "jquery-ui": "components/jqueryui#~1.10",
     "marked": "~0.3",


### PR DESCRIPTION
The 2.x branch we were using is no longer updated, so we should try to move to a newer version.

I've test-driven this briefly to make sure that it's not completely broken, but if there are compatibility issues with extensions or Javascript output that uses jQuery, we won't find out until we get people using it.