### PR TITLE
Fixed possible XSS detected by Fortify webscan

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -28,6 +28,7 @@ except ImportError:
 from jinja2 import TemplateNotFound
 from tornado import web, gen, escape, httputil
 from tornado.log import app_log
+from tornado.escape import xhtml_escape
 
 from notebook._sysinfo import get_sys_info
 
@@ -522,6 +523,7 @@ class APIHandler(IPythonHandler):
                 reply['message'] = 'Unhandled error'
                 reply['reason'] = None
                 reply['traceback'] = ''.join(traceback.format_exception(*exc_info))
+        reply['message'] = xhtml_escape(reply['message'])
         self.log.warning(reply['message'])
         self.finish(json.dumps(reply))
 


### PR DESCRIPTION
Hi,

request to API endpoint returned non-escaped string:

**Request:** 
```
http://192.168.0.10:8888/api/contents/Untitled%20Folder/<iMg%20SrC%3dvBsCrIpT%3aMsgBox%2878146%29>
```

**Response:**
```
{"message": "No such file or directory: Untitled Folder/<iMg%20SrC%3dvBsCrIpT%3aMsgBox%2878146%29>", "reason": null
```

**Expected Response:**
```
{"message": "No such file or directory: Untitled Folder/&lt;iMg SrC=vBsCrIpT:MsgBox(78146)&gt;", "reason": null}
```