### PR TITLE
add kernel_info_timeout traitlet for slow kernel start/restart

### DIFF
--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -104,7 +104,8 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
 
     @property
     def kernel_info_timeout(self):
-        return self.settings.get('kernel_info_timeout', 10)
+        km_default = self.kernel_manager.kernel_info_timeout
+        return self.settings.get('kernel_info_timeout', km_default)
 
     @property
     def iopub_msg_rate_limit(self):


### PR DESCRIPTION
This allows you to configure how long the notebook waits for a kernel give its `kernel_info_reply`. 

I looked into adding a test, but I think that this would require a good bit of machinery to test properly. I can do that if we want to, but it looks like we're not testing the functionality of most other traitlets directly.

Note: this is not kernel specific… but I don't think we have any way to do kernel specific configuration for the handler as of today.