### PR TITLE
Kernel ram metric

### DIFF
--- a/notebook/prometheus/metrics.py
+++ b/notebook/prometheus/metrics.py
@@ -25,3 +25,9 @@ KERNEL_CURRENTLY_RUNNING_TOTAL = Gauge(
     'counter for how many kernels are running labeled by type',
     ['type']
 )
+
+KERNEL_RAM_USAGE_MB = Gauge(
+    'kernel_ram_usage_mb',
+    'shows how much RAM in MB per kernel',
+    ['kernel_id', 'type']
+)

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,8 @@ for more information.
         'ipykernel', # bless IPython kernel for now
         'Send2Trash',
         'terminado>=0.8.1',
-        'prometheus_client'
+        'prometheus_client',
+        'psutil'
     ],
     extras_require = {
         ':python_version == "2.7"': ['ipaddress'],


### PR DESCRIPTION
I have added a metric for the RAM per kernel.
Each kernel appears alone identified by his id and type.
I have chose to implement the monitoring by a background task with the tornado framework.
As soon as you start the notebook it will all the running kernels.
Every 0.2 seconds it will set the RAM usage of the specific kernel to what is uses at that moment.
Additionally, the way i check the ram of each process is with the `psutil` package.
I have found that this was the easiest way, if you guys have something else in mind please 

relevant issue #3682
