### PR TITLE
bootstrap 3.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "backbone": "components/backbone#~1.2",
-    "bootstrap": "components/bootstrap#~3.3",
+    "bootstrap": "bootstrap#~3.4",
     "bootstrap-tour": "0.9.0",
     "codemirror": "components/codemirror#~5.37",
     "es6-promise": "~1.0",

--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -37,7 +37,7 @@
             jquery: 'components/jquery/jquery.min',
             json: 'components/requirejs-plugins/src/json',
             text: 'components/requirejs-text/text',
-            bootstrap: 'components/bootstrap/js/bootstrap.min',
+            bootstrap: 'components/bootstrap/dist/js/bootstrap.min',
             bootstraptour: 'components/bootstrap-tour/build/js/bootstrap-tour.min',
             'jquery-ui': 'components/jquery-ui/jquery-ui.min',
             moment: 'components/moment/min/moment-with-locales',

--- a/setupbase.py
+++ b/setupbase.py
@@ -133,7 +133,7 @@ def find_package_data():
     # (there are lots of resources we bundle for sdist-reasons that we don't actually use)
     static_data.extend([
         pjoin(components, "backbone", "backbone-min.js"),
-        pjoin(components, "bootstrap", "js", "bootstrap.min.js"),
+        pjoin(components, "bootstrap", "dist", "js", "bootstrap.min.js"),
         pjoin(components, "bootstrap-tour", "build", "css", "bootstrap-tour.min.css"),
         pjoin(components, "bootstrap-tour", "build", "js", "bootstrap-tour.min.js"),
         pjoin(components, "font-awesome", "css", "*.css"),

--- a/tools/build-main.js
+++ b/tools/build-main.js
@@ -19,7 +19,7 @@ var rjs_config = {
     jquery: 'components/jquery/jquery.min',
     json: 'components/requirejs-plugins/src/json',
     text: 'components/requirejs-text/text',
-    bootstrap: 'components/bootstrap/js/bootstrap.min',
+    bootstrap: 'components/bootstrap/dist/js/bootstrap.min',
     bootstraptour: 'components/bootstrap-tour/build/js/bootstrap-tour.min',
     "jquery-ui": 'components/jquery-ui/jquery-ui.min',
     moment: 'components/moment/min/moment-with-locales',


### PR DESCRIPTION
the latest 3.x bugfix release, since we are preparing 5.7.3

and switch from components/ to canonical bootstrap repo, which puts bootstrap.min.js into a `dist` subdir because components hasn't received the 3.4 update.