### PR TITLE
Disable the host check for 5.6 because of gh-3754

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -34,6 +34,7 @@ New features:
   checking the ``Host`` header from the browser (:ghpull:`3714`).
   This check can be disabled if necessary by setting
   ``NotebookApp.allow_remote_access``.
+  (Disabled by default while we work out some Mac issues in :ghissue:`3754`).
 - Add kernel_info_timeout traitlet to enable restarting slow kernels (:ghpull:`3665`)
 - Add ``custom_display_host`` config option to override displayed URL (:ghpull:`3668`)
 - Add /metrics endpoint for Prometheus Metrics (:ghpull:`3490`)

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -852,6 +852,10 @@ class NotebookApp(JupyterApp):
     @default('allow_remote_access')
     def _default_allow_remote(self):
         """Disallow remote access if we're listening only on loopback addresses"""
+        # Disable the check temporarily because of Mac issues:
+        # https://github.com/jupyter/notebook/issues/3754
+        return True
+
         try:
             addr = ipaddress.ip_address(self.ip)
         except ValueError:


### PR DESCRIPTION
I intend to re-enable this again straight after the release, but for now we want to get 5.6 out without breaking things for lots of Mac users.