### PR TITLE
Fix Enter causes page reload in shortcuts editor

### DIFF
--- a/notebook/static/notebook/js/shortcuteditor.js
+++ b/notebook/static/notebook/js/shortcuteditor.js
@@ -50,6 +50,7 @@ var KeyBinding = createClass({
         that.props.onAddBindings(that.state.shrt, that.props.ckey);
       }
       that.state.shrt='';
+      event.preventDefault();
       return false;
     };
     return createElement('form', {className:'jupyter-keybindings',


### PR DESCRIPTION
Currently:

1. Open keyboard shortcuts editor
2. Click to change / assign a keyboard combination
3. Type the keys to assign
4. Press the Enter key to save the assignment
5. Entire browser page refreshes

I think the return false in the current code was meant to stop this from happening, but a call to event.preventDefault() is also required to prevent full-page form submission.

I think the behavior could still use some tweaking since pressing Enter in the dialog even when a shortcut field does not have the edit focus does nothing.