### PR TITLE
[WIP] use Accept-Language header in jinja templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ __pycache__
 .coverage
 .pytest_cache
 src
+.pytest_cache
 
 *.swp
 *.map

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,9 +67,21 @@ script:
       else
           true
       fi
-    - 'if [[ $GROUP == js* ]]; then travis_retry python -m notebook.jstest ${GROUP:3}; fi'
-    - 'if [[ $GROUP == python ]]; then nosetests -v --exclude-dir notebook/tests/selenium --with-coverage --cover-package=notebook notebook; fi'
-    - 'if [[ $GROUP == selenium ]]; then py.test -sv notebook/tests/selenium; fi'
+    - |
+      # javascript tests
+      if [[ $GROUP == js* ]]; then
+        travis_retry python -m notebook.jstest ${GROUP:3}
+      fi
+    - |
+      # python tests
+      if [[ $GROUP == python ]]; then
+        pytest -v --ignore notebook/tests/selenium --cov notebook notebook
+      fi
+    - |
+      # selenium tests
+      if [[ $GROUP == selenium ]]; then
+        pytest -sv notebook/tests/selenium
+      fi
     - |
       if [[ $GROUP == docs ]]; then
         EXIT_STATUS=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ script:
     - |
       # python tests
       if [[ $GROUP == python ]]; then
-        pytest -v --ignore notebook/tests/selenium --cov notebook notebook
+        pytest -v --ignore notebook/tests/selenium --cov notebook --pyargs notebook
       fi
     - |
       # selenium tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ env:
     - GROUP=js/services
 
 before_install:
-    - pip install --upgrade pip
-    - pip install --upgrade setuptools wheel nose coverage codecov
+    - pip install --upgrade setuptools pip
+    - pip install --upgrade codecov attrs
     - nvm install 6.9.2
     - nvm use 6.9.2
     - node --version
@@ -50,7 +50,7 @@ before_install:
     - pip install "attrs>=17.4.0"
 
 install:
-    - pip install --pre .[test] $EXTRA_PIP
+    - pip install --upgrade --upgrade-strategy eager --pre .[test] $EXTRA_PIP
     - pip freeze
     - wget https://github.com/jgm/pandoc/releases/download/1.19.1/pandoc-1.19.1-1-amd64.deb && sudo dpkg -i pandoc-1.19.1-1-amd64.deb
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
   - cmd: conda config --set show_channel_urls true
   - cmd: conda config --add channels conda-forge
   #- cmd: conda update --yes --quiet conda
-  - cmd: conda install -y pyzmq tornado jupyter_client nbformat ipykernel pip nodejs nose
+  - cmd: conda install -y pyzmq tornado jupyter_client nbformat ipykernel pip nodejs nose pytest
   # not using `conda install -y` on nbconvent package because there is
   # currently a bug with the version that the anaconda installs, so we will just install it with pip
   - cmd: pip install nbconvert
@@ -25,4 +25,4 @@ install:
   - cmd: pip install .[test]
 
 test_script:
-  - nosetests  -v notebook --exclude-dir notebook\tests\selenium
+  - pytest -v --ignore notebook/tests/selenium --cov notebook notebook

--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -10,7 +10,6 @@ import json
 import mimetypes
 import os
 import re
-import sys
 import traceback
 import types
 import warnings
@@ -27,7 +26,7 @@ except ImportError:
     from urlparse import urlparse # Py 2
 
 from jinja2 import TemplateNotFound
-from tornado import web, gen, escape, httputil
+from tornado import web, escape, httputil
 from tornado.log import app_log
 import prometheus_client
 
@@ -39,7 +38,7 @@ from ipython_genutils.py3compat import string_types, PY3
 
 import notebook
 from notebook._tz import utcnow
-from notebook.i18n import combine_translations
+from notebook.i18n import combine_translations, get_translation, parse_accept_lang_header
 from notebook.utils import is_hidden, url_path_join, url_is_absolute, url_escape
 from notebook.services.security import csp_report_uri
 
@@ -451,16 +450,29 @@ class IPythonHandler(AuthenticatedHandler):
     #---------------------------------------------------------------
     # template rendering
     #---------------------------------------------------------------
-    
+
     def get_template(self, name):
         """Return the jinja template object for a given name"""
         return self.settings['jinja2_env'].get_template(name)
-    
+
     def render_template(self, name, **ns):
         ns.update(self.template_namespace)
+
+        accept_language = self.request.headers.get('Accept-Language', '')
+        languages = parse_accept_lang_header(accept_language)
+
+        # register backend translations with jinja
+        self.settings['jinja2_env'].install_gettext_translations(
+            get_translation('nbui', languages),
+            newstyle=False,
+        )
+
+        # pass frontend translations to javascript
+        ns['nbjs_translations'] = combine_translations(languages)
+
         template = self.get_template(name)
         return template.render(**ns)
-    
+
     @property
     def template_namespace(self):
         return dict(
@@ -479,11 +491,9 @@ class IPythonHandler(AuthenticatedHandler):
             xsrf_form_html=self.xsrf_form_html,
             token=self.token,
             xsrf_token=self.xsrf_token.decode('utf8'),
-            nbjs_translations=json.dumps(combine_translations(
-                self.request.headers.get('Accept-Language', ''))),
             **self.jinja_template_vars
         )
-    
+
     def get_json_body(self):
         """Return the body of the request as JSON data."""
         if not self.request.body:

--- a/notebook/i18n/README.md
+++ b/notebook/i18n/README.md
@@ -12,7 +12,7 @@ However…
 
 1. `jupyter notebook` command reads the `LANG` environment variable at startup,
 (`xx_XX` or just `xx` form, where `xx` is the language code you're wanting to
-run in).
+run in). This is used to set the
 
 Hint: if running Windows, you can set it in PowerShell with `${Env:LANG} = "xx_XX"`.
       if running Ubuntu 14, you should set environment variable `LANGUAGE="xx_XX"`.
@@ -108,15 +108,10 @@ to handle these cases properly.
 ### Known issues and future evolutions
 
 1. Right now there are two different places where the desired language is set.  At startup time, the Jupyter console's messages pay attention to the setting of the `${LANG}` environment variable
-as set in the shell at startup time.  Unfortunately, this is also the time where the Jinja2
-environment is set up, which means that the template stuff will always come from this setting.
-We really want to be paying attention to the browser's settings for the stuff that happens in the
-browser, so we need to be able to retrieve this information after the browser is started and somehow
-communicate this back to Jinja2.  So far, I haven't yet figured out how to do this, which means that if the ${LANG} at startup doesn't match the browser's settings, you could potentially get a mix
-of languages in the UI ( never a good thing ).
-
+as set in the shell at startup time. Messages in the frontend are handled in two places: in jinja2 templates and via i18n in javascript.
+Both of these should respect the `Accept-Language` header from the browser.
 2. We will need to decide if console messages should be translatable, and enable them if desired.
-3. The keyboard shorcut editor was implemented after the i18n work was completed, so that portion
+3. The keyboard shortcut editor was implemented after the i18n work was completed, so that portion
 does not have translation support at this time.
 4. Babel's documentation has instructions on how to integrate messages extraction
 into your *setup.py* so that eventually we can just do:

--- a/notebook/i18n/__init__.py
+++ b/notebook/i18n/__init__.py
@@ -2,10 +2,13 @@
 """
 from collections import defaultdict
 import errno
+import gettext
+import glob
 import io
 import json
-from os.path import dirname, join as pjoin
+from os.path import basename, dirname, join as pjoin
 import re
+
 
 I18N_DIR = dirname(__file__)
 # Cache structure:
@@ -15,7 +18,37 @@ I18N_DIR = dirname(__file__)
 #     ...
 #   }
 # }}
-TRANSLATIONS_CACHE = {'nbjs': {}}
+TRANSLATIONS_CACHE = {}
+# COMBINED_CACHE is a cache of the json-serialized combined result
+# for a given language combination
+COMBINED_CACHE = {}
+
+# the supported languages, as found in I18N_DIR
+_SUPPORTED_LANGUAGES = set()
+
+def _load_supported_languages():
+    """Load the supported language list (just once)"""
+    _SUPPORTED_LANGUAGES.clear()
+
+    _SUPPORTED_LANGUAGES.add('en')
+
+    for lang in glob.glob(pjoin(I18N_DIR, '??_??')):
+        lang = basename(lang)
+        # add both fr and fr_FR
+        _SUPPORTED_LANGUAGES.add(lang.split('_')[0])
+        _SUPPORTED_LANGUAGES.add(lang)
+    return _SUPPORTED_LANGUAGES
+
+
+def filter_languages(languages):
+    """Filter a language list to only those that are supported"""
+    if not _SUPPORTED_LANGUAGES:
+        _load_supported_languages()
+    filtered = []
+    for language in languages:
+        if language in _SUPPORTED_LANGUAGES and language not in filtered:
+            filtered.append(language)
+    return tuple(filtered)
 
 
 _accept_lang_re = re.compile(r'''
@@ -24,11 +57,12 @@ _accept_lang_re = re.compile(r'''
   (?P<qvalue>[01](.\d+)?)
 )?''', re.VERBOSE)
 
+
 def parse_accept_lang_header(accept_lang):
     """Parses the 'Accept-Language' HTTP header.
 
-    Returns a list of language codes in *ascending* order of preference
-    (with the most preferred language last).
+    Returns a list of language codes in *descending* order of preference
+    (with the most preferred language first).
     """
     by_q = defaultdict(list)
     for part in accept_lang.split(','):
@@ -49,7 +83,9 @@ def parse_accept_lang_header(accept_lang):
     res = []
     for qvalue, langs in sorted(by_q.items()):
         res.extend(sorted(langs))
-    return res
+    # make it a tuple so it's hashable
+    return tuple(res[::-1])
+
 
 def load(language, domain='nbjs'):
     """Load translations from an nbjs.json file"""
@@ -65,9 +101,10 @@ def load(language, domain='nbjs'):
         data = json.load(f)
     return data["locale_data"][domain]
 
+
 def cached_load(language, domain='nbjs'):
     """Load translations for one language, using in-memory cache if available"""
-    domain_cache = TRANSLATIONS_CACHE[domain]
+    domain_cache = TRANSLATIONS_CACHE.setdefault(domain, {})
     try:
         return domain_cache[language]
     except KeyError:
@@ -75,25 +112,60 @@ def cached_load(language, domain='nbjs'):
         domain_cache[language] = data
         return data
 
-def combine_translations(accept_language, domain='nbjs'):
+
+def combine_translations(lang_codes, domain='nbjs'):
     """Combine translations for multiple accepted languages.
 
-    Returns data re-packaged in jed1.x format.
+    Returns data re-packaged in jed1.x format, serialized as JSON
     """
-    lang_codes = parse_accept_lang_header(accept_language)
+    lang_codes = filter_languages(lang_codes)
+    if lang_codes in COMBINED_CACHE:
+        return COMBINED_CACHE[lang_codes]
+
     combined = {}
-    for language in lang_codes:
+    # step backwards because the first priority comes first
+    # and we want to load that last
+    for language in lang_codes[::-1]:
         if language == 'en':
             # en is default, all translations are in frontend.
             combined.clear()
         else:
             combined.update(cached_load(language, domain))
 
-    combined[''] = {"domain":"nbjs"}
+    combined[''] = {"domain": "nbjs"}
 
-    return {
-        "domain": domain,
-        "locale_data": {
-            domain: combined
+    COMBINED_CACHE[lang_codes] = json.dumps(
+        {
+            "domain": domain,
+            "locale_data": {
+                domain: combined
+            }
         }
-    }
+    )
+    return COMBINED_CACHE[lang_codes]
+
+# global translation cache
+_GETTEXT_TRANSLATION_CACHE = {}
+
+
+def get_translation(domain, languages=None):
+    """get a gettext.translation object for a given domain
+
+    Translation objects are cached, so each call with a given language list
+    returns the same translation instance.
+
+    The cache key is
+    """
+    domain_translations = _GETTEXT_TRANSLATION_CACHE.setdefault(domain, {})
+    if languages:
+        # filter languages to avoid duplicate entries in cache
+        # with the same supported language subset,
+        # e.g. [fr_FR, de_DE] and [fr_FR, es_ES] should both
+        # return [fr_FR] when we have no translations for the other languages
+        language_key = filter_languages(languages)
+    else:
+        language_key = None
+    if language_key not in domain_translations:
+        domain_translations[language_key] = gettext.translation(
+            domain, languages=languages, localedir=I18N_DIR, fallback=True)
+    return domain_translations[language_key]

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -184,11 +184,8 @@ class NotebookWebApplication(web.Application):
 
         # If the user is running the notebook in a git directory, make the assumption
         # that this is a dev install and suggest to the developer `npm run build:watch`.
-        base_dir = os.path.realpath(os.path.join(__file__, '..', '..'))
+        base_dir = os.path.realpath(os.path.join(notebook.__file__, os.pardir, os.pardir))
         dev_mode = os.path.exists(os.path.join(base_dir, '.git'))
-
-        nbui = gettext.translation('nbui', localedir=os.path.join(base_dir, 'notebook/i18n'), fallback=True)
-        env.install_gettext_translations(nbui, newstyle=False)
 
         if dev_mode:
             DEV_NOTE_NPM = """It looks like you're running the notebook from source.

--- a/notebook/tests/test_i18n.py
+++ b/notebook/tests/test_i18n.py
@@ -1,10 +1,34 @@
-import nose.tools as nt
+import pytest
 
 from notebook import i18n
 
 def test_parse_accept_lang_header():
     palh = i18n.parse_accept_lang_header
-    nt.assert_equal(palh(''), [])
-    nt.assert_equal(palh('zh-CN,en-GB;q=0.7,en;q=0.3'),
-                    ['en', 'en_GB', 'zh_CN'])
-    nt.assert_equal(palh('nl,fr;q=0'), ['nl'])
+    assert palh('') == ()
+    assert palh('zh-CN,en-GB;q=0.7,en;q=0.3') == ('zh_CN', 'en_GB', 'en')
+    assert palh('nl,fr;q=0') == ('nl',)
+
+
+@pytest.mark.parametrize(
+    'languages, expected',
+    [
+        (
+            ('fr_FR', 'en_GB'),
+            ('fr_FR',),
+        ),
+        (
+            (),
+            (),
+        ),
+        (
+            ('fr_FR', 'fr', 'fr'),
+            ('fr_FR', 'fr'),
+        ),
+        (
+            ('zh_CN', 'fr', 'zh_CN'),
+            ('zh_CN', 'fr'),
+        ),
+    ],
+)
+def test_filter_languages(languages, expected):
+    assert i18n.filter_languages(languages) == expected

--- a/notebook/tests/test_i18n.py
+++ b/notebook/tests/test_i18n.py
@@ -1,6 +1,12 @@
+"""Tests for translation utilities"""
+import json
+import re
+
 import pytest
 
 from notebook import i18n
+
+from .launchnotebook import NotebookTestBase
 
 def test_parse_accept_lang_header():
     palh = i18n.parse_accept_lang_header
@@ -32,3 +38,53 @@ def test_parse_accept_lang_header():
 )
 def test_filter_languages(languages, expected):
     assert i18n.filter_languages(languages) == expected
+
+
+class TestAcceptLanguageHeaders(NotebookTestBase):
+
+    def test_notranslate(self):
+        headers = {"Accept-Language": ""}
+        r = self.request("GET", "/tree/", headers=headers)
+        r.raise_for_status()
+        html = r.text
+        nbjs_translations = self.find_nbjs_translations(html)
+        assert list(nbjs_translations.keys()) == ['']
+
+    def find_nbjs_translations(self, html):
+        """Find the nbjs_translations object in the HTML page
+
+        Returns the nbjs locale data
+        """
+        m = re.search(r"nbjs_translations\s*=\s*(.*);", html)
+        if m is None:
+            return None
+        translations = json.loads(m.group(1))
+        return translations['locale_data']['nbjs']
+
+    def test_tree_fr(self):
+        headers = {"Accept-Language": "fr-FR;q=0.9,en;q=0.5"}
+        r = self.request("GET", "/tree/", headers=headers)
+        r.raise_for_status()
+        html = r.text
+        # test a frontend translation
+        nbjs_translations = self.find_nbjs_translations(html)
+        assert '(autosaved)' in nbjs_translations
+        assert nbjs_translations['(autosaved)'] == ['(auto-sauvegardé)']
+        # and a backend one
+        trans = i18n.get_translation("nbui", ["fr_FR"])
+        assert trans.gettext("Files") != "Files"
+        assert trans.gettext("Files") in html
+
+    def test_tree_zh(self):
+        headers = {"Accept-Language": "zh-CN;q=0.9,en;q=0.5"}
+        r = self.request("GET", "/tree/", headers=headers)
+        r.raise_for_status()
+        html = r.text
+        # test a frontend translation
+        nbjs_translations = self.find_nbjs_translations(html)
+        assert '(autosaved)' in nbjs_translations
+        assert nbjs_translations['(autosaved)'] == ['(自动保存)']
+        # and a backend one
+        trans = i18n.get_translation("nbui", ["zh_CN"])
+        assert trans.gettext("Files") != "Files"
+        assert trans.gettext("Files") in html

--- a/notebook/tests/test_notebookapp.py
+++ b/notebook/tests/test_notebookapp.py
@@ -15,6 +15,7 @@ except ImportError:
     from mock import patch # py2
 
 import nose.tools as nt
+import pytest
 
 from traitlets.tests.utils import check_help_all_output
 
@@ -93,27 +94,30 @@ def test_generate_config():
         assert os.path.exists(os.path.join(td, 'jupyter_notebook_config.py'))
 
 #test if the version testin function works
-def test_pep440_version():
-
-    for version in [
+@pytest.mark.parametrize(
+    'version',
+    [
         '4.1.0.b1',
         '4.1.b1',
         '4.2',
         'X.y.z',
         '1.2.3.dev1.post2',
-        ]:
-        def loc():
-            with nt.assert_raises(ValueError):
-                raise_on_bad_version(version)
-        yield loc
+    ]
+)
+def test_pep440_version_bad(version):
+    with pytest.raises(ValueError):
+        raise_on_bad_version(version)
 
-    for version in [
+
+@pytest.mark.parametrize(
+    'version',
+    [
         '4.1.1',
         '4.2.1b3',
-        ]:
-
-        yield (raise_on_bad_version, version)
-
+    ]
+)
+def test_pep440_version_ok(version):
+    raise_on_bad_version(version)
 
 
 pep440re = re.compile('^(\d+)\.(\d+)\.(\d+((a|b|rc)\d+)?)(\.post\d+)?(\.dev\d*)?$')

--- a/notebook/transutils.py
+++ b/notebook/transutils.py
@@ -3,11 +3,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import os
-import gettext
+from .i18n import get_translation
 
+# global default translation object (used for log messages)
 
-# Set up message catalog access
-base_dir = os.path.realpath(os.path.join(__file__, '..', '..'))
-trans = gettext.translation('notebook', localedir=os.path.join(base_dir, 'notebook/i18n'), fallback=True)
+trans = get_translation('notebook')
 _ = trans.gettext


### PR DESCRIPTION
solves translation issue where jinja used server-side LANG environment and javascript used browser configuration via the Accept-Language header, which could result in multiple languages on the page. Now, all browser messages should be consistent with the browser settings.

Introduces caching of gettext translation objects to ensure that we don't keep loading the translation config on every request.

cc @JCEmmons

TODO:

- selenium test with Accept-Language header to verify that it's loading the right thing (verified manually, but we should have a real test)