### PR TITLE
Add info about messaging specs

### DIFF
--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -19,6 +19,9 @@ define([
      * Preliminary documentation for the REST API is at
      * https://github.com/ipython/ipython/wiki/IPEP-16%3A-Notebook-multi-directory-dashboard-and-URL-mapping#kernels-api
      * 
+     * Documentation for the messaging specifications is at
+     * https://jupyter-client.readthedocs.io/en/stable/messaging.html
+     *
      * @class Kernel
      * @param {string} kernel_service_url - the URL to access the kernel REST api
      * @param {string} ws_url - the websockets URL


### PR DESCRIPTION
I found it very useful to read https://jupyter-client.readthedocs.io/en/stable/messaging.html in order to understand what is happening here. What do you think?