### PR TITLE
Default to right table alignment but allow table local overrides

### DIFF
--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -732,7 +732,8 @@ define([
         var renderer = new marked.Renderer();
         renderer.tablecell = function (content, flags) {
           var type = flags.header ? 'th' : 'td';
-          var start_tag = '<' + type + '>';
+          var style = flags.align == null ? '': ' style="text-align: ' + flags.align + '"';
+          var start_tag = '<' + type + style + '>';
           var end_tag = '</' + type + '>\n';
           return start_tag + content + end_tag;
         };

--- a/notebook/static/notebook/js/textcell.js
+++ b/notebook/static/notebook/js/textcell.js
@@ -395,7 +395,8 @@ define([
             var renderer = new marked.Renderer();
             renderer.tablecell = function (content, flags) {
               var type = flags.header ? 'th' : 'td';
-              var start_tag = '<' + type + '>';
+              var style = flags.align == null ? '': ' style="text-align: ' + flags.align + '"';
+              var start_tag = '<' + type + style + '>';
               var end_tag = '</' + type + '>\n';
               return start_tag + content + end_tag;
             };


### PR DESCRIPTION
Allow markdown tables to specify their alignment with the `:--`, `:--:`, `--:` syntax while still allowing `---` to default to `right` alignment.

This reverts a previous change (part of #2534) that stripped the alignment information from the rendered HTML coming out of the marked renderer. To be clear this does not change the `right` alignment default but does bring back support for overriding this alignment per column by using the gfm table alignment syntax.

Since the default is defined as a css rule, the `align` attribute would no longer override that and as such this PR uses an inline `style` with the appropriate `text-align` instead. Caja by default whitelists `text-align` so the style is not stripped during sanitation. 

The alignment is properly captured in display data:

```python
from IPython.core.display import Markdown

display(Markdown('''
| None | Right | Left | Center |
|------|------:|:-----|:------:|
| 0    | 1     | 2    | 3      |
'''))
```

as well as in a markdown cell:

```markdown
| None | Right | Left | Center |
|------|------:|:-----|:------:|
| 0    | 1     | 2    | 3      |
```

both render as

| None | Right | Left | Center |
|-----:|------:|:-----|:------:|
| 0    | 1     | 2    | 3      |

Fixes #3919 (and the prior #3024). 