### PR TITLE
Fix uneven input prompt width for markdown cells

### DIFF
--- a/notebook/static/notebook/less/codecell.less
+++ b/notebook/static/notebook/less/codecell.less
@@ -46,7 +46,7 @@ div.run_this_cell {
     width: 1ex;
 }
 
-div.code_cell div.input_prompt {
+div.input_prompt {
     min-width: 15ex;
 }
 


### PR DESCRIPTION
Closes https://github.com/jupyter/notebook/issues/3781

![image](https://user-images.githubusercontent.com/512354/42950435-dcaa00a8-8b28-11e8-95f8-54ae557e7202.png)
