### PR TITLE
Include status types when logging activity

### DIFF
--- a/notebook/services/kernels/kernelmanager.py
+++ b/notebook/services/kernels/kernelmanager.py
@@ -405,9 +405,11 @@ class MappingKernelManager(MultiKernelManager):
             msg = session.deserialize(fed_msg_list)
 
             msg_type = msg['header']['msg_type']
-            self.log.debug("activity on %s: %s", kernel_id, msg_type)
             if msg_type == 'status':
                 kernel.execution_state = msg['content']['execution_state']
+                self.log.debug("activity on %s: %s (%s)", kernel_id, msg_type, kernel.execution_state)
+            else:
+                self.log.debug("activity on %s: %s", kernel_id, msg_type)
 
         kernel._activity_stream.on_recv(record_activity)
 


### PR DESCRIPTION
Recently I needed to troubleshoot kernel responses and found it helpful
to distinguish status types (busy vs. idle) - thought others might find
it useful as well.

Entries that previously appeared as...
```
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: status
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: status
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: status
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: status
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: execute_input
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: display_data
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: execute_result
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: status
```
will now appear as...
```
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: status (idle)
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: status (busy)
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: status (idle)
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: status (busy)
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: execute_input
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: display_data
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: execute_result
 activity on 33383dcc-c054-4dc0-b842-16063ea160fe: status (idle)
```