### PR TITLE
Describe problems and solutions involving CSP headers

### DIFF
--- a/docs/source/public_server.rst
+++ b/docs/source/public_server.rst
@@ -358,6 +358,42 @@ For example, in Firefox, go to the Preferences panel, Advanced section,
 Network tab, click 'Settings...', and add the address of the notebook server
 to the 'No proxy for' field.
 
+Content-Security-Policy (CSP)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Certain `security guidelines
+<https://infosec.mozilla.org/guidelines/web_security.html#content-security-policy>`_
+recommend that servers use a Content-Security-Policy (CSP) header to prevent
+cross-site scripting vulnerabilities, specifically limiting to ``default-src:
+https:`` when possible.  This directive causes two problems with Jupyter.
+First, it disables execution of inline javascript code, which is used
+extensively by Jupyter.  Second, it limits communication to the https scheme,
+and prevents WebSockets from working because they communicate via the wss
+scheme (or ws for insecure communication).  Jupyter uses WebSockets for
+interacting with kernels, so when you visit a server with such a CSP, your
+browser will block attempts to use wss, which will cause you to see
+"Connection failed" messages from jupyter notebooks, or simply no response
+from jupyter terminals.  By looking in your browser's javascript console, you
+can see any error messages that will explain what is failing.
+
+To avoid these problem, you need to add ``'unsafe-inline'`` and ``connect-src
+https: wss:`` to your CSP header, at least for pages served by jupyter.  (That
+is, you can leave your CSP unchanged for other parts of your website.)  Note
+that multiple CSP headers are allowed, but successive CSP headers can only
+restrict the policy; they cannot loosen it.  For example, if your server sends
+both of these headers
+
+    Content-Security-Policy "default-src https: 'unsafe-inline'"
+    Content-Security-Policy "connect-src https: wss:"
+
+the first policy will already eliminate wss connections, so the second has no
+effect.  Therefore, you can't simply add the second header; you have to
+actually modify your CSP header to look more like this:
+
+    Content-Security-Policy "default-src https: 'unsafe-inline'; connect-src https: wss:"
+
+
+
 Docker CMD
 ~~~~~~~~~~
 


### PR DESCRIPTION
This PR just adds a section to the documentation describing problems and solutions to serving jupyter from a public server that uses the Content-Security-Policy (CSP) header.

I ran into these problems using the latest docker container `jupyter/scipy-notebook` to serve from a subdirectory on an existing webserver.  I used a setup essentially like [the one described in the docs](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/recipes.html#running-behind-a-nginx-proxy).  I was able to access Jupyter through both the notebook interface and the jupyterlab interface, and the pages basically seemed to be working, in the sense that I could see menus and file listings, and so on.

However, actual connections to the kernel weren't working.  For example, when I opened a new notebook, the kernel wouldn't start and I'd get the usual "Connection failed" message saying "A connection to the notebook server could not be established."  Or in jupyterlab, everything would look fine, but when I'd try to execute a cell it would just hang.  When I tried to open a terminal, nothing at all would happen; I wouldn't get a prompt or any message whatsoever.  Looking at the javascript console, I saw lots of failed connections to WebSockets (which evidently go via the `wss:` scheme, or `ws:` if you're not encrypting), with messages saying that our Contect-Security-Policy (CSP) was blocking those requests.

Now, because we have lots of different web apps running, we try to follow basic security guidelines — specifically [Mozilla's guidelines](https://infosec.mozilla.org/guidelines/web_security.html#content-security-policy), which includes a recommendation to use a restrictive CSP.  I believe the problem is that our CSP includes `default-src https: 'unsafe-inline'`, and that means that `wss:` can't be used.  My solution was to add

    connect-src https: wss:

to the CSP, at least for the subdirectory where I'm serving jupyter.  Now, everything's working great.  (I also noticed that `'unsafe-inline'` is definitely necessary, so I mention that in the docs.)

I had a harder time than I should have figuring that out (because I was looking for 404s, and forgot to check the console for a while), so I'm hoping this at least shows up in search engines for people like me who just searched for the problem first.