### PR TITLE
[FIX] notebookapp, auth: `get_secure_cookie` kwargs

### DIFF
--- a/notebook/auth/login.py
+++ b/notebook/auth/login.py
@@ -168,7 +168,8 @@ class LoginHandler(IPythonHandler):
             return handler._user_id
         user_id = cls.get_user_token(handler)
         if user_id is None:
-            user_id = handler.get_secure_cookie(handler.cookie_name)
+            get_secure_cookie_kwargs  = handler.settings.get('get_secure_cookie_kwargs', {})
+            user_id = handler.get_secure_cookie(handler.cookie_name, **get_secure_cookie_kwargs )
         else:
             cls.set_login_cookie(handler, user_id)
             # Record that the current request has been authenticated with a token.

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -945,6 +945,10 @@ class NotebookApp(JupyterApp):
         help=_("Extra keyword arguments to pass to `set_secure_cookie`."
              " See tornado's set_secure_cookie docs for details.")
     )
+    get_secure_cookie_kwargs = Dict(config=True,
+        help=_("Extra keyword arguments to pass to `get_secure_cookie`."
+             " See tornado's get_secure_cookie docs for details.")
+    )
     ssl_options = Dict(config=True,
             help=_("""Supply SSL options for the tornado HTTPServer.
             See the tornado docs for details."""))
@@ -1338,6 +1342,7 @@ class NotebookApp(JupyterApp):
             self.tornado_settings['allow_origin_pat'] = re.compile(self.allow_origin_pat)
         self.tornado_settings['allow_credentials'] = self.allow_credentials
         self.tornado_settings['cookie_options'] = self.cookie_options
+        self.tornado_settings['get_secure_cookie_kwargs'] = self.get_secure_cookie_kwargs
         self.tornado_settings['token'] = self.token
         if (self.open_browser or self.file_to_run) and not self.password:
             self.one_time_token = binascii.hexlify(os.urandom(24)).decode('ascii')


### PR DESCRIPTION
Per Tornado's documentation:

>By default, Tornado’s secure cookies expire after 30 days.
>To change this, use the expires_days keyword argument to
>set_secure_cookie and the max_age_days argument to get_secure_cookie.
>These two values are passed separately so that you may
>e.g. have a cookie that is valid for 30 days for most purposes,
>but for certain sensitive actions
>(such as changing billing information)
>you use a smaller max_age_days when reading the cookie.

With the current implementation in `auth/login.py`,
this is possible to pass the `expires_days` option
but not possible to enforce it as this is not possible
to pass `max_age_days` to `get_secure_cookie`

This makes impossible to set the cookie expiration without
using a custom `LoginHandler`.

This revision is about adding the possibility to pass options
to Tornado's `get_secure_cookie` method,
so it can be possible to set the cookies expiration,
among others.

In my opinion,  `get_cookie_options` is a weird naming given the options to pass to `set_secure_cookie` are called `cookie_options`. That said, I am not sure what is your policy regarding the retro-compatibility of  the settings, if `cookie_options` can be renamed `set_cookie_options` or not. Anyway we first have to discuss the feasibility of this change. 