### PR TITLE
Fix for broken/permission denied symlinks

### DIFF
--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -298,7 +298,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
         if not os.path.isdir(os_path):
             raise web.HTTPError(404, four_o_four)
-        elif is_hidden(os_path, self.root_dir) and not self.allow_hidden:
+        elif is_hidden(os_path, self.root_dir) and not self.allow_hidden and not os.path.islink(os_path):
             self.log.info("Refusing to serve hidden directory %r, via 404 Error",
                 os_path
             )


### PR DESCRIPTION
This is an alternate fix for #3151.  This will still show the broken link.
If the user clicks on the link, they will see the standard permission denied error.
A more complete fix would some how disable the click or add some icon for it.
But this will address the problem where the user doesn't see any listing due
to a single broken link in a directory.