### PR TITLE
Allow access control headers to be overriden in jupyter_notebook_conf…

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -607,8 +607,11 @@ class APIHandler(IPythonHandler):
         return super(APIHandler, self).finish(*args, **kwargs)
 
     def options(self, *args, **kwargs):
-        self.set_header('Access-Control-Allow-Headers',
-                        'accept, content-type, authorization, x-xsrftoken')
+        if 'Access-Control-Allow-Headers' in self.settings.get('headers', {}):
+            self.set_header('Access-Control-Allow-Headers', self.settings['headers']['Access-Control-Allow-Headers'])
+        else:
+            self.set_header('Access-Control-Allow-Headers',
+                            'accept, content-type, authorization, x-xsrftoken')
         self.set_header('Access-Control-Allow-Methods',
                         'GET, PUT, POST, PATCH, DELETE, OPTIONS')
 


### PR DESCRIPTION
…ig.py.  This will allow for greater CORS and proxy flexibility.