### PR TITLE
remove vestigial lines from documentation

### DIFF
--- a/docs/source/extending/savehooks.rst
+++ b/docs/source/extending/savehooks.rst
@@ -54,7 +54,7 @@ A post-save hook to make a script equivalent whenever the notebook is saved
     def script_post_save(model, os_path, contents_manager, **kwargs):
         """convert notebooks to Python script after save with nbconvert
 
-        replaces `ipython notebook --script`
+        replaces `jupyter notebook --script`
         """
         from nbconvert.exporters.script import ScriptExporter
 
@@ -69,7 +69,6 @@ A post-save hook to make a script equivalent whenever the notebook is saved
         log = contents_manager.log
 
         base, ext = os.path.splitext(os_path)
-        py_fname = base + '.py'
         script, resources = _script_exporter.from_filename(os_path)
         script_fname = base + resources.get('output_extension', '.txt')
         log.info("Saving script /%s", to_api_path(script_fname, contents_manager.root_dir))


### PR DESCRIPTION
Found here:
https://jupyter-notebook.readthedocs.io/en/stable/extending/savehooks.html

Two changes:

 - replace usage of `ipython` -> `jupyter`
 - remove reference to `py_fname` (presumably left over from when this was used only for python scripts, now superceded by the use of `resources.get('output_extension', '.txt')`

Already removed from the core script [here](https://github.com/jupyter/notebook/blob/b8b66332e2023e83d2ee04f83d8814f567e01a4e/notebook/services/contents/filemanager.py)

