### PR TITLE
add `or 127.0.0.1` when listening on all-ips

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1358,7 +1358,7 @@ class NotebookApp(JupyterApp):
                 url += '/'
         else:
             if self.ip in ('', '0.0.0.0'):
-                ip = socket.gethostname()
+                ip = "(%s or 127.0.0.1)" % socket.gethostname()
             else:
                 ip = self.ip
             url = self._url(ip)


### PR DESCRIPTION
Effectively reverts #3356 due to issues like #3605. Makes it not a copyable URL anymore, but there’s simply no way for a copyable host to work in general in this case. For folks who want a copyable URL, they can now set display_url via #3668.