### PR TITLE
Add bracket autocompletion to codemirror config of text cell

### DIFF
--- a/notebook/static/notebook/js/textcell.js
+++ b/notebook/static/notebook/js/textcell.js
@@ -74,7 +74,9 @@ define([
     TextCell.options_default = {
         cm_config : {
             mode: 'htmlmixed',
-            lineWrapping : true,
+            lineWrapping: true,
+            matchBrackets: true,
+            autoCloseBrackets: true
         }
     };
 


### PR DESCRIPTION
Typing parentheses/quotes around selected text in markdown or raw text cell surrounds it with parentheses. Brackets will also be auto-completed and matching will be highlighted. 

Fix for Issue #4023