### PR TITLE
Corrected alt-text of "replace in all cells"

### DIFF
--- a/notebook/static/notebook/js/searchandreplace.js
+++ b/notebook/static/notebook/js/searchandreplace.js
@@ -167,7 +167,7 @@ define([
       .attr('type', 'button')
       .addClass("btn btn-default btn-sm")
       .attr('data-toggle','button')
-      .attr('title', i18n.msg._('Replace in selected cells'));
+      .attr('title', i18n.msg._('Replace in all cells'));
 
     var isCaseSensitiveButton = $('<button/>')
       .attr('type', 'button')


### PR DESCRIPTION
When using the (great) "Find and Replace" function in the notebook, there is a button one can click to replace text in **all** cells, not only the selected one.

It's alt-text ("hover-text") says that it does the opposite of what it does, as seen in the image. In the image the button is not been selected and only finds one of the two "hello" instances.

![image](https://user-images.githubusercontent.com/2721423/47210036-1f61f700-d392-11e8-8d0a-c9cc9a553160.png)
