### PR TITLE
fix:can't choose same file twice when in upload file

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -338,11 +338,11 @@ define([
                 reader.onerror = reader_onerror;
             }
         });
-        // Replace the file input form wth a clone of itself. This is required to
+        // Clear fileinput value. This is required to
         // reset the form. Otherwise, if you upload a file, delete it and try to
         // upload it again, the changed event won't fire.
         var form = $('input.fileinput');
-        form.replaceWith(form.clone(true));
+        form.val('');
         return false;
     };
 


### PR DESCRIPTION
Clear fileinput value. This is required to reset the form. Otherwise, if you upload a file, delete it and try to upload it again, the changed event won't fire.
the old, replacing fileinput did not work as expected