### PR TITLE
Return output prompt to width of input prompt after #3772

### DIFF
--- a/notebook/static/notebook/less/outputarea.less
+++ b/notebook/static/notebook/less/outputarea.less
@@ -41,7 +41,7 @@ div.out_prompt_overlay:hover {
 
 div.output_prompt {
     color: @output_prompt_color;
-    min-width: 11ex;
+    min-width: 15ex;
 }
 
 /* This class is the outer container of all output sections. */


### PR DESCRIPTION
In #3772 a change to do with play buttons in the cell markers was reverted, it looks like the `.input_prompt` styles were changed back, but `.output_prompt` was not updated to match:

![image](https://user-images.githubusercontent.com/286704/43889362-da7fa988-9bbb-11e8-8447-c354f842e2e4.png)

This sorts that out:
![image](https://user-images.githubusercontent.com/286704/43889410-fd5706fe-9bbb-11e8-8cf2-87c80cc58674.png)