### PR TITLE
remove multiple download links for the #download_ipynb click

### DIFF
--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -174,20 +174,6 @@ define([
             that.notebook.save_notebook_as();
             return false;
         });
-        this.element.find('#download_ipynb').click(function () {
-            var base_url = that.notebook.base_url;
-            var notebook_path = utils.encode_uri_components(that.notebook.notebook_path);
-            var url = utils.url_path_join(
-                base_url, 'files', notebook_path
-            ) + '?download=1';
-            if (that.notebook.dirty && that.notebook.writable) {
-                that.notebook.save_notebook().then(function() {
-                    that._new_window(url);
-                });
-            } else {
-                that._new_window(url);
-            }
-        });
         
         this.element.find('#print_preview').click(function () {
             that._nbconvert('html', false);


### PR DESCRIPTION
This PR is with respect to issue #4270.

A user noticed that when you click the option to download the notebook, it pops open two different windows. One for downloading the .ipynb file, and the other for a .json file. Both of which seem to be the same thing? 

I noticed there was an extra event call for this element compared to all the other drop down items. Removing this call also removed the popup for the 'json' file, but users are still prompted to download the .ipynb file. I believe this is what should occur? Furthermore, it appears that [this](https://github.com/jupyter/notebook/blob/46a887f6e0ecf50f3af5ecadaa05a6ac34675fbb/notebook/static/notebook/js/menubar.js#L133) function handles downloads in all other cases, including the `#download_ipynb` element. 



