### PR TITLE
Implement password hashing with bcrypt

### DIFF
--- a/notebook/auth/security.py
+++ b/notebook/auth/security.py
@@ -21,7 +21,7 @@ from jupyter_core.paths import jupyter_config_dir
 salt_len = 12
 
 
-def passwd(passphrase=None, algorithm='sha1'):
+def passwd(passphrase=None, algorithm='bcrypt'):
     """Generate hashed password and salt for use in notebook configuration.
 
     In the notebook configuration, set `c.NotebookApp.password` to
@@ -59,11 +59,17 @@ def passwd(passphrase=None, algorithm='sha1'):
         else:
             raise ValueError('No matching passwords found. Giving up.')
 
-    h = hashlib.new(algorithm)
-    salt = ('%0' + str(salt_len) + 'x') % random.getrandbits(4 * salt_len)
-    h.update(cast_bytes(passphrase, 'utf-8') + str_to_bytes(salt, 'ascii'))
+    if algorithm == 'bcrypt':
+        import bcrypt
+        h = bcrypt.hashpw(cast_bytes(passphrase, 'utf-8'), bcrypt.gensalt())
 
-    return ':'.join((algorithm, salt, h.hexdigest()))
+        return ':'.join((algorithm, cast_unicode(h, 'ascii')))
+    else:
+        h = hashlib.new(algorithm)
+        salt = ('%0' + str(salt_len) + 'x') % random.getrandbits(4 * salt_len)
+        h.update(cast_bytes(passphrase, 'utf-8') + str_to_bytes(salt, 'ascii'))
+
+        return ':'.join((algorithm, salt, h.hexdigest()))
 
 
 def passwd_check(hashed_passphrase, passphrase):
@@ -84,30 +90,37 @@ def passwd_check(hashed_passphrase, passphrase):
     Examples
     --------
     >>> from notebook.auth.security import passwd_check
+    >>> passwd_check('bcrypt:...', 'mypassword')
+    True
+
+    >>> passwd_check('bcrypt:...', 'otherpassword')
+    False
+
     >>> passwd_check('sha1:0e112c3ddfce:a68df677475c2b47b6e86d0467eec97ac5f4b85a',
     ...              'mypassword')
     True
-
-    >>> passwd_check('sha1:0e112c3ddfce:a68df677475c2b47b6e86d0467eec97ac5f4b85a',
-    ...              'anotherpassword')
-    False
     """
-    try:
-        algorithm, salt, pw_digest = hashed_passphrase.split(':', 2)
-    except (ValueError, TypeError):
-        return False
+    if hashed_passphrase.startswith('bcrypt:'):
+        import bcrypt
+        return bcrypt.checkpw(cast_bytes(passphrase, 'utf-8'),
+                              cast_bytes(hashed_passphrase[7:], 'ascii'))
+    else:
+        try:
+            algorithm, salt, pw_digest = hashed_passphrase.split(':', 2)
+        except (ValueError, TypeError):
+            return False
 
-    try:
-        h = hashlib.new(algorithm)
-    except ValueError:
-        return False
+        try:
+            h = hashlib.new(algorithm)
+        except ValueError:
+            return False
 
-    if len(pw_digest) == 0:
-        return False
+        if len(pw_digest) == 0:
+            return False
 
-    h.update(cast_bytes(passphrase, 'utf-8') + cast_bytes(salt, 'ascii'))
+        h.update(cast_bytes(passphrase, 'utf-8') + cast_bytes(salt, 'ascii'))
 
-    return h.hexdigest() == pw_digest
+        return h.hexdigest() == pw_digest
 
 @contextmanager
 def persist_config(config_file=None, mode=0o600):

--- a/notebook/auth/tests/test_security.py
+++ b/notebook/auth/tests/test_security.py
@@ -1,12 +1,12 @@
 # coding: utf-8
-from ..security import passwd, passwd_check, salt_len
+from ..security import passwd, passwd_check
 import nose.tools as nt
 
 def test_passwd_structure():
     p = passwd('passphrase')
     algorithm, hashed = p.split(':')
-    nt.assert_equal(algorithm, 'bcrypt')
-    nt.assert_true(hashed.startswith('$2b$'))
+    nt.assert_equal(algorithm, 'argon2')
+    nt.assert_true(hashed.startswith('$argon2id$'))
 
 def test_roundtrip():
     p = passwd('passphrase')
@@ -22,6 +22,6 @@ def test_passwd_check_unicode():
     # GH issue #4524
     phash = u'sha1:23862bc21dd3:7a415a95ae4580582e314072143d9c382c491e4f'
     assert passwd_check(phash, u"łe¶ŧ←↓→")
-    phash = (u'bcrypt:$2b$12$'
-             u'/IwxT/HWZRlDczICrZQVr.Mg0K5eu9Sv817lgf8qUd8goygYs1OlO')
+    phash = (u'argon2:$argon2id$v=19$m=10240,t=10,p=8$'
+             u'qjjDiZUofUVVnrVYxacnbA$l5pQq1bJ8zglGT2uXP6iOg')
     assert passwd_check(phash, u"łe¶ŧ←↓→")

--- a/notebook/auth/tests/test_security.py
+++ b/notebook/auth/tests/test_security.py
@@ -4,10 +4,9 @@ import nose.tools as nt
 
 def test_passwd_structure():
     p = passwd('passphrase')
-    algorithm, salt, hashed = p.split(':')
-    nt.assert_equal(algorithm, 'sha1')
-    nt.assert_equal(len(salt), salt_len)
-    nt.assert_equal(len(hashed), 40)
+    algorithm, hashed = p.split(':')
+    nt.assert_equal(algorithm, 'bcrypt')
+    nt.assert_true(hashed.startswith('$2b$'))
 
 def test_roundtrip():
     p = passwd('passphrase')
@@ -22,4 +21,7 @@ def test_bad():
 def test_passwd_check_unicode():
     # GH issue #4524
     phash = u'sha1:23862bc21dd3:7a415a95ae4580582e314072143d9c382c491e4f'
+    assert passwd_check(phash, u"łe¶ŧ←↓→")
+    phash = (u'bcrypt:$2b$12$'
+             u'/IwxT/HWZRlDczICrZQVr.Mg0K5eu9Sv817lgf8qUd8goygYs1OlO')
     assert passwd_check(phash, u"łe¶ŧ←↓→")

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ for more information.
         # pyzmq>=17 is not technically necessary,
         # but hopefully avoids incompatibilities with Tornado 5. April 2018
         'pyzmq>=17',
-        'bcrypt',
+        'argon2-cffi',
         'ipython_genutils',
         'traitlets>=4.2.1',
         'jupyter_core>=4.6.1',

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ for more information.
         # pyzmq>=17 is not technically necessary,
         # but hopefully avoids incompatibilities with Tornado 5. April 2018
         'pyzmq>=17',
+        'bcrypt',
         'ipython_genutils',
         'traitlets>=4.2.1',
         'jupyter_core>=4.6.1',


### PR DESCRIPTION
Fixes #2426

The `hashlib` hashing method could probably be removed from `passwd()` since nothing ever specifies the `algorithm` argument. Should probably be kept in `passwd_check()` until people update their configs.