### PR TITLE
Prefix base URL to breadcrumb root URL

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -382,7 +382,8 @@ define([
         var breadcrumb = $('.breadcrumb');
         breadcrumb.empty();
         var list_item = $('<li/>');
-        var root = $('<li/>').append('<a href="/tree"><i class="fa fa-folder"></i></a>').click(function(e) {
+        var root_url = utils.url_path_join(that.base_url, '/tree');
+        var root = $('<li/>').append('<a href="' + root_url + '"><i class="fa fa-folder"></i></a>').click(function(e) {
             // Allow the default browser action when the user holds a modifier (e.g., Ctrl-Click)
             if(e.altKey || e.metaKey || e.shiftKey) {
                 return true;


### PR DESCRIPTION
The base URL was only prefixed to the breadcrumbs following the root. 
See https://github.com/jupyterhub/jupyterhub/issues/2137 for the full problem description.