### PR TITLE
ip_address only accepts unicode on Python 2

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -35,7 +35,7 @@ from notebook._sysinfo import get_sys_info
 
 from traitlets.config import Application
 from ipython_genutils.path import filefind
-from ipython_genutils.py3compat import string_types
+from ipython_genutils.py3compat import string_types, PY3
 
 import notebook
 from notebook._tz import utcnow
@@ -426,6 +426,10 @@ class IPythonHandler(AuthenticatedHandler):
         # Browsers format IPv6 addresses like [::1]; we need to remove the []
         if host.startswith('[') and host.endswith(']'):
             host = host[1:-1]
+
+        if not PY3:
+            # ip_address only accepts unicode on Python 2
+            host = host.decode('utf8', 'replace')
 
         try:
             addr = ipaddress.ip_address(host)


### PR DESCRIPTION
ipaddress.ip_address('127.0.0.1') fails with ValueError on Python 2

need to decode it, otherwise 127.0.0.1 won't be treated as local

workaround in the meantime should be to use 'localhost' instead of '127.0.0.1'

closes https://github.com/jupyter/nbdime/issues/408

cc @vidartf