### PR TITLE
Wait for 'New' dropdown button to be clickable for Selenium tests

### DIFF
--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -61,7 +61,7 @@ data-server-root="{{server_root}}"
                   </span>
                 </form>
                 <div id="new-buttons" class="btn-group">
-                  <button class="dropdown-toggle btn btn-default btn-xs" data-toggle="dropdown">
+                  <button class="dropdown-toggle btn btn-default btn-xs" id="new-dropdown-button" data-toggle="dropdown">
                   <span>{% trans %}New{% endtrans %}</span>
                   <span class="caret"></span>
                   </button>

--- a/notebook/tests/selenium/utils.py
+++ b/notebook/tests/selenium/utils.py
@@ -231,7 +231,8 @@ class Notebook:
 def select_kernel(browser, kernel_name='kernel-python3'):
     """Clicks the "new" button and selects a kernel from the options.
     """
-    new_button = wait_for_selector(browser, "#new-buttons", single=True)
+    wait = WebDriverWait(browser, 10)
+    new_button = wait.until(EC.element_to_be_clickable((By.ID, "new-dropdown-button")))
     new_button.click()
     kernel_selector = '#{} a'.format(kernel_name)
     kernel = wait_for_selector(browser, kernel_selector, single=True)


### PR DESCRIPTION
Selenium tests have been failing intermittently with an `ElementNotInteractableException` on the line `new_button.click()`. Restarting the test usually makes it work.

This PR waits for the button to be clickable, rather than just present in the DOM. Hopefully that will prevent the error.