### PR TITLE
Prevent access through 'NoneType' when closing activity_stream

### DIFF
--- a/notebook/services/kernels/kernelmanager.py
+++ b/notebook/services/kernels/kernelmanager.py
@@ -272,8 +272,9 @@ class MappingKernelManager(MultiKernelManager):
         """Shutdown a kernel by kernel_id"""
         self._check_kernel_id(kernel_id)
         kernel = self._kernels[kernel_id]
-        kernel._activity_stream.close()
-        kernel._activity_stream = None
+        if kernel._activity_stream:
+            kernel._activity_stream.close()
+            kernel._activity_stream = None
         self.stop_buffering(kernel_id)
         self._kernel_connections.pop(kernel_id, None)
         self.last_kernel_activity = utcnow()


### PR DESCRIPTION
Although I'm unable to reproduce the issue, its a safe change to
prevent an AttributeError from occuring ('NoneType' object has no
attribute 'close').  The user that reported this is attempting to
launch a kernel and I believe the launch only partially completed
such that `kernel._activity_stream` did not get established.
(This occurred from Jupyter Enterprise Gateway where we deal with remote
kernel launches across resource-managed clusters, so things are a bit
more involved relative to kernel establishment.)

Here's the traceback that occurs without this change...
```
[E 2018-09-10 17:31:18.897 EnterpriseGatewayApp] The following exception was encountered while checking the idle duration of kernel 389e11d9-f354-4113-8cdc-a34da14cee50: 'NoneType' object has no attribute 'close'
    Traceback (most recent call last):
      File "/opt/anaconda3/lib/python3.6/site-packages/notebook/services/kernels/kernelmanager.py", line 415, in cull_kernels
        self.cull_kernel_if_idle(kernel_id)
      File "/opt/anaconda3/lib/python3.6/site-packages/notebook/services/kernels/kernelmanager.py", line 436, in cull_kernel_if_idle
        self.shutdown_kernel(kernel_id)
      File "/opt/anaconda3/lib/python3.6/site-packages/notebook/services/kernels/kernelmanager.py", line 263, in shutdown_kernel
        kernel._activity_stream.close()
    AttributeError: 'NoneType' object has no attribute 'close'
```