### PR TITLE
modify contributing instructions to use pytest for testing

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -136,11 +136,11 @@ Install dependencies::
 
 To run the Python tests, use::
 
-    nosetests
+    pytest
 
 If you want coverage statistics as well, you can run::
 
-    nosetests --with-coverage --cover-package=notebook notebook
+    py.test --cov notebook -v --pyargs notebook
 
 JavaScript Tests
 ^^^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ for more information.
         ':python_version == "2.7"': ['ipaddress'],
         'test:python_version == "2.7"': ['mock'],
         'test': ['nose', 'coverage', 'requests', 'nose_warnings_filters',
-                 'nbval', 'nose-exclude', 'selenium'],
+                 'nbval', 'nose-exclude', 'selenium', 'pytest', 'pytest-cov'],
         'test:sys_platform == "win32"': ['nose-exclude'],
     },
     entry_points = {


### PR DESCRIPTION
At the scipy sprints it was suggested that I use pytest rather than nose to run the jupyter notebook tests. I had been following the contributing documentation that directs using nose. This PR
- modifies the contributing instructions to use pytest when running the notebook tests
- adds pytest and pytest-cov to the the test key in extras_require so that pytest and the coverage package are included in the test dependencies. 