### PR TITLE
Launch the browser with a redirect file

### DIFF
--- a/notebook/auth/login.py
+++ b/notebook/auth/login.py
@@ -204,16 +204,10 @@ class LoginHandler(IPythonHandler):
             return
         # check login token from URL argument or Authorization header
         user_token = cls.get_token(handler)
-        one_time_token = handler.one_time_token
         authenticated = False
         if user_token == token:
             # token-authenticated, set the login cookie
             handler.log.debug("Accepting token-authenticated connection from %s", handler.request.remote_ip)
-            authenticated = True
-        elif one_time_token and user_token == one_time_token:
-            # one-time-token-authenticated, only allow this token once
-            handler.settings.pop('one_time_token', None)
-            handler.log.info("Accepting one-time-token-authenticated connection from %s", handler.request.remote_ip)
             authenticated = True
 
         if authenticated:

--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -181,11 +181,6 @@ class AuthenticatedHandler(web.RequestHandler):
         return self.settings.get('token', None)
 
     @property
-    def one_time_token(self):
-        """Return the one-time-use token for this application, if any."""
-        return self.settings.get('one_time_token', None)
-
-    @property
     def login_available(self):
         """May a user proceed to log in?
 
@@ -475,7 +470,7 @@ class IPythonHandler(AuthenticatedHandler):
             logged_in=self.logged_in,
             allow_password_change=self.settings.get('allow_password_change'),
             login_available=self.login_available,
-            token_available=bool(self.token or self.one_time_token),
+            token_available=bool(self.token),
             static_url=self.static_url,
             sys_info=json_sys_info(),
             contents_js_source=self.contents_js_source,

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1805,8 +1805,9 @@ class NotebookApp(JupyterApp):
             # with auth info.
             self.log.critical('\n'.join([
                 '\n',
-                'Copy/paste this URL into your browser when you connect for the first time,',
-                'to login with a token:',
+                'To access the notebook, open this file in a browser:',
+                '    %s' % urljoin('file:', pathname2url(self.browser_open_file)),
+                'Or copy and paste one of these URLs:',
                 '    %s' % self.display_url,
             ]))
 

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1718,7 +1718,7 @@ class NotebookApp(JupyterApp):
 
     def _write_browser_open_file(self, url, fh):
         if self.token:
-            url = url_concat(url, {'token': self.one_time_token})
+            url = url_concat(url, {'token': self.token})
         url = url_path_join(self.connection_url, url)
 
         jinja2_env = self.web_app.settings['jinja2_env']

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -755,12 +755,6 @@ class NotebookApp(JupyterApp):
         """)
     ).tag(config=True)
 
-    one_time_token = Unicode(
-        help=_("""One-time token used for opening a browser.
-        Once used, this token cannot be used again.
-        """)
-    )
-
     _token_generated = True
 
     @default('token')
@@ -1371,9 +1365,6 @@ class NotebookApp(JupyterApp):
         self.tornado_settings['cookie_options'] = self.cookie_options
         self.tornado_settings['get_secure_cookie_kwargs'] = self.get_secure_cookie_kwargs
         self.tornado_settings['token'] = self.token
-        if (self.open_browser or self.file_to_run) and not self.password:
-            self.one_time_token = binascii.hexlify(os.urandom(24)).decode('ascii')
-            self.tornado_settings['one_time_token'] = self.one_time_token
 
         # ensure default_url starts with base_url
         if not self.default_url.startswith(self.base_url):

--- a/notebook/templates/browser-open.html
+++ b/notebook/templates/browser-open.html
@@ -1,0 +1,18 @@
+{# This template is not served, but written as a file to open in the browser,
+   passing the token without putting it in a command-line argument. #}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="1;url={{ open_url }}" />
+    <title>Opening Jupyter Notebook</title>
+</head>
+<body>
+
+<p>
+    This page should redirect you to Jupyter Notebook. If it doesn't,
+    <a href="{{ open_url }}">click here to go to Jupyter</a>.
+</p>
+
+</body>
+</html>

--- a/notebook/utils.py
+++ b/notebook/utils.py
@@ -13,10 +13,11 @@ import sys
 from distutils.version import LooseVersion
 
 try:
-    from urllib.parse import quote, unquote, urlparse
+    from urllib.parse import quote, unquote, urlparse, urljoin
+    from urllib.request import pathname2url
 except ImportError:
-    from urllib import quote, unquote
-    from urlparse import urlparse
+    from urllib import quote, unquote, pathname2url
+    from urlparse import urlparse, urljoin
 
 from ipython_genutils import py3compat
 


### PR DESCRIPTION
This avoids putting the authentication token into a command-line argument to launch the browser, where it's visible to other users. Filesystem permissions should ensure that only the user who started the notebook can use this route to authenticate. Thanks to Dr Owain Kenway for suggesting this technique.

We should decide whether the "Copy/paste this URL into your browser" message should show the real URL (as it currently does),  the `file://` URL, or both. You may need the real URL to use the notebook via SSH tunnelling, or when the notebook server is running in a container, but it makes it easy to inadvertantly reveal your token on a multi-user system by running a command that contains it.

If we go for this approach, we can also remove the single-use token, but I haven't done that yet.