### PR TITLE
Fix ui-icons from blocking tooltip text

### DIFF
--- a/notebook/static/notebook/less/tooltip.less
+++ b/notebook/static/notebook/less/tooltip.less
@@ -85,7 +85,9 @@
 .tooltiptext
 {
     /*avoid the button to overlap on some docstring*/
-    padding-right:30px
+    padding-right:30px;
+     /*avoid the ui-icon(s) from overlapping the tooltip*/
+     padding-top:30px;
 }
 
 .ipython_tooltip {


### PR DESCRIPTION
closes #4230.

![screenshot from 2018-11-26 17-38-18](https://user-images.githubusercontent.com/25018435/49046641-ca8c7a00-f1a2-11e8-8911-6d404d02aa2c.png)

Fix looks like the above. 