### PR TITLE
Updated the description of Heading cells, which are no longer used

### DIFF
--- a/docs/source/examples/Notebook/What is the Jupyter Notebook.ipynb
+++ b/docs/source/examples/Notebook/What is the Jupyter Notebook.ipynb
@@ -146,7 +146,7 @@
     "\n",
     "* **Code cells:** Input and output of live code that is run in the kernel\n",
     "* **Markdown cells:** Narrative text with embedded LaTeX equations\n",
-    "* **Heading cells:** 6 levels of hierarchical organization and formatting\n",
+    "* **Heading cells:** Jupyter no longer uses special heading cells. Instead, write your headings in Markdown cells using # characters\n",
     "* **Raw cells:** Unformatted text that is included, without modification, when notebooks are converted to different formats using nbconvert\n",
     "\n",
     "Internally, notebook documents are **[JSON](https://en.wikipedia.org/wiki/JSON) data** with **binary values [base64](http://en.wikipedia.org/wiki/Base64)** encoded. This allows them to be **read and manipulated programmatically** by any programming language. Because JSON is a text format, notebook documents are version control friendly.\n",
@@ -173,9 +173,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.0"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/docs/source/examples/Notebook/What is the Jupyter Notebook.ipynb
+++ b/docs/source/examples/Notebook/What is the Jupyter Notebook.ipynb
@@ -153,7 +153,7 @@
     "\n",
     "**Notebooks can be exported** to different static formats including HTML, reStructeredText, LaTeX, PDF, and slide shows ([reveal.js](http://lab.hakim.se/reveal-js/)) using Jupyter's `nbconvert` utility.\n",
     "\n",
-    "Furthermore, any notebook document available from a **public URL on or GitHub can be shared** via [nbviewer](http://nbviewer.jupyter.org). This service loads the notebook document from the URL and renders it as a static web page. The resulting web page may thus be shared with others **without their needing to install the Jupyter Notebook**."
+    "Furthermore, any notebook document available from a **public URL or on GitHub can be shared** via [nbviewer](http://nbviewer.jupyter.org). This service loads the notebook document from the URL and renders it as a static web page. The resulting web page may thus be shared with others **without their needing to install the Jupyter Notebook**."
    ]
   }
  ],

--- a/docs/source/examples/Notebook/What is the Jupyter Notebook.ipynb
+++ b/docs/source/examples/Notebook/What is the Jupyter Notebook.ipynb
@@ -142,11 +142,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notebooks consist of a **linear sequence of cells**. There are four basic cell types:\n",
+    "Notebooks consist of a **linear sequence of cells**. There are three basic cell types:\n",
     "\n",
     "* **Code cells:** Input and output of live code that is run in the kernel\n",
     "* **Markdown cells:** Narrative text with embedded LaTeX equations\n",
-    "* **Heading cells:** Jupyter no longer uses special heading cells. Instead, write your headings in Markdown cells using # characters\n",
     "* **Raw cells:** Unformatted text that is included, without modification, when notebooks are converted to different formats using nbconvert\n",
     "\n",
     "Internally, notebook documents are **[JSON](https://en.wikipedia.org/wiki/JSON) data** with **binary values [base64](http://en.wikipedia.org/wiki/Base64)** encoded. This allows them to be **read and manipulated programmatically** by any programming language. Because JSON is a text format, notebook documents are version control friendly.\n",


### PR DESCRIPTION
Heading cells don't exist anymore, so I've updated the "What is the Jupyter Notebook" example to describe them in the same way that jupyter describes them when you try to set a cell to type "Heading"