### PR TITLE
[WIP] Prompt for folder name when creating a new folder - fix #3928

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -32,7 +32,7 @@ New features:
 - Update jquery-ui to 1.12 (:ghpull:`3836`)
 - Check Host header to more securely protect localhost deployments from DNS rebinding.
   This is a pre-emptive measure, not fixing a known vulnerability (:ghpull:`3766`).
-  Use `.NotebookApp.allow_remote_access` and `.NotebookApp.local_hostnames` to configure
+  Use ``.NotebookApp.allow_remote_access`` and ``.NotebookApp.local_hostnames`` to configure
   access.
 - Allow access-control-allow-headers to be overridden (:ghpull:`3886`)
 - Allow configuring max_body_size and max_buffer_size (:ghpull:`3829`)
@@ -46,7 +46,7 @@ Fixing problems:
 
 - Fix breadcrumb link when running with a base url (:ghpull:`3905`)
 - Fix possible type error when closing activity stream (:ghpull:`3907`)
-- Disable metadata editing for non-editable celsl (:ghpull:`3744`)
+- Disable metadata editing for non-editable cells (:ghpull:`3744`)
 - Fix some styling and alignment of prompts caused by regressions in 5.6.0.
 - Enter causing page reload in shortcuts editor (:ghpull:`3871`)
 - Fix uploading to the same file twice (:ghpull:`3712`)

--- a/notebook/services/contents/handlers.py
+++ b/notebook/services/contents/handlers.py
@@ -148,10 +148,10 @@ class ContentsHandler(APIHandler):
         self._finish_model(model)
     
     @gen.coroutine
-    def _new_untitled(self, path, type='', ext=''):
+    def _new_untitled(self, path, type='', ext='', new_name=''):
         """Create a new, empty untitled entity"""
         self.log.info(u"Creating new %s in %s", type or 'file', path)
-        model = yield gen.maybe_future(self.contents_manager.new_untitled(path=path, type=type, ext=ext))
+        model = yield gen.maybe_future(self.contents_manager.new_untitled(path=path, type=type, ext=ext, new_name=new_name))
         self.set_status(201)
         validate_model(model, expect_content=False)
         self._finish_model(model)
@@ -194,10 +194,11 @@ class ContentsHandler(APIHandler):
             copy_from = model.get('copy_from')
             ext = model.get('ext', '')
             type = model.get('type', '')
+            name = model.get('name', '')
             if copy_from:
                 yield self._copy(copy_from, path)
             else:
-                yield self._new_untitled(path, type=type, ext=ext)
+                yield self._new_untitled(path, type=type, ext=ext, new_name=name)
         else:
             yield self._new_untitled(path)
 

--- a/notebook/services/contents/manager.py
+++ b/notebook/services/contents/manager.py
@@ -355,7 +355,7 @@ class ContentsManager(LoggingConfigurable):
             )
         return model
     
-    def new_untitled(self, path='', type='', ext=''):
+    def new_untitled(self, path='', type='', ext='', new_name=''):
         """Create a new untitled file or directory in path
         
         path must be a directory
@@ -364,6 +364,7 @@ class ContentsManager(LoggingConfigurable):
         
         Use `new` to create files with a fully specified path (including filename).
         """
+
         path = path.strip('/')
         if not self.dir_exists(path):
             raise HTTPError(404, 'No such directory: %s' % path)
@@ -389,7 +390,11 @@ class ContentsManager(LoggingConfigurable):
         else:
             raise HTTPError(400, "Unexpected model type: %r" % model['type'])
         
-        name = self.increment_filename(untitled + ext, path, insert=insert)
+        if new_name == '':
+            name = self.increment_filename(untitled + ext, path, insert=insert)
+        else:
+            name = new_name
+
         path = u'{0}/{1}'.format(path, name)
         return self.new(model, path)
     

--- a/notebook/static/services/contents.js
+++ b/notebook/static/services/contents.js
@@ -115,7 +115,8 @@ define(function(requirejs) {
     Contents.prototype.new_untitled = function(path, options) {
         var data = JSON.stringify({
           ext: options.ext,
-          type: options.type
+          type: options.type,
+          name: options.name
         });
 
         var settings = {

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -191,7 +191,8 @@ define([
                 e.preventDefault();
             });
             $('#new-folder').click(function(e) {
-                that.contents.new_untitled(that.notebook_path || '', {type: 'directory'})
+                var foldername = prompt("New folder:");
+                that.contents.new_untitled(that.notebook_path || '', {type: 'directory', name: foldername})
                 .then(function(){
                     that.load_list();
                 }).catch(function (e) {


### PR DESCRIPTION
**Description**
On the homepage of the server, prompt for the folder name when creating a new folder instead of creating one with the name 'Untitled Folder'.

Currently the name is set using the already existing method `new_untitled`, which previously would create a new untitled {folder | file | notebook}. It does not make much sense, since we are setting a new name to the folder and, well, it is not untitled anymore. What do you suggest? Do I create a new function? Or rename the existing one?

**Modified Files**
- `notebook/services/contents/handlers.py`
- `notebook/services/contents/manager.py`
- `notebook/static/services/contents.js`
- `notebook/static/tree/js/notebooklist.js`

**TODO**
- [ ] **Create new function instead of using `new_untitled`.**
- [ ] Show Modal DIalog when prompting for folder name instead of native browser prompt.
- [ ]  Tests