### PR TITLE
Add --whole-filesystem command line flag

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -108,7 +108,9 @@ from jupyter_core.paths import jupyter_runtime_dir, jupyter_path
 from notebook._sysinfo import get_sys_info
 
 from ._tz import utcnow, utcfromtimestamp
-from .utils import url_path_join, check_pid, url_escape, urljoin, pathname2url
+from .utils import (url_path_join, check_pid, url_escape, urljoin, pathname2url,
+                    path2url)
+
 
 #-----------------------------------------------------------------------------
 # Module globals
@@ -527,6 +529,14 @@ flags['no-mathjax']=(
 flags['allow-root']=(
     {'NotebookApp' : {'allow_root' : True}},
     _("Allow the notebook to be run from root user.")
+)
+
+flags['whole-filesystem'] = (
+    {'NotebookApp': {
+        'notebook_dir': '/',
+        'default_url': url_path_join('/tree', path2url(os.getcwd())),
+    }},
+    _("Allow the server to navigate up to the root directory.")
 )
 
 # Add notebook manager flags


### PR DESCRIPTION
For security, we don't currently serve files above the notebook directory, normally the working directory where you launch the server. Someone who gets full access can still access the full filesystem by starting a kernel or a terminal, but it limits the possible damage if the attacker can only make plain HTTP requests.

However, this restriction is often frustrating, and people would like to be able to navigate up from the start point, trusting other layers of security. This can be achieved with the correct configuration, but it's not very convenient.

This PR adds a `--whole-filesystem` command line flag which uses the filesystem root `/` as the notebook directory, but opens the browser to the CWD where you launched the notebook. It's meant as a proposal for discussion, not a finished work.

I haven't thought yet about what this does on Windows, or with custom contents managers which don't use a filesystem.