### PR TITLE
Logging updates

### DIFF
--- a/notebook/log.py
+++ b/notebook/log.py
@@ -14,6 +14,9 @@ except ImportError:
     from urllib import urlparse, urlunparse
 
 from tornado.log import access_log
+from tornado.web import StaticFileHandler
+
+
 # url params to be scrubbed if seen
 # any url param that *contains* one of these
 # will be scrubbed from logs
@@ -62,8 +65,12 @@ def log_request(handler):
     """
     status = handler.get_status()
     request = handler.request
-    if status < 300 or status == 304:
-        # Successes (or 304 FOUND) are debug-level
+
+    if (
+        isinstance(handler, StaticFileHandler)
+        and (status < 300 or status == 304)
+    ):
+        # Successes (or 304 FOUND) on static files are debug-level
         log_method = access_log.debug
     elif status < 400:
         log_method = access_log.info

--- a/notebook/log.py
+++ b/notebook/log.py
@@ -6,11 +6,55 @@
 #-----------------------------------------------------------------------------
 
 import json
+
+try:
+    from urllib.parse import urlparse, urlunparse
+except ImportError:
+    # py2
+    from urllib import urlparse, urlunparse
+
 from tornado.log import access_log
+# url params to be scrubbed if seen
+# any url param that *contains* one of these
+# will be scrubbed from logs
+SCRUB_PARAM_KEYS = ('token', 'auth', 'key', 'code', 'state')
+
+
+def _scrub_uri(uri):
+    """scrub auth info from uri"""
+    parsed = urlparse(uri)
+    if parsed.query:
+        # check for potentially sensitive url params
+        # use manual list + split rather than parsing
+        # to minimally perturb original
+        parts = parsed.query.split('&')
+        changed = False
+        for i, s in enumerate(parts):
+            if '=' in s:
+                key, value = s.split('=', 1)
+                for substring in SCRUB_PARAM_KEYS:
+                    if substring in key:
+                        parts[i] = key + '=[secret]'
+                        changed = True
+        if changed:
+            parsed = parsed._replace(query='&'.join(parts))
+            return urlunparse(parsed)
+    return uri
+
+
+def _scrub_headers(headers):
+    """scrub auth info from headers"""
+    headers = dict(headers)
+    if 'Authorization' in headers:
+        auth = headers['Authorization']
+        if auth.startswith('token '):
+            headers['Authorization'] = 'token [secret]'
+    return headers
+
 
 def log_request(handler):
     """log a bit more information about each request than tornado's default
-    
+
     - move static file get success to debug-level (reduces noise)
     - get proxied IP instead of proxy IP
     - log referer for redirect and failed requests
@@ -27,22 +71,21 @@ def log_request(handler):
         log_method = access_log.warning
     else:
         log_method = access_log.error
-    
+
     request_time = 1000.0 * handler.request.request_time()
     ns = dict(
         status=status,
         method=request.method,
         ip=request.remote_ip,
-        uri=request.uri,
+        uri=_scrub_uri(request.uri),
         request_time=request_time,
     )
     msg = "{status} {method} {uri} ({ip}) {request_time:.2f}ms"
     if status >= 400:
         # log bad referers
-        ns['referer'] = request.headers.get('Referer', 'None')
+        ns['referer'] = _scrub_uri(request.headers.get('Referer', 'None'))
         msg = msg + ' referer={referer}'
     if status >= 500 and status != 502:
         # log all headers if it caused an error
-        log_method(json.dumps(dict(request.headers), indent=2))
+        log_method(json.dumps(_scrub_headers(request.headers), indent=2))
     log_method(msg.format(**ns))
-


### PR DESCRIPTION
- log non-static-file successes at INFO-level (page views, API requests)
- scrub sensitive fields in url params, headers

Alternatives to increased logging that would result in slightly less log output:

- only include simple successes of API requests
- only include simple successes of non-GET methods (biggest reduction)

closes #3564