### PR TITLE
Fix for the terminal shutdown issue

### DIFF
--- a/notebook/terminal/handlers.py
+++ b/notebook/terminal/handlers.py
@@ -40,3 +40,8 @@ class TermSocket(WebSocketMixin, IPythonHandler, terminado.TermSocket):
     def write_message(self, message, binary=False):
         super(TermSocket, self).write_message(message, binary=binary)
         self.application.settings['terminal_last_activity'] = utcnow()
+
+    def open(self, url_component=None):
+        if not url_component in self.term_manager.terminals:
+            raise web.HTTPError(404)
+        return super(TermSocket, self).open(url_component)


### PR DESCRIPTION
This fixes an error that prevents a terminal from being properly shut down in JupyterLab as reported in [issue 5061](https://github.com/jupyterlab/jupyterlab/issues/5061). This is caused by automatic terminal creation upon a websocket opening request, which is the default behavior of the `NamedTermManager` of `terminado` when the client requests a nonexistent websocket connection. 