### PR TITLE
Fix for the terminal shutdown issue

### DIFF
--- a/notebook/terminal/handlers.py
+++ b/notebook/terminal/handlers.py
@@ -31,6 +31,8 @@ class TermSocket(WebSocketMixin, IPythonHandler, terminado.TermSocket):
     def get(self, *args, **kwargs):
         if not self.get_current_user():
             raise web.HTTPError(403)
+        if not args[0] in self.term_manager.terminals:
+            raise web.HTTPError(404)
         return super(TermSocket, self).get(*args, **kwargs)
 
     def on_message(self, message):


### PR DESCRIPTION
This PR is aimed to fix the problem of Zombie terminal as reported in [issue 5061](https://github.com/jupyterlab/jupyterlab/issues/5061) of JupyterLab. It adds checking for the parameter of websocket request against existing terminals in order to avoid unexpected creation of terminals. According to the issue report, the `xtermjs` client tries to recreate the websocket connection after termination of the shell process, which then triggers the creation of another terminal (shell process) on the server.

The issue can also be "fixed" in the upstream project `terminado`, in which the default behavior of `NamedTermManager` is to automatically start a new terminal in response to a websocket handshake. However, the fix proposed in this PR is cleaner and more efficient.