### PR TITLE
Add "test" npm script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ config.rst
 /.project
 /.pydevproject
 
+package-lock.json
+

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "bower": "bower install",
     "build": "python setup.py js css",
-    "build:watch": "set -e; while true; do npm run build; sleep 3; done"
+    "build:watch": "set -e; while true; do npm run build; sleep 3; done",
+    "test": "python -m notebook.jstest"
   },
   "devDependencies": {
     "bower": "*",


### PR DESCRIPTION
This adds a "test" npm script that will allow us to run JS scripts with a:

```bash
# Run all tests
npm run test

# Run markdown test
npm run test -- markdown
```