### PR TITLE
Start working on ability to have async_start_kernel in KernelManagers.

### DIFF
--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -87,7 +87,7 @@ class KernelActionHandler(APIHandler):
 
             try:
                 res = km.restart_kernel(kernel_id)
-                if res is not None
+                if res is not None:
                     yield from res
             except Exception as e:
                 self.log.error("Exception restarting kernel", exc_info=True)

--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -29,7 +29,11 @@ class MainKernelHandler(APIHandler):
     @gen.coroutine
     def get(self):
         km = self.kernel_manager
-        kernels = yield gen.maybe_future(km.list_kernels())
+        res = km.list_kernels()
+        if not isinstance(res, list):
+            kernels = res
+        else:
+            kernels = yield res
         self.finish(json.dumps(kernels, default=date_default))
 
     @web.authenticated
@@ -82,7 +86,9 @@ class KernelActionHandler(APIHandler):
         if action == 'restart':
 
             try:
-                yield gen.maybe_future(km.restart_kernel(kernel_id))
+                res = km.restart_kernel(kernel_id)
+                if res is not None
+                    yield from res
             except Exception as e:
                 self.log.error("Exception restarting kernel", exc_info=True)
                 self.set_status(500)

--- a/notebook/services/kernels/kernelmanager.py
+++ b/notebook/services/kernels/kernelmanager.py
@@ -160,9 +160,9 @@ class MappingKernelManager(MultiKernelManager):
                 kwargs['cwd'] = self.cwd_for_path(path)
             
             sup =  super(MappingKernelManager, self)
-            async_sk = getattr(sup, 'async_start_kernel', None)
+            async_sk = getattr(sup, 'start_kernel_async', None)
             if async_sk is not None:
-                res = super().async_start_kernel(**kwargs)
+                res = super().start_kernel_async(**kwargs)
             else:
                 res = super().start_kernel(**kwargs)
 


### PR DESCRIPTION
I would like to have ability to have async function in there in
particular because I need to start a kernel via slurm, and I don not kow
ahead of time which node it is going to be schedule on.

So far most of the solutions there are hacky and require having ssh
tunnels, which I would like to avoid. As so far the start_kernel
function already setup and connect ports it requires to be made async,
or deeply change the API.

I went with creating and checking for a second 'async_start_kernel' on
super, as it is MultiKernelManager in jupyter_clienc, and changing
`start_kernel` to be a coroutine function would be a break of API.

I have a patch on jupyter_client that itself check whether prorper kernel
manager start_kernel function are coroutine functions or not.

In the long run this should allow to progressively migrate
jupyter_client to use and async start_kernel, but we can't yet as anyway
we still support 2.7 on jupyter-Client.

Note that gen.maybe_future in tornado is deprecated, and it is
recommended to check for results and yield unknown objects:

    Deprecated since version 4.3: This function only handles Futures,
    not other yieldable objects. Instead of maybe_future, check for the
    non-future result types you expect (often just None), and yield
    anything unknown

The kernel_id is a Unicode Traitlet so unless subclass overwite that
should be fine.