### PR TITLE
Re-enable Host header check after 5.6

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -852,10 +852,6 @@ class NotebookApp(JupyterApp):
     @default('allow_remote_access')
     def _default_allow_remote(self):
         """Disallow remote access if we're listening only on loopback addresses"""
-        # Disable the check temporarily because of Mac issues:
-        # https://github.com/jupyter/notebook/issues/3754
-        return True
-
         try:
             addr = ipaddress.ip_address(self.ip)
         except ValueError:


### PR DESCRIPTION
We need to figure out the Mac issues in #3754, but I want to ensure this doesn't linger indefinitely.