### PR TITLE
Update to jQuery UI 1.12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "jed": "~1.1.1",
     "jquery": "components/jquery#~3.3",
     "jquery-typeahead": "~2.0.0",
-    "jquery-ui": "components/jqueryui#~1.10",
+    "jquery-ui": "components/jqueryui#~1.12",
     "marked": "~0.4",
     "MathJax": "^2.7.4",
     "moment": "~2.19.3",


### PR DESCRIPTION
# Context

[Jupyter Lmod](https://github.com/cmd-ntrf/jupyter-lmod) is a notebook server extension that allows users to interact with environment modules before launching kernels. It adds a tab that includes a search bar that uses jQuery UI autocomplete.

# Issue 

PR #3655 updated the jQuery version to 3.3 and left jQuery UI version to 1.10. There are compatibility issues between these two versions that manifest in jupyter-lmod. The results proposed by autocomplete appears at the top of the page instead of under the search bar.

The following figure illustrates the bug.
<img width="649" alt="buggy" src="https://user-images.githubusercontent.com/884095/43867801-c135eee8-9b38-11e8-916c-43ec3873a310.png">

This is the stacktrace generated by jquery in the javascript console.
```
Uncaught TypeError: r.getClientRects is not a function
    at w.fn.init.offset (jquery.min.js:2)
    at Object.getWithinInfo (jquery-ui.min.js:6)
    at w.fn.init.t.fn.position (jquery-ui.min.js:6)
    at t.(anonymous function).(anonymous function)._suggest (http://localhost:8888/static/components/jquery-ui/ui/minified/jquery-ui.min.js:6:33686)
    at t.(anonymous function).(anonymous function)._suggest (http://localhost:8888/static/components/jquery-ui/ui/minified/jquery-ui.min.js:6:5029)
    at t.(anonymous function).(anonymous function).__response (http://localhost:8888/static/components/jquery-ui/ui/minified/jquery-ui.min.js:6:33003)
    at t.(anonymous function).(anonymous function).__response (http://localhost:8888/static/components/jquery-ui/ui/minified/jquery-ui.min.js:6:5029)
    at t.(anonymous function).(anonymous function).e (http://localhost:8888/static/components/jquery-ui/ui/minified/jquery-ui.min.js:6:4913)
    at t.(anonymous function).(anonymous function).__response (http://localhost:8888/static/components/jquery-ui/ui/minified/jquery-ui.min.js:6:35170)
    at t.(anonymous function).(anonymous function).__response (http://localhost:8888/static/components/jquery-ui/ui/minified/jquery-ui.min.js:6:5029)
```

The following figure corresponds to the expected result using jQuery UI 1.12 with Jupyter notebook 5.6, or using previous version of Jupyter notebook.
<img width="646" alt="correct" src="https://user-images.githubusercontent.com/884095/43867807-c7a99a2c-9b38-11e8-9e67-1d5da0817ba7.png">
# Proposed solution 
Update jquery-ui to 1.12 in `bower.json`.
# Disclaimer

I could not find the exact reason why jQuery UI 1.10 autocomplete does not work with jQuery 3.3. I came to the conclusion that jquery-ui had to be updated after reading the following answer on StackOverflow https://stackoverflow.com/a/50016548. I wish I had a better source.
