### PR TITLE
Get the list of exporters from entrypoints

### DIFF
--- a/notebook/services/nbconvert/handlers.py
+++ b/notebook/services/nbconvert/handlers.py
@@ -4,18 +4,32 @@ from tornado import web
 
 from ...base.handlers import APIHandler
 
+
 class NbconvertRootHandler(APIHandler):
 
     @web.authenticated
     def get(self):
         try:
-            from nbconvert.exporters.export import exporter_map
+            from nbconvert.exporters import base
         except ImportError as e:
             raise web.HTTPError(500, "Could not import nbconvert: %s" % e)
         res = {}
-        for format, exporter in exporter_map.items():
-            res[format] = info = {}
-            info['output_mimetype'] = exporter.output_mimetype
+        exporters = base.get_export_names()
+        for exporter_name in exporters:
+            try:
+                exporter_class = base.get_exporter(exporter_name)
+            except ValueError:
+                # I think the only way this will happen is if the entrypoint
+                # is uninstalled while this method is running
+                continue
+            # XXX: According to the docs, it looks like this should be set to None
+            # if the exporter shouldn't be exposed to the front-end and a friendly
+            # name if it should. However, none of the built-in exports have it defined.
+            # if not exporter_class.export_from_notebook:
+            #    continue
+            res[exporter_name] = {
+                "output_mimetype": exporter_class.output_mimetype,
+            }
 
         self.finish(json.dumps(res))
 


### PR DESCRIPTION
`exporter_map` is deprecated, so let's use the list of exporters fetched
from the installed entrypoints.

There's a supposed attribute `export_from_notebook` that should be set
to a friendly string name if the exporter should be exposed in the
front-end. However, the exporters defined in `nbconvert` don't have it
set, so I haven't used it to determine inclusion in the list. Instead,
I've used the entrypoint name as the friendly name, which looks like it
was the intention from the way they are named.

I ran the unit tests and tried starting up the notebook server and
accessing the API endpoint to verify the JSON looked correct.