### PR TITLE
closes #4029: implement optional markdown header and footer files

### DIFF
--- a/docs/source/examples/Notebook/header.md
+++ b/docs/source/examples/Notebook/header.md
@@ -1,0 +1,4 @@
+# Notebook Examples
+
+The pages in this section are all converted notebook files. You can also
+[view these notebooks on nbviewer](http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/)

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -542,8 +542,6 @@ define([
 	span12.empty();
 	that.contents.get(list_item.path, {"content": true}).then(
           function (data) {
-	    // input_area.getDoc().setValue(data.content);
-	    // span12.append($('<div style="margin:auto;text-align:center;color:grey"/>').text(data.content));
 	    span12.append($('<div style="margin:auto;text-align:center;color:grey"/>').innerHTML = marked(data.content));
 	  },
           function(error) {


### PR DESCRIPTION
I took a stab at implementing header and footer support from #4029. Comments appreciated. I'll add documentation to this PR after I get feedback that this change is welcomed.

```
$ jupyter notebook --debug docs/source/examples/Notebook/
```

![selection_176](https://user-images.githubusercontent.com/109453/46123475-a4168680-c1d3-11e8-91f5-49a4eb08c592.png)
