### PR TITLE
Load notebook after extensions have loaded.

### DIFF
--- a/notebook/static/notebook/js/main.js
+++ b/notebook/static/notebook/js/main.js
@@ -241,9 +241,9 @@ requirejs([
     })
     .catch(function(error) {
         console.error('Could not load ipywidgets', error);
+    }).then(function() {
+        notebook.load_notebook(common_options.notebook_path);
     });
     // END HARDCODED WIDGETS HACK
-
-    notebook.load_notebook(common_options.notebook_path);
 
 });


### PR DESCRIPTION
Is it possible that we can enforce the notebook loading after extensions have run?

I run this branch locally because I have a nbextension that needs to modify the notebook js classes before they're instantiated.

I might be the only one i need of this but I figure it wouldn't hurt to ask :/