### PR TITLE
Check 'Host' header for local connections

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -436,8 +436,12 @@ class IPythonHandler(AuthenticatedHandler):
             allow = addr.is_loopback
 
         if not allow:
-            self.log.warning("Blocking request with non-local 'Host' %s (%s)",
-                             host, self.request.host)
+            self.log.warning(
+                ("Blocking request with non-local 'Host' %s (%s). "
+                 "If the notebook should be accessible at that name, "
+                 "set NotebookApp.allow_remote_access to disable the check."),
+                host, self.request.host
+            )
         return allow
 
     def prepare(self):

--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -5,6 +5,7 @@
 
 import datetime
 import functools
+import ipaddress
 import json
 import mimetypes
 import os
@@ -410,6 +411,39 @@ class IPythonHandler(AuthenticatedHandler):
             # Servers without authentication are vulnerable to XSRF
             return
         return super(IPythonHandler, self).check_xsrf_cookie()
+
+    def check_host(self):
+        """Check the host header if remote access disallowed.
+
+        Returns True if the request should continue, False otherwise.
+        """
+        if self.settings.get('allow_remote_access', False):
+            return True
+
+        # Remove port (e.g. ':8888') from host
+        host = re.match(r'^(.*?)(:\d+)?$', self.request.host).group(1)
+
+        # Browsers format IPv6 addresses like [::1]; we need to remove the []
+        if host.startswith('[') and host.endswith(']'):
+            host = host[1:-1]
+
+        try:
+            addr = ipaddress.ip_address(host)
+        except ValueError:
+            # Not an IP address: check against hostnames
+            allow = host in self.settings.get('local_hostnames', [])
+        else:
+            allow = addr.is_loopback
+
+        if not allow:
+            self.log.warning("Blocking request with non-local 'Host' %s (%s)",
+                             host, self.request.host)
+        return allow
+
+    def prepare(self):
+        if not self.check_host():
+            raise web.HTTPError(403)
+        return super(IPythonHandler, self).prepare()
 
     #---------------------------------------------------------------
     # template rendering

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -856,7 +856,7 @@ class NotebookApp(JupyterApp):
             addr = ipaddress.ip_address(self.ip)
         except ValueError:
             # Address is a hostname
-            for info in socket.getaddrinfo(self.ip, self.port, type=socket.SOCK_STREAM):
+            for info in socket.getaddrinfo(self.ip, self.port, 0, socket.SOCK_STREAM):
                 addr = ipaddress.ip_address(info[4][0])
                 if not addr.is_loopback:
                     return True

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -252,6 +252,8 @@ class NotebookWebApplication(web.Application):
             password=jupyter_app.password,
             xsrf_cookies=True,
             disable_check_xsrf=jupyter_app.disable_check_xsrf,
+            allow_remote_access=jupyter_app.allow_remote_access,
+            local_hostnames=jupyter_app.local_hostnames,
 
             # managers
             kernel_manager=kernel_manager,
@@ -829,6 +831,29 @@ class NotebookApp(JupyterApp):
         These services can disable all authentication and security checks,
         with the full knowledge of what that implies.
         """
+    )
+
+    allow_remote_access = Bool(False, config=True,
+       help="""Allow requests where the Host header doesn't point to a local server
+
+       By default, requests get a 403 forbidden response if the 'Host' header
+       shows that the browser thinks it's on a non-local domain.
+       Setting this option to True disables this check.
+
+       This protects against 'DNS rebinding' attacks, where a remote web server
+       serves you a page and then changes its DNS to send later requests to a
+       local IP, bypassing same-origin checks.
+
+       Local IP addresses (such as 127.0.0.1 and ::1) are allowed as local,
+       along with hostnames configured in local_hostnames.
+       """)
+
+    local_hostnames = List(Unicode(), ['localhost'], config=True,
+       help="""Hostnames to allow as local when allow_remote_access is False.
+
+       Local IP addresses (such as 127.0.0.1 and ::1) are automatically accepted
+       as local as well.
+       """
     )
 
     open_browser = Bool(True, config=True,

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -857,8 +857,10 @@ class NotebookApp(JupyterApp):
         except ValueError:
             # Address is a hostname
             for info in socket.getaddrinfo(self.ip, self.port, 0, socket.SOCK_STREAM):
-                addr = ipaddress.ip_address(info[4][0])
-                if not addr.is_loopback:
+                addr = info[4][0]
+                if not py3compat.PY3:
+                    addr = addr.decode('ascii')
+                if not ipaddress.ip_address(addr).is_loopback:
                     return True
             return False
         else:

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ for more information.
         'prometheus_client'
     ],
     extras_require = {
+        ':python_version == "2.7"': ['ipaddress'],
         'test:python_version == "2.7"': ['mock'],
         'test': ['nose', 'coverage', 'requests', 'nose_warnings_filters',
                  'nbval', 'nose-exclude'],


### PR DESCRIPTION
cc @minrk @rgbkrk 

I was reading [another article about DNS rebinding](https://medium.com/@brannondorsey/attacking-private-networks-from-the-internet-with-dns-rebinding-ea7098a2d325), and it reminded me that I meant to add another layer of security to protect against such attacks. The default options in this PR will reject any request where the `Host` header isn't `localhost` or a loopback IP address.

To be clear, I believe that our on-by-default token authentication already protects against DNS rebinding attacks. I want to add an extra layer of protection in case there are flaws in our existing security, or in case people disable token authentication without understanding the implications.

This is probably too stringent to drop on people directly - it would break all servers where remote access is meant to be possible, and require people to update their settings. Possible ways to soften it:

- Disable the check if `NotebookApp.ip` is configured to anything other than `localhost`. Could make it easy to switch off security accidentally, e.g. if you configure `localhost6` to experiment with IPv6.
- Disable the check if we're telling the server to listen on any non-loopback interface - assume people who configure this are using some external security measures. Can we reliably know whether the server is listening on a public IP?
- Disable the check by default and let people enable it if they want. I'd rather not do this, because approximately no-one will enable it. But it could be used as a transition period.