### PR TITLE
Optimize large file uploads

### DIFF
--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -1314,7 +1314,8 @@ define([
 
                     var parse_large_file = function (f, item) {
                         // codes inspired by https://stackoverflow.com/a/28318964
-                        var chunk_size = 1024 * 1024;
+                        // 8MB chunk size chosen to match chunk sizes used by benchmark reference (AWS S3)
+                        var chunk_size = 1024 * 1024 * 8;
                         var offset = 0;
                         var chunk = 0;
                         var chunk_reader = null;

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -1365,18 +1365,25 @@ define([
                             reader.onerror = on_error;
                         };
 
+                        // This approach avoids triggering multiple GC pauses for large files.
+                        // Borrowed from kanaka's answer at:
+                        // https://stackoverflow.com/questions/12710001/how-to-convert-uint8-array-to-base64-encoded-string
+                        var  Uint8ToString = function(u8a){
+                            var CHUNK_SZ = 0x8000;
+                            var c = [];
+                            for (var i=0; i < u8a.length; i+=CHUNK_SZ) {
+                              c.push(String.fromCharCode.apply(null, u8a.subarray(i, i+CHUNK_SZ)));
+                            }
+                            return c.join("");
+                        };
+
                         // These codes to upload file in original class
                         var upload_file = function(item, chunk) {
                             var filedata = item.data('filedata');
                             if (filedata instanceof ArrayBuffer) {
                                 // base64-encode binary file data
-                                var bytes = '';
                                 var buf = new Uint8Array(filedata);
-                                var nbytes = buf.byteLength;
-                                for (var i=0; i<nbytes; i++) {
-                                    bytes += String.fromCharCode(buf[i]);
-                                }
-                                filedata = btoa(bytes);
+                                filedata = btoa(Uint8ToString(buf));
                                 format = 'base64';
                             }
                             var model = { name: filename, path: path };


### PR DESCRIPTION
This PR seeks to make two optimizations to the JS code for uploading large files using the Upload function in `notebooklist.js`. 

### Avoiding GC Pauses when Reading File
When the current version of the code is run in Chrome it triggers several GC pauses while converting Uint8 bytes into a String of Characters before that string is base64 encoded and wrapped in JSON to be uploaded

The original code in question is:
```
// base64-encode binary file data
var bytes = '';
var buf = new Uint8Array(filedata);
var nbytes = buf.byteLength;
for (var i=0; i<nbytes; i++) {
    bytes += String.fromCharCode(buf[i]); // This line triggers GC pauses.
}
filedata = btoa(bytes);
```

It turns out that Chrome's GC will pretty consistently pause on the line in the loop which converts a byte into a single character string and then concatenates it to the `bytes`. 

I believe this happens b/c Chrome's GC will sometimes perform GC on string concatenations, and the current approach results in a lot of those (> 1 million for each 1 MB chunk). 

I profiled this in Chrome's devtools by uploading a 128MB file to a Jupyter notebook running on `localhost` (my MacBook Pro) to avoid any network constraints. The profiler shows that each 1MB chunk upload triggers Minor GC 4-5 times, and that these pauses account for the vast majority of the time spent in a single Chunk's upload time. 

In this example you can see GC pauses taking 105ms of the total 148ms `upload_file` call. 
<img width="1284" alt="1mb unoptimized" src="https://user-images.githubusercontent.com/1577197/49471967-46f30e80-f7dc-11e8-9a66-b2258d95f810.png">

My change (7a42187) uses a more GC efficient approach (borrowed from https://stackoverflow.com/questions/12710001/how-to-convert-uint8-array-to-base64-encoded-string) to convert raw UInt8s into Strings to be base64 encoded.

This approach speeds uploads up significantly. In this example there is only 1 very short GC pause, and the total exec time for `upload_file` is cut down to 34ms from 148ms. 
<img width="1283" alt="1mb optimized" src="https://user-images.githubusercontent.com/1577197/49472194-c84aa100-f7dc-11e8-9635-199ad26f11b0.png">

This has the affect of more than doubling the throughput of files being uploaded this way! At least when not constrained by realistic network conditions.

### Increasing the upload chunk size from 1MB to 8MB.
After implementing the previous optimization, I also tried varying the size of the chunks that are uploaded, and noticed that sending larger chunks of data also increases throughput. The effect is somewhat minor when tested entirely on `localhost`, but on over the internet the speed up is pretty significant. 

When testing locally I noticed that using 8MB chunk sizes speeds things up ~30%:
```
# localhost
2100ms to upload 32MB (1MB chunk) = 15.24 MB/s
1600ms to upload 32MB (8mb chunk) = 20 MB/s
```

Over the internet connection in my test environment 8MB chunks speeds things up ~200%:
```
# test network
12900ms for 32MB (1mb chunk) = 2.48MB/s
4377ms for 32MB (8mb chunk) = 7.3MB/s
```
FWIW, AWS S3 uses 8MB chunks when uploading using their JS client so 8MB seems reasonable to use here. 

### Summary
In my tests over a real internet connection in my environment these two optimizations combined speed up large file uploads ~248%! 

### Future work
This could be improved even further if the upload code were to be refactored to upload raw bytes instead of a base64 encoded string, since base64 encoding raw data increases the size ~30%. So for each MB of raw data that the current code needs to upload, it actually needs to upload 1.3MB of base64 encoded data. But that should be a seperate PR imo. 