### PR TITLE
Add Documentation regarding backslash escaping in Markdown File

### DIFF
--- a/docs/source/examples/Notebook/Working With Markdown Cells.ipynb
+++ b/docs/source/examples/Notebook/Working With Markdown Cells.ipynb
@@ -93,13 +93,27 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And shorthand for links:\n",
-    "\n",
-    "[Jupyter's website](http://jupyter.org)"
-   ]
+    "cell_type": "markdown",
+    "metadata": { },
+    "source": [
+      "And shorthand for links:\n",
+      "\n",
+      "[Jupyter's website](http://jupyter.org)"
+    ]
+  },
+  {
+    "cell_type": "markdown",
+    "metadata": { },
+    "source": [
+      "You can use backslash \\ to generate literal characters which would otherwise have special meaning in the Markdown syntax.\n",
+      "\n",
+      "```\n",
+      "\\*literal asterisks\\*\n",
+      " *literal asterisks*\n",
+      "```\n",
+      "\n",
+      "Use double backslash \\ \\ to generate the literal $ symbol."
+    ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Adds a small section on how to generate literal characters of the characters used in the Markdown Syntax.
Also includes how to escape the $ symbol as mentioned in Issue #4244.