### PR TITLE
Fix typo in nbjs.po

### DIFF
--- a/notebook/i18n/zh_CN/LC_MESSAGES/nbjs.po
+++ b/notebook/i18n/zh_CN/LC_MESSAGES/nbjs.po
@@ -284,7 +284,7 @@ msgstr "粘贴代码块"
 #: notebook/static/notebook/js/actions.js:237
 #: notebook/static/notebook/js/actions.js:238
 msgid "split cell at cursor"
-msgstr "在鼠标出分割代码块"
+msgstr "在鼠标处分割代码块"
 
 #: notebook/static/notebook/js/actions.js:245
 #: notebook/static/notebook/js/actions.js:246


### PR DESCRIPTION
`出` is a typo of `处` in Chinese with same pronunciation. It's a common mistake with some Chinese input methods.