### PR TITLE
Respect parent template headercontainer in child pages

### DIFF
--- a/notebook/templates/edit.html
+++ b/notebook/templates/edit.html
@@ -19,13 +19,13 @@ data-file-path="{{file_path}}"
 {% endblock %}
 
 {% block headercontainer %}
-{{super()}}
 
 <span id="save_widget" class="pull-left save_widget">
     <span class="filename"></span>
     <span class="last_modified"></span>
 </span>
 
+{{super()}}
 {% endblock %}
 
 {% block header %}

--- a/notebook/templates/edit.html
+++ b/notebook/templates/edit.html
@@ -19,6 +19,7 @@ data-file-path="{{file_path}}"
 {% endblock %}
 
 {% block headercontainer %}
+{{super()}}
 
 <span id="save_widget" class="pull-left save_widget">
     <span class="filename"></span>

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -36,7 +36,6 @@ data-notebook-path="{{notebook_path | urlencode}}"
 
 
 {% block headercontainer %}
-{{super()}}
 
 
 <span id="save_widget" class="save_widget">
@@ -44,6 +43,8 @@ data-notebook-path="{{notebook_path | urlencode}}"
     <span class="checkpoint_status"></span>
     <span class="autosave_status"></span>
 </span>
+
+{{super()}}
 
 <span id="kernel_logo_widget">
   {% block kernel_logo_widget %}

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -36,6 +36,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
 
 
 {% block headercontainer %}
+{{super()}}
 
 
 <span id="save_widget" class="save_widget">

--- a/notebook/templates/terminal.html
+++ b/notebook/templates/terminal.html
@@ -19,6 +19,7 @@ data-ws-path="{{ws_path}}"
 {% endblock %}
 
 {% block headercontainer %}
+{{super()}}
 <span id="save_widget" class="save_widget"></span>
 {% endblock headercontainer %}
 

--- a/notebook/templates/terminal.html
+++ b/notebook/templates/terminal.html
@@ -19,8 +19,8 @@ data-ws-path="{{ws_path}}"
 {% endblock %}
 
 {% block headercontainer %}
-{{super()}}
 <span id="save_widget" class="save_widget"></span>
+{{super()}}
 {% endblock headercontainer %}
 
 {% block site %}

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -12,6 +12,7 @@ data-server-root="{{server_root}}"
 {% endblock %}
 
 {% block headercontainer %}
+{{super()}}
   <span class="flex-spacer"></span>
   {% if shutdown_button %}
     <span id="shutdown_widget">

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -12,8 +12,8 @@ data-server-root="{{server_root}}"
 {% endblock %}
 
 {% block headercontainer %}
-{{super()}}
   <span class="flex-spacer"></span>
+  {{super()}}
   {% if shutdown_button %}
     <span id="shutdown_widget">
       <button id="shutdown" class="btn btn-sm navbar-btn"


### PR DESCRIPTION
Child pages currently override `headercontainer` blocks from `page`. If, for example, you were to use jupyterhub's `page` template override to label a container image, it won't be shown as all child pages override `headercontainer` without respecting the parent's block. Adding `{{super()}}` allows you to set `headercontainer` in `page` and have it persist in child pages.

Extremely poorly aligned, unformatted example after adding `{{super()}}`:
![image](https://user-images.githubusercontent.com/5308250/49546137-2e9af680-f8a5-11e8-88ae-07b9be7eaaae.png)

----

Alternatively, you could use imagemagick to build a text image from a build arg in docker and mosaic it with a jupyterhub logo and then replace jupyterhub's `{{logo_url}}` with that image in base64. It works perfectly, but it adds 13KB to each page load in my case and I'd prefer something more minimal like plaintext. But it is a hilarious solution and I love it, so here it is anyway:
```
ARG BASE_CONTAINER=jupyter/minimal-notebook
FROM $BASE_CONTAINER

USER root

RUN apt-get update && apt-get install -yq --no-install-recommends \
   imagemagick pngcrush \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
ARG IMAGE_LABEL="UNLABELD CONTAINER IMAGE 🚱"
ADD logo.png /tmp/logo.png
RUN convert -font Courier -pointsize 42 -background none "label:$IMAGE_LABEL" /tmp/label.png \
	&& montage /tmp/logo.png -label '' /tmp/label.png -background none -geometry +1+1 /tmp/built_logo.png \
	&& pngcrush /tmp/built_logo.png /tmp/crushed_logo.png \
	&& sed -e "s|{{logo_url}}|data:image/png;base64,$(base64 /tmp/crushed_logo.png | tr -d '\n')|" -i $(find "$CONDA_DIR/lib/" -path '*/jupyterhub/singleuser.py' | head -n 1)
```
![image](https://user-images.githubusercontent.com/5308250/49546776-a1f13800-f8a6-11e8-9454-e5296aab8a53.png)
