### PR TITLE
Fix default value method for `allow_remote_access` when ip is '*'

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -865,6 +865,12 @@ class NotebookApp(JupyterApp):
     @default('allow_remote_access')
     def _default_allow_remote(self):
         """Disallow remote access if we're listening only on loopback addresses"""
+
+        # if blank, self.ip was configured to "*" meaning bind to all interfaces,
+        # see _valdate_ip
+        if self.ip == "":
+            return True
+
         try:
             addr = ipaddress.ip_address(self.ip)
         except ValueError:


### PR DESCRIPTION
Fixes #3946.  When the config value for `ip` is set to `*`, meaning listen on all interfaces, it causes the default value method for the `allow_remote_access` config option to fail. This PR adds a short circuit for that default value method.

I didn't see an obvious place to put a new test, but on my local machine, this actually fixes a currently failing one.