### PR TITLE
Download and export

### DIFF
--- a/notebook/static/base/js/utils.js
+++ b/notebook/static/base/js/utils.js
@@ -1183,6 +1183,17 @@ define([
         document.head.appendChild(link);
     };
 
+    var file_extension = function(path){
+        /**
+         *  return the last pat after the dot in a filepath
+         *  or the filepath itself if no dots present.
+         *  Empty string if the filepath ends with a dot.
+         **/
+        var parts = path.split('.');
+        return parts[parts.length-1];
+    };
+
+
     var utils = {
         throttle: throttle,
         is_loaded: is_loaded,
@@ -1236,7 +1247,8 @@ define([
         js_idx_to_char_idx: js_idx_to_char_idx,
         char_idx_to_js_idx: char_idx_to_js_idx,
         _ansispan:_ansispan,
-        change_favicon: change_favicon
+        change_favicon: change_favicon,
+        file_extension: file_extension
     };
 
     return utils;

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -174,7 +174,7 @@ define([
             that.notebook.save_notebook_as();
             return false;
         });
-        this.element.find('#download_ipynb').click(function () {
+        this.element.find('#download_file').click(function () {
             var base_url = that.notebook.base_url;
             var notebook_path = utils.encode_uri_components(that.notebook.notebook_path);
             var url = utils.url_path_join(
@@ -188,13 +188,13 @@ define([
                 that._new_window(url);
             }
         });
-        
+
         this.element.find('#print_preview').click(function () {
             that._nbconvert('html', false);
         });
 
-        this.element.find('#download_menu li').click(function (ev) {
-            that._nbconvert(ev.target.parentElement.getAttribute('id').substring(9), true);
+        this.element.find('#export_menu li').click(function (ev) {
+            that._nbconvert(ev.target.parentElement.getAttribute('id').substring(7), true);
         });
 
         this.events.on('trust_changed.Notebook', function (event, trusted) {

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -14,16 +14,6 @@ define([
 ], function($, IPython, utils, i18n, dialog, events, keyboard, moment, bidi) {
     "use strict";
 
-    var extension = function(path){
-      /**
-       *  return the last pat after the dot in a filepath
-       *  or the filepath itself if no dots present.
-       *  Empty string if the filepath ends with a dot.
-       **/
-      var parts = path.split('.');
-      return parts[parts.length-1];
-    };
-
     var item_in = function(item, list) {
       // Normalize list and item to lowercase
       var normalized_list = list.map(function(_item) {
@@ -33,7 +23,7 @@ define([
     };
 
     var includes_extension = function(filepath, extensionslist) {
-      return item_in(extension(filepath), extensionslist);
+      return item_in(utils.file_extension(filepath), extensionslist);
     };
 
     function name_sorter(ascending) {

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -107,18 +107,19 @@ data-notebook-path="{{notebook_path | urlencode}}"
                         </li>
                         <li class="divider"></li>
                         <li id="print_preview"><a href="#">{% trans %}Print Preview{% endtrans %}</a></li>
-                        <li class="dropdown-submenu"><a href="#">{% trans %}Download as{% endtrans %}</a>
-                            <ul id="download_menu" class="dropdown-menu">
-                                <li id="download_ipynb"><a href="#">{% trans %}Notebook (.ipynb){% endtrans %}</a></li>
-                                <li id="download_script"><a href="#">{% trans %}Script{% endtrans %}</a></li>
-                                <li id="download_html"><a href="#">{% trans %}HTML (.html){% endtrans %}</a></li>
-                                <li id="download_slides"><a href="#">{% trans %}Reveal.js slides (.html){% endtrans %}</a></li>
-                                <li id="download_markdown"><a href="#">{% trans %}Markdown (.md){% endtrans %}</a></li>
-                                <li id="download_rst"><a href="#">{% trans %}reST (.rst){% endtrans %}</a></li>
-                                <li id="download_latex"><a href="#">{% trans %}LaTeX (.tex){% endtrans %}</a></li>
-                                <li id="download_pdf"><a href="#">{% trans %}PDF via LaTeX (.pdf){% endtrans %}</a></li>
+                        <li id="download_file"><a href="#">{% trans %}Download{% endtrans %}</a></li>
+                        <li class="dropdown-submenu"><a href="#">{% trans %}Export as{% endtrans %}</a>
+                            <ul id="export_menu" class="dropdown-menu">
+                                <li id="export_notebook"><a href="#">{% trans %}Notebook (.ipynb){% endtrans %}</a></li>
+                                <li id="export_script"><a href="#">{% trans %}Script{% endtrans %}</a></li>
+                                <li id="export_html"><a href="#">{% trans %}HTML (.html){% endtrans %}</a></li>
+                                <li id="export_slides"><a href="#">{% trans %}Reveal.js slides (.html){% endtrans %}</a></li>
+                                <li id="export_markdown"><a href="#">{% trans %}Markdown (.md){% endtrans %}</a></li>
+                                <li id="export_rst"><a href="#">{% trans %}reST (.rst){% endtrans %}</a></li>
+                                <li id="export_latex"><a href="#">{% trans %}LaTeX (.tex){% endtrans %}</a></li>
+                                <li id="export_pdf"><a href="#">{% trans %}PDF via LaTeX (.pdf){% endtrans %}</a></li>
                                 {% for exporter in get_custom_frontend_exporters() %}
-                                <li id="download_{{ exporter.name }}">
+                                <li id="export_{{ exporter.name }}">
                                     <a href="#">{{ exporter.display }}</a>
                                 </li>
                                 {% endfor %}


### PR DESCRIPTION
This is a fix for #3769.

Previously the 'Download as > Notebook (ipynb)' menu item was hooked up to two event handlers, one which downloaded the current file 'as is' off disk (and seemed to work ok), and one which tried to pass it through `nbconvert` as an `ipynb` file (derived from the menu item's ID `download_ipynb`), and displayed a 500.

I've instead added a new menu item 'Download' which downloads the file 'as is', and fixed the ID as `export_notebook` to align with what `nbconvert` expects (and renamed the `download` menu markup items to `export` to align with the `exporters` that are enumerated at the bottom).

Even though for `ipynb` files the behaviour should be similar, if you've got a custom ContentsManager or something installed you might be editing a different file on disk to an actual ipynb file, so you may want to be able to choose the behaviour you want.