### PR TITLE
properly handle unicode characters in home dirs

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -212,7 +212,7 @@ class NotebookWebApplication(web.Application):
         now = utcnow()
         
         root_dir = contents_manager.root_dir
-        home = os.path.expanduser('~')
+        home = py3compat.str_to_unicode(os.path.expanduser('~'), encoding=sys.getfilesystemencoding()) 
         if root_dir.startswith(home + os.path.sep):
             # collapse $HOME to ~
             root_dir = '~' + root_dir[len(home):]


### PR DESCRIPTION
Jupyter fails to start when the user has Unicode characters in his homedir. This fixes that. See https://github.com/sagemath/sage-windows/issues/10#issuecomment-392137049 and https://github.com/jupyter/jupyter_core/pull/131