### PR TITLE
try to fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ before_install:
         tar -xzf geckodriver-v0.19.1-linux64.tar.gz -C geckodriver
         export PATH=$PATH:$PWD/geckodriver
       fi
+    - pip install "attrs>=17.4.0"
 
 install:
     - pip install --pre .[test]


### PR DESCRIPTION
Json schema pre seem to require attrs>17.3.0. 

So pin it in tests. 

Should solve issues of people like @Hyaxia in #4038 

Let's see if the test pass only with this change. 