### PR TITLE
Enable login mode for terminal - to automatically source the /etc/profile script

### DIFF
--- a/notebook/terminal/__init__.py
+++ b/notebook/terminal/__init__.py
@@ -21,6 +21,9 @@ def initialize(webapp, notebook_dir, connection_url, settings):
     shell = settings.get('shell_command',
         [os.environ.get('SHELL') or default_shell]
     )
+    # Enable login mode - to automatically source the /etc/profile script
+    if os.name != 'nt':
+        shell.append('-l')
     terminal_manager = webapp.settings['terminal_manager'] = NamedTermManager(
         shell_command=shell,
         extra_env={'JUPYTER_SERVER_ROOT': notebook_dir,


### PR DESCRIPTION
Jupyter's terminal does not source in a vast majority of environment variables defined in `/etc/profile` and `/etc/profile.d`. According to sh & bash docs, these locations are sourced by "login" or "interactive" terminals. Being technically an interactive terminal, Jupyter's terminado should use interactive mode by default.

Consider for example CUDA toolkit, which is usually added into PATH using /etc/profile.d script. Without sourcing it, Jupyter terminal would confuse users not being able to find CUDA compiler.