### PR TITLE
Don't trash non-empty directories on Windows

### DIFF
--- a/notebook/services/contents/tests/test_contents_api.py
+++ b/notebook/services/contents/tests/test_contents_api.py
@@ -7,6 +7,7 @@ import io
 import json
 import os
 import shutil
+import sys
 from unicodedata import normalize
 
 pjoin = os.path.join
@@ -523,6 +524,8 @@ class APITest(NotebookTestBase):
         self.assertEqual(listing, [])
 
     def test_delete_non_empty_dir(self):
+        if sys.platform == 'win32':
+            self.skipTest("Disabled deleting non-empty dirs on Windows")
         # Test that non empty directory can be deleted
         self.api.delete(u'å b')
         # Check if directory has actually been deleted


### PR DESCRIPTION
It appears that the Windows backend of send2trash can't guarantee that files won't actually be deleted. There are some hints that this happens in particular when you delete a lot of data at once. So this returns to refusing to delete folders unless they're empty (or contain only ipynb checkpoints).

Closes gh-3631