### PR TITLE
Prompt for folder name when creating a new folder

### DIFF
--- a/notebook/services/contents/handlers.py
+++ b/notebook/services/contents/handlers.py
@@ -148,10 +148,10 @@ class ContentsHandler(APIHandler):
         self._finish_model(model)
     
     @gen.coroutine
-    def _new_untitled(self, path, type='', ext='', title=''):
-        """Create a new, empty untitled entity"""
+    def _new_entity(self, path, type='', ext='', title=''):
+        """Create a new, empty entity"""
         self.log.info(u"Creating new %s in %s", type or 'file', path)
-        model = yield gen.maybe_future(self.contents_manager.new_untitled(path=path, type=type, ext=ext, title=title))
+        model = yield gen.maybe_future(self.contents_manager.new_entity(path=path, type=type, ext=ext, title=title))
         self.set_status(201)
         validate_model(model, expect_content=False)
         self._finish_model(model)
@@ -198,9 +198,9 @@ class ContentsHandler(APIHandler):
             if copy_from:
                 yield self._copy(copy_from, path)
             else:
-                yield self._new_untitled(path, type=type, ext=ext, title=title)
+                yield self._new_entity(path, type=type, ext=ext, title=title)
         else:
-            yield self._new_untitled(path)
+            yield self._new_entity(path)
 
     @web.authenticated
     @gen.coroutine
@@ -225,7 +225,7 @@ class ContentsHandler(APIHandler):
             else:
                 yield gen.maybe_future(self._upload(model, path))
         else:
-            yield gen.maybe_future(self._new_untitled(path))
+            yield gen.maybe_future(self._new_entity(path))
 
     @web.authenticated
     @gen.coroutine

--- a/notebook/services/contents/handlers.py
+++ b/notebook/services/contents/handlers.py
@@ -148,10 +148,10 @@ class ContentsHandler(APIHandler):
         self._finish_model(model)
     
     @gen.coroutine
-    def _new_untitled(self, path, type='', ext=''):
+    def _new_untitled(self, path, type='', ext='', title=''):
         """Create a new, empty untitled entity"""
         self.log.info(u"Creating new %s in %s", type or 'file', path)
-        model = yield gen.maybe_future(self.contents_manager.new_untitled(path=path, type=type, ext=ext))
+        model = yield gen.maybe_future(self.contents_manager.new_untitled(path=path, type=type, ext=ext, title=title))
         self.set_status(201)
         validate_model(model, expect_content=False)
         self._finish_model(model)
@@ -194,10 +194,11 @@ class ContentsHandler(APIHandler):
             copy_from = model.get('copy_from')
             ext = model.get('ext', '')
             type = model.get('type', '')
+            title = model.get('title', '')
             if copy_from:
                 yield self._copy(copy_from, path)
             else:
-                yield self._new_untitled(path, type=type, ext=ext)
+                yield self._new_untitled(path, type=type, ext=ext, title=title)
         else:
             yield self._new_untitled(path)
 

--- a/notebook/services/contents/manager.py
+++ b/notebook/services/contents/manager.py
@@ -355,7 +355,7 @@ class ContentsManager(LoggingConfigurable):
             )
         return model
 
-    def new_untitled(self, path='', type='', ext='', title=''):
+    def new_entity(self, path='', type='', ext='', title=''):
         """Create a new untitled file or directory in path
         
         path must be a directory

--- a/notebook/services/contents/manager.py
+++ b/notebook/services/contents/manager.py
@@ -356,7 +356,7 @@ class ContentsManager(LoggingConfigurable):
         return model
 
     def new_entity(self, path='', type='', ext='', title=''):
-        """Create a new untitled file or directory in path
+        """Create a new file or directory in path
         
         path must be a directory
         
@@ -377,19 +377,20 @@ class ContentsManager(LoggingConfigurable):
         else:
             model.setdefault('type', 'file')
         
-        insert = ''
-        if model['type'] == 'directory':
-            untitled = self.untitled_directory
-            insert = ' '
-        elif model['type'] == 'notebook':
-            untitled = self.untitled_notebook
-            ext = '.ipynb'
-        elif model['type'] == 'file':
-            untitled = self.untitled_file
-        else:
-            raise HTTPError(400, "Unexpected model type: %r" % model['type'])
-        
-        name = title if title else self.increment_filename(untitled + ext, path, insert=insert)
+        insert = ' '
+        if not title:
+            if model['type'] == 'directory':
+                title = self.untitled_directory
+                insert = ' '
+            elif model['type'] == 'notebook':
+                title = self.untitled_notebook
+                ext = '.ipynb'
+            elif model['type'] == 'file':
+                title = self.untitled_file
+            else:
+                raise HTTPError(400, "Unexpected model type: %r" % model['type'])
+
+        name = self.increment_filename(title + ext, path, insert=insert)
         
         path = u'{0}/{1}'.format(path, name)
         return self.new(model, path)

--- a/notebook/services/contents/manager.py
+++ b/notebook/services/contents/manager.py
@@ -354,8 +354,8 @@ class ContentsManager(LoggingConfigurable):
                 e.message, json.dumps(e.instance, indent=1, default=lambda obj: '<UNKNOWN>'),
             )
         return model
-    
-    def new_untitled(self, path='', type='', ext=''):
+
+    def new_untitled(self, path='', type='', ext='', title=''):
         """Create a new untitled file or directory in path
         
         path must be a directory
@@ -389,7 +389,8 @@ class ContentsManager(LoggingConfigurable):
         else:
             raise HTTPError(400, "Unexpected model type: %r" % model['type'])
         
-        name = self.increment_filename(untitled + ext, path, insert=insert)
+        name = title if title else self.increment_filename(untitled + ext, path, insert=insert)
+        
         path = u'{0}/{1}'.format(path, name)
         return self.new(model, path)
     

--- a/notebook/services/contents/tests/test_contents_api.py
+++ b/notebook/services/contents/tests/test_contents_api.py
@@ -377,7 +377,7 @@ class APITest(NotebookTestBase):
 
         # Second time
         resp = self.api.create_untitled(path=u'å b')
-        self._check_created(resp, u'å b/Untitled1.ipynb')
+        self._check_created(resp, u'å b/Untitled 1.ipynb')
 
         # And two directories down
         resp = self.api.create_untitled(path='foo/bar')

--- a/notebook/services/contents/tests/test_largefilemanager.py
+++ b/notebook/services/contents/tests/test_largefilemanager.py
@@ -34,7 +34,7 @@ class TestLargeFileManager(TestCase):
 
         cm = self.contents_manager
         # Create a notebook
-        model = cm.new_untitled(type='notebook')
+        model = cm.new_entity(type='notebook')
         name = model['name']
         path = model['path']
 
@@ -99,7 +99,7 @@ class TestLargeFileManager(TestCase):
         # Create a directory and notebook in that directory
         sub_dir = '/foo/'
         self.make_dir('foo')
-        model = cm.new_untitled(path=sub_dir, type='notebook')
+        model = cm.new_entity(path=sub_dir, type='notebook')
         name = model['name']
         path = model['path']
         model = cm.get(path)

--- a/notebook/services/contents/tests/test_manager.py
+++ b/notebook/services/contents/tests/test_manager.py
@@ -115,7 +115,7 @@ class TestFileContentsManager(TestCase):
             path = 'test bad symlink'
             _make_dir(cm, path)
 
-            file_model = cm.new_untitled(path=path, ext='.txt')
+            file_model = cm.new_entity(path=path, ext='.txt')
 
             # create a broken symlink
             self.symlink(cm, "target", '%s/%s' % (path, 'bad symlink'))
@@ -158,7 +158,7 @@ class TestFileContentsManager(TestCase):
 
         with TemporaryDirectory() as td:
             cm = FileContentsManager(root_dir=td)
-            model = cm.new_untitled(type='file')
+            model = cm.new_entity(type='file')
             os_path = cm._get_os_path(model['path'])
 
             os.chmod(os_path, 0o400)
@@ -256,7 +256,7 @@ class TestContentsManager(TestCase):
 
     def new_notebook(self):
         cm = self.contents_manager
-        model = cm.new_untitled(type='notebook')
+        model = cm.new_entity(type='notebook')
         name = model['name']
         path = model['path']
 
@@ -268,10 +268,10 @@ class TestContentsManager(TestCase):
         cm.save(full_model, path)
         return nb, name, path
 
-    def test_new_untitled(self):
+    def test_new_entity(self):
         cm = self.contents_manager
         # Test in root directory
-        model = cm.new_untitled(type='notebook')
+        model = cm.new_entity(type='notebook')
         assert isinstance(model, dict)
         self.assertIn('name', model)
         self.assertIn('path', model)
@@ -281,7 +281,7 @@ class TestContentsManager(TestCase):
         self.assertEqual(model['path'], 'Untitled.ipynb')
 
         # Test in sub-directory
-        model = cm.new_untitled(type='directory')
+        model = cm.new_entity(type='directory')
         assert isinstance(model, dict)
         self.assertIn('name', model)
         self.assertIn('path', model)
@@ -291,7 +291,7 @@ class TestContentsManager(TestCase):
         self.assertEqual(model['path'], 'Untitled Folder')
         sub_dir = model['path']
 
-        model = cm.new_untitled(path=sub_dir)
+        model = cm.new_entity(path=sub_dir)
         assert isinstance(model, dict)
         self.assertIn('name', model)
         self.assertIn('path', model)
@@ -301,10 +301,10 @@ class TestContentsManager(TestCase):
         self.assertEqual(model['path'], '%s/untitled' % sub_dir)
 
         # Test with a compound extension
-        model = cm.new_untitled(path=sub_dir, ext='.foo.bar')
+        model = cm.new_entity(path=sub_dir, ext='.foo.bar')
         self.assertEqual(model['name'], 'untitled.foo.bar')
-        model = cm.new_untitled(path=sub_dir, ext='.foo.bar')
-        self.assertEqual(model['name'], 'untitled1.foo.bar')
+        model = cm.new_entity(path=sub_dir, ext='.foo.bar')
+        self.assertEqual(model['name'], 'untitled 1.foo.bar')
 
     def test_modified_date(self):
 
@@ -336,7 +336,7 @@ class TestContentsManager(TestCase):
     def test_get(self):
         cm = self.contents_manager
         # Create a notebook
-        model = cm.new_untitled(type='notebook')
+        model = cm.new_entity(type='notebook')
         name = model['name']
         path = model['path']
 
@@ -360,7 +360,7 @@ class TestContentsManager(TestCase):
         # Test in sub-directory
         sub_dir = '/foo/'
         self.make_dir('foo')
-        model = cm.new_untitled(path=sub_dir, ext='.ipynb')
+        model = cm.new_entity(path=sub_dir, ext='.ipynb')
         model2 = cm.get(sub_dir + name)
         assert isinstance(model2, dict)
         self.assertIn('name', model2)
@@ -370,7 +370,7 @@ class TestContentsManager(TestCase):
         self.assertEqual(model2['path'], '{0}/{1}'.format(sub_dir.strip('/'), name))
 
         # Test with a regular file.
-        file_model_path = cm.new_untitled(path=sub_dir, ext='.txt')['path']
+        file_model_path = cm.new_entity(path=sub_dir, ext='.txt')['path']
         file_model = cm.get(file_model_path)
         self.assertDictContainsSubset(
             {
@@ -425,7 +425,7 @@ class TestContentsManager(TestCase):
     def test_update(self):
         cm = self.contents_manager
         # Create a notebook
-        model = cm.new_untitled(type='notebook')
+        model = cm.new_entity(type='notebook')
         name = model['name']
         path = model['path']
 
@@ -444,7 +444,7 @@ class TestContentsManager(TestCase):
         # Create a directory and notebook in that directory
         sub_dir = '/foo/'
         self.make_dir('foo')
-        model = cm.new_untitled(path=sub_dir, type='notebook')
+        model = cm.new_entity(path=sub_dir, type='notebook')
         path = model['path']
 
         # Change the name in the model for rename
@@ -463,7 +463,7 @@ class TestContentsManager(TestCase):
     def test_save(self):
         cm = self.contents_manager
         # Create a notebook
-        model = cm.new_untitled(type='notebook')
+        model = cm.new_entity(type='notebook')
         name = model['name']
         path = model['path']
 
@@ -482,7 +482,7 @@ class TestContentsManager(TestCase):
         # Create a directory and notebook in that directory
         sub_dir = '/foo/'
         self.make_dir('foo')
-        model = cm.new_untitled(path=sub_dir, type='notebook')
+        model = cm.new_entity(path=sub_dir, type='notebook')
         name = model['name']
         path = model['path']
         model = cm.get(path)
@@ -538,7 +538,7 @@ class TestContentsManager(TestCase):
 
         # Creating a notebook in a non_existant directory should fail
         with self.assertRaisesHTTPError(404):
-            cm.new_untitled("foo/bar_diff", ext=".ipynb")
+            cm.new_entity("foo/bar_diff", ext=".ipynb")
 
         cm.rename("foo/bar", "foo/bar_diff")
 
@@ -556,7 +556,7 @@ class TestContentsManager(TestCase):
             self.check_populated_dir_files(new_dirname)
 
         # Created a notebook in the renamed directory should work
-        cm.new_untitled("foo/bar_diff", ext=".ipynb")
+        cm.new_entity("foo/bar_diff", ext=".ipynb")
 
     def test_delete_root(self):
         cm = self.contents_manager

--- a/notebook/static/edit/js/menubar.js
+++ b/notebook/static/edit/js/menubar.js
@@ -51,7 +51,7 @@ define([
             var w = window.open(undefined, IPython._target);
             // Create a new file in the current directory
             var parent = utils.url_path_split(editor.file_path)[0];
-            editor.contents.new_untitled(parent, {type: "file"}).then(
+            editor.contents.new_entity(parent, {type: "file"}).then(
                 function (data) {
                     w.location = utils.url_path_join(
                         that.base_url, 'edit', utils.encode_uri_components(data.path)

--- a/notebook/static/notebook/js/kernelselector.js
+++ b/notebook/static/notebook/js/kernelselector.js
@@ -304,7 +304,7 @@ define([
         // notebook's path.
         var that = this;
         var parent = utils.url_path_split(that.notebook.notebook_path)[0];
-        that.notebook.contents.new_untitled(parent, {type: "notebook"}).then(
+        that.notebook.contents.new_entity(parent, {type: "notebook"}).then(
             function (data) {
                 var url = utils.url_path_join(
                     that.notebook.base_url, 'notebooks',

--- a/notebook/static/services/contents.js
+++ b/notebook/static/services/contents.js
@@ -112,7 +112,7 @@ define(function(requirejs) {
      *      ext: file extension to use
      *      type: model type to create ('notebook', 'file', or 'directory')
      */
-    Contents.prototype.new_untitled = function(path, options) {
+    Contents.prototype.new_entity = function(path, options) {
         var data = JSON.stringify({
           ext: options.ext,
           type: options.type,

--- a/notebook/static/services/contents.js
+++ b/notebook/static/services/contents.js
@@ -115,7 +115,8 @@ define(function(requirejs) {
     Contents.prototype.new_untitled = function(path, options) {
         var data = JSON.stringify({
           ext: options.ext,
-          type: options.type
+          type: options.type,
+          title: options.title
         });
 
         var settings = {

--- a/notebook/static/tree/js/newnotebook.js
+++ b/notebook/static/tree/js/newnotebook.js
@@ -79,7 +79,7 @@ define([
         kernel_name = kernel_name || this.default_kernel;
         var w = window.open(undefined, IPython._target);
         var dir_path = $('body').attr('data-notebook-path');
-        this.contents.new_untitled(dir_path, {type: "notebook"}).then(
+        this.contents.new_entity(dir_path, {type: "notebook"}).then(
             function (data) {
                 var url = utils.url_path_join(
                     that.base_url, 'notebooks',

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -191,7 +191,7 @@ define([
                 e.preventDefault();
             });
             $('#new-folder').click(function(e) {
-                var input = $('<input/>').attr('type','text').attr('size','25').addClass('form-control');
+                var input = $('<input/>').attr('type','text').attr('size','25').attr('placeholder', 'Untitled Folder').addClass('form-control');
                 var new_dir_msg = i18n.msg._("Enter a new directory name:");
                 var new_dir_title = i18n.msg._("New directory");
                 var dialog_body = $('<div/>').append(
@@ -215,7 +215,8 @@ define([
                         Create : {
                             class: "btn-primary",
                             click: function() {
-                                that.contents.new_entity(that.notebook_path || '', {type: 'directory', title: input.val()})
+                                var new_title = input.val() === "" ? "Untitled Folder" : input.val();
+                                that.contents.new_entity(that.notebook_path || '', {type: 'directory', title: new_title})
                                 .then(function(){
                                     that.load_list();
                                 }).catch(function (e) {

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -191,7 +191,9 @@ define([
                 e.preventDefault();
             });
             $('#new-folder').click(function(e) {
-                that.contents.new_untitled(that.notebook_path || '', {type: 'directory'})
+                var new_title = prompt("New directory:")
+
+                that.contents.new_untitled(that.notebook_path || '', {type: 'directory', title: new_title})
                 .then(function(){
                     that.load_list();
                 }).catch(function (e) {

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -167,7 +167,7 @@ define([
             NotebookList._bound_singletons = true;
             $('#new-file').click(function(e) {
                 var w = window.open('', IPython._target);
-                that.contents.new_untitled(that.notebook_path || '', {type: 'file', ext: '.txt'}).then(function(data) {
+                that.contents.new_entity(that.notebook_path || '', {type: 'file', ext: '.txt'}).then(function(data) {
                     w.location = utils.url_path_join(
                         that.base_url, 'edit',
                         utils.encode_uri_components(data.path)
@@ -192,11 +192,11 @@ define([
             });
             $('#new-folder').click(function(e) {
                 var input = $('<input/>').attr('type','text').attr('size','25').addClass('form-control');
-                var rename_msg = i18n.msg._("Enter a new directory name:");
-                var rename_title = i18n.msg._("New directory");
+                var new_dir_msg = i18n.msg._("Enter a new directory name:");
+                var new_dir_title = i18n.msg._("New directory");
                 var dialog_body = $('<div/>').append(
                     $("<p/>").addClass("rename-message")
-                        .text(rename_msg)
+                        .text(new_dir_msg)
                 ).append(
                     $("<br/>")
                 ).append(input);
@@ -207,7 +207,7 @@ define([
                 var button_labels = [ i18n.msg._("Cancel"), i18n.msg._("Rename"), i18n.msg._("Create"), i18n.msg._("OK"), i18n.msg._("Move")];
 
                 var d = dialog.modal({
-                    title : rename_title,
+                    title : new_dir_title,
                     body : dialog_body,
                     default_button: "Cancel",
                     buttons : {
@@ -215,7 +215,7 @@ define([
                         Create : {
                             class: "btn-primary",
                             click: function() {
-                                that.contents.new_untitled(that.notebook_path || '', {type: 'directory', title: input.val()})
+                                that.contents.new_entity(that.notebook_path || '', {type: 'directory', title: input.val()})
                                 .then(function(){
                                     that.load_list();
                                 }).catch(function (e) {

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -191,27 +191,63 @@ define([
                 e.preventDefault();
             });
             $('#new-folder').click(function(e) {
-                var new_title = prompt("New directory:")
+                var input = $('<input/>').attr('type','text').attr('size','25').addClass('form-control');
+                var rename_msg = i18n.msg._("Enter a new directory name:");
+                var rename_title = i18n.msg._("New directory");
+                var dialog_body = $('<div/>').append(
+                    $("<p/>").addClass("rename-message")
+                        .text(rename_msg)
+                ).append(
+                    $("<br/>")
+                ).append(input);
+        
+                // This statement is used simply so that message extraction
+                // will pick up the strings.  The actual setting of the text
+                // for the button is in dialog.js.
+                var button_labels = [ i18n.msg._("Cancel"), i18n.msg._("Rename"), i18n.msg._("Create"), i18n.msg._("OK"), i18n.msg._("Move")];
 
-                that.contents.new_untitled(that.notebook_path || '', {type: 'directory', title: new_title})
-                .then(function(){
-                    that.load_list();
-                }).catch(function (e) {
-                    dialog.modal({
-                        title: i18n.msg._('Creating Folder Failed'),
-                        body: $('<div/>')
-                            .text(i18n.msg._("An error occurred while creating a new folder."))
-                            .append($('<div/>')
-                                .addClass('alert alert-danger')
-                                .text(e.message || e)),
-                        buttons: {
-                            OK: {'class': 'btn-primary'}
+                var d = dialog.modal({
+                    title : rename_title,
+                    body : dialog_body,
+                    default_button: "Cancel",
+                    buttons : {
+                        Cancel: {},
+                        Create : {
+                            class: "btn-primary",
+                            click: function() {
+                                that.contents.new_untitled(that.notebook_path || '', {type: 'directory', title: input.val()})
+                                .then(function(){
+                                    that.load_list();
+                                }).catch(function (e) {
+                                    dialog.modal({
+                                        title: i18n.msg._('Creating Folder Failed'),
+                                        body: $('<div/>')
+                                            .text(i18n.msg._("An error occurred while creating a new folder."))
+                                            .append($('<div/>')
+                                                .addClass('alert alert-danger')
+                                                .text(e.message || e)),
+                                        buttons: {
+                                            OK: {'class': 'btn-primary'}
+                                        }
+                                    });
+                                    console.warn('Error during New directory creation', e);
+                                });
+                                that.load_sessions();
+                                e.preventDefault();
+                            }
                         }
-                    });
-                    console.warn('Error during New directory creation', e);
+                    },
+                    open : function () {
+                        // Upon ENTER, click the OK button.
+                        input.keydown(function (event) {
+                            if (event.which === keyboard.keycodes.enter) {
+                                d.find('.btn-primary').first().click();
+                                return false;
+                            }
+                        });
+                        input.focus();
+                    }
                 });
-                that.load_sessions();
-                e.preventDefault();
             });
 
             // Bind events for action buttons.


### PR DESCRIPTION
**Description**
resolve #3928 

On the server homepage, prompt for the folder name when creating a new folder instead of creating one with the name 'Untitled Folder'.

Currently the name is set using the already existing method `new_untitled`, which previously would create a new untitled {folder | file | notebook}. It does not make much sense, since we are setting a new name to the folder and, well, it is not untitled anymore. What do you suggest? Do I create a new function? Or rename the existing one?

**EDIT 2018-10-16**
Renamed new_untitled to new_entity and rebuilt naming logic

**Modified Files**
- `notebook/services/contents/handlers.py`
- `notebook/services/contents/manager.py`
- `notebook/static/services/contents.js`
- `notebook/static/tree/js/notebooklist.js`
- `notebook/static/edit/js/menubar.js`
- `notebook/static/notebook/js/kernelselector.js`
- `notebook/static/tree/js/newnotebook.js`

**To Do**
- [x] **Create new function instead of using `new_untitled`. (?)**
- [x] Show Modal DIalog when prompting for folder name instead of native browser prompt.
- [x]  Tests