### PR TITLE
adding selenium to test requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ for more information.
         ':python_version == "2.7"': ['ipaddress'],
         'test:python_version == "2.7"': ['mock'],
         'test': ['nose', 'coverage', 'requests', 'nose_warnings_filters',
-                 'nbval', 'nose-exclude'],
+                 'nbval', 'nose-exclude', 'selenium'],
         'test:sys_platform == "win32"': ['nose-exclude'],
     },
     entry_points = {


### PR DESCRIPTION
I noticed when I tried to run the tests for the notebook that selenium wasn't in the requirements for the test environment, so I got a selenium error.  I added selenium to the test list in the extras_require dict. 