### PR TITLE
Fix copy/paste-ability of default URL presented on startup

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1439,7 +1439,9 @@ class NotebookApp(JupyterApp):
         if self.token:
             # Don't log full token if it came from config
             token = self.token if self._token_generated else '...'
-            url = url_concat(url, {'token': token})
+            url = (url_concat(url, {'token': token})
+                  + '\n or '
+                  + url_concat(self._url('127.0.0.1'), {'token': token}))
         return url
 
     @property

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1432,7 +1432,7 @@ class NotebookApp(JupyterApp):
                 url += '/'
         else:
             if self.ip in ('', '0.0.0.0'):
-                ip = "(%s or 127.0.0.1)" % socket.gethostname()
+                ip = "%s" % socket.gethostname()
             else:
                 ip = self.ip
             url = self._url(ip)


### PR DESCRIPTION
Currently the default URL message given on the console on startup is:


Copy/paste this URL into your browser when you connect for the first time,
    to login with a token:
        http://(myip.com or 127.0.0.1):8888/?token=8fdc8 ...


This will always need editing to use. Replace brackets/ 'or' part with host IP (e.g. 'myip.com')
to make it copy/pastable again.