### PR TITLE
update marked to 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ before_install:
         tar -xzf geckodriver-v0.19.1-linux64.tar.gz -C geckodriver
         export PATH=$PATH:$PWD/geckodriver
       fi
+    - pip install "attrs>=17.4.0"
 
 install:
     - pip install --pre .[test]

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "jquery": "components/jquery#~3.3",
     "jquery-typeahead": "~2.0.0",
     "jquery-ui": "components/jqueryui#~1.12",
-    "marked": "~0.4",
+    "marked": "~0.5",
     "MathJax": "^2.7.4",
     "moment": "~2.19.3",
     "preact": "https://unpkg.com/preact@^7.2.0/dist/preact.min.js",


### PR DESCRIPTION
Changed 'marked' dependency version to 0.5 August release for fixing rendering bugs of formatted markdown cells.

closes #3874