### PR TITLE
Disable math jax inside fenced code blocks (closes #4037)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ before_install:
         tar -xzf geckodriver-v0.19.1-linux64.tar.gz -C geckodriver
         export PATH=$PATH:$PWD/geckodriver
       fi
+    - pip install "attrs>=17.4.0"
 
 install:
     - pip install --pre .[test]

--- a/notebook/static/notebook/js/mathjaxutils.js
+++ b/notebook/static/notebook/js/mathjaxutils.js
@@ -113,9 +113,12 @@ define([
         var hasCodeSpans = /`/.test(text),
             de_tilde;
         if (hasCodeSpans) {
-            text = text.replace(/~/g, "~T").replace(/(^|[^\\])(`+)([^\n]*?[^`\n])\2(?!`)/gm, function (wholematch) {
+            var tilde = function (wholematch) {
                 return wholematch.replace(/\$/g, "~D");
-            });
+            }
+            text = text.replace(/~/g, "~T")
+                       .replace(/(^|[^\\])(`+)([^\n]*?[^`\n])\2(?!`)/gm, tilde)
+                       .replace(/^\s{0,3}(`{3,})(.|\n)*?\1/gm, tilde);
             de_tilde = function (text) {
                 return text.replace(/~([TD])/g, function (wholematch, character) {
                                                     return { T: "~", D: "$" }[character];

--- a/notebook/tests/notebook/markdown.js
+++ b/notebook/tests/notebook/markdown.js
@@ -106,7 +106,7 @@ casper.notebook_test(function () {
     codeblock = '```python\ns = "$"\nt = "$"\n```'
     result = '<pre><code class="cm-s-ipython language-python">' + 
              '<span class="cm-variable">s</span> <span class="cm-operator">=</span> <span class="cm-string">"$"</span>\n' +
-             '<span class="cm-variable">t</span> <span class="cm-operator">=</span> <span class="cm-string">"$"</span></code></pre>\n';
+             '<span class="cm-variable">t</span> <span class="cm-operator">=</span> <span class="cm-string">"$"</span></code></pre>';
     md_render_test(codeblock, result, 'Markdown code block python');
 
     function mathjax_render_test(input_string, result, message){

--- a/notebook/tests/notebook/markdown.js
+++ b/notebook/tests/notebook/markdown.js
@@ -103,6 +103,10 @@ casper.notebook_test(function () {
     result = '<pre><code class="cm-s-ipython language-aaaa">x = 1</code></pre>'
     md_render_test(codeblock, result, 'Markdown code block unknown language');
 
+    codeblock = '```python\ns = "$"\nt = "$"\n```'
+    result = '<pre><code class="cm-s-ipython language-python"><span class="cm-variable">s</span> <span class="cm-operator">=</span> <span class="cm-string">"$"</span>\n<span class="cm-variable">t</span> <span class="cm-operator">=</span> <span class="cm-string">"$"</span></code></pre>\n';
+    md_render_test(codeblock, result, 'Markdown code block python');
+
     function mathjax_render_test(input_string, result, message){
       casper.thenEvaluate(function (text){
         window._test_result = null;

--- a/notebook/tests/notebook/markdown.js
+++ b/notebook/tests/notebook/markdown.js
@@ -104,7 +104,9 @@ casper.notebook_test(function () {
     md_render_test(codeblock, result, 'Markdown code block unknown language');
 
     codeblock = '```python\ns = "$"\nt = "$"\n```'
-    result = '<pre><code class="cm-s-ipython language-python"><span class="cm-variable">s</span> <span class="cm-operator">=</span> <span class="cm-string">"$"</span>\n<span class="cm-variable">t</span> <span class="cm-operator">=</span> <span class="cm-string">"$"</span></code></pre>\n';
+    result = '<pre><code class="cm-s-ipython language-python">' + 
+             '<span class="cm-variable">s</span> <span class="cm-operator">=</span> <span class="cm-string">"$"</span>\n' +
+             '<span class="cm-variable">t</span> <span class="cm-operator">=</span> <span class="cm-string">"$"</span></code></pre>\n';
     md_render_test(codeblock, result, 'Markdown code block python');
 
     function mathjax_render_test(input_string, result, message){


### PR DESCRIPTION
Any text between $ characters within markdown seems to be rendered in tex math mode using MathJax. However, within code blocks with language specified (e.g., enclosed by ```python and ```), this is almost always the wrong choice. Further, tt interacts badly with any syntax highlighting.

This PR disables MathJax processing within fenced code blocks. This should fix #4038 