### PR TITLE
updating file tree in "extending notebook" section

### DIFF
--- a/docs/source/examples/Notebook/Distributing Jupyter Extensions as Python Packages.ipynb
+++ b/docs/source/examples/Notebook/Distributing Jupyter Extensions as Python Packages.ipynb
@@ -284,12 +284,15 @@
    "metadata": {},
    "source": [
     "In addition to the `my_fancy_module` file tree, assume:\n",
-    "- `jupyter-config/`\n",
-    "  - `jupyter_notebook_config.d/`\n",
-    "    - `my_fancy_module.json`\n",
-    "  - `nbconfig/`\n",
-    "    - `notebook.d/`\n",
-    "      - `my_fancy_module.json`"
+    "\n",
+    "```\n",
+    "jupyter-config/\n",
+    "├── jupyter_notebook_config.d/\n",
+    "│   └── my_fancy_module.json\n",
+    "└── nbconfig/\n",
+    "    └── notebook.d/\n",
+    "        └── my_fancy_module.json\n",
+    "```"
    ]
   },
   {


### PR DESCRIPTION
I was going through the "extending the notebook" section and noticed that there's a file tree that's being rendered incorrectly which is a bit confusing. This cleans that up.

Here's the page w/ the bug now: https://jupyter-notebook.readthedocs.io/en/latest/examples/Notebook/Distributing%20Jupyter%20Extensions%20as%20Python%20Packages.html#Automatically-enabling-a-server-extension-and-nbextension

While I'm at it, is it possible to automatically activate a bundler w/ install in the same way following these instructions? They seem to be scoped for nbserver / notebook extensions only