### PR TITLE
Added functionality for selecting multiple running items

### DIFF
--- a/notebook/static/tree/js/main.js
+++ b/notebook/static/tree/js/main.js
@@ -98,6 +98,7 @@ requirejs([
         session_list:  session_list},
         common_options));
     var kernel_list = new kernellist.KernelList('#running_list_panel',  $.extend({
+        contents: contents,
         session_list:  session_list},
         common_options));
     

--- a/notebook/static/tree/js/main.js
+++ b/notebook/static/tree/js/main.js
@@ -97,13 +97,13 @@ requirejs([
         contents: contents,
         session_list:  session_list},
         common_options));
-    var kernel_list = new kernellist.KernelList('#running_list',  $.extend({
+    var kernel_list = new kernellist.KernelList('#running_list_panel',  $.extend({
         session_list:  session_list},
         common_options));
     
     var terminal_list;
     if (utils.get_body_data("terminalsAvailable") === "True") {
-        terminal_list = new terminallist.TerminalList('#terminal_list', common_options);
+        terminal_list = new terminallist.TerminalList('#terminal_list_panel', common_options);
     }
 
     var login_widget = new loginwidget.LoginWidget('#login_widget', common_options);

--- a/notebook/static/tree/js/terminallist.js
+++ b/notebook/static/tree/js/terminallist.js
@@ -7,7 +7,8 @@ define([
     'base/js/utils',
     'base/js/i18n',
     'tree/js/notebooklist',
-], function($, IPython, utils, i18n, notebooklist) {
+    'bidi/bidi'
+], function($, IPython, utils, i18n, notebooklist, bidi) {
     "use strict";
 
     var TerminalList = function (selector, options) {
@@ -24,12 +25,12 @@ define([
         this.element_name = options.element_name || 'running';
         this.selector = selector;
         this.terminals = [];
-        if (this.selector !== undefined) {
-            this.element = $(selector);
-            this.style();
-            this.bind_events();
-            this.load_terminals();
-        }
+        this.selected = [];
+        this.element = $('#terminal_list');
+        this.style();
+        this.bind_events();
+        this.load_terminals();
+
     };
 
     TerminalList.prototype = Object.create(notebooklist.NotebookList.prototype);
@@ -40,6 +41,26 @@ define([
             that.load_terminals();
         });
         $('#new-terminal').click($.proxy(this.new_terminal, this));
+        $('#' + this.element_name + '_toolbar').find('.shutdown-button').click($.proxy(this.shutdown_selected, this));
+
+        var select_all = $(that.selector).find('#select-all');
+        select_all.change(function () {
+            if (!select_all.prop('checked') || select_all.data('indeterminate')) {
+                that.select('select-none');
+            } else {
+                that.select('select-all');
+            }
+        });
+        $(that.selector).find('#button-select-all').click(function (e) {
+            // toggle checkbox if the click doesn't come from the checkbox already
+            if (!$(e.target).is('input[type=checkbox]')) {
+                if (select_all.prop('checked') || select_all.data('indeterminate')) {
+                    that.select('select-none');
+                } else {
+                    that.select('select-all');
+                }
+            }
+        });
     };
 
     TerminalList.prototype.new_terminal = function (event) {
@@ -81,15 +102,29 @@ define([
 
     TerminalList.prototype.terminals_loaded = function (data) {
         this.terminals = data;
+        var selected_before = this.selected;
         this.clear_list();
         var item, term;
         for (var i=0; i < this.terminals.length; i++) {
             term = this.terminals[i];
-            item = this.new_item(-1);
+            item = this.new_item(-1, true);
             this.add_link(term.name, item);
             this.add_shutdown_button(term.name, item);
         }
-        $('#terminal_list_header').toggle(data.length === 0);
+
+        selected_before.forEach(function(item) {
+            var list_items = $('.list_item');
+            for (var i=0; i<list_items.length; i++) {
+                var $list_item = $(list_items[i]);
+                if ($list_item.data('term-name') === item.term_name) {
+                    $list_item.find('input[type=checkbox]').prop('checked', true);
+                    break;
+                }
+            }
+        });
+
+        $('#terminal_list_placeholder').toggle(data.length === 0);
+        this._selection_changed();
     };
     
     TerminalList.prototype.add_link = function(name, item) {
@@ -106,22 +141,98 @@ define([
     TerminalList.prototype.add_shutdown_button = function(name, item) {
         var that = this;
         var shutdown_button = $("<button/>").text(i18n._("Shutdown")).addClass("btn btn-xs btn-warning").
-            click(function (e) {
-                var settings = {
-                    processData : false,
-                    type : "DELETE",
-                    dataType : "json",
-                    success : function () {
-                        that.load_terminals();
-                    },
-                    error : utils.log_ajax_error,
-                };
-                var url = utils.url_path_join(that.base_url, 'api/terminals',
-                    utils.encode_uri_components(name));
-                utils.ajax(url, settings);
-                return false;
+            click(function () {
+                that.shutdown_terminal(name);
             });
         item.find(".item_buttons").text("").append(shutdown_button);
+    };
+
+    TerminalList.prototype.shutdown_selected = function() {
+        var that = this;
+        this.selected.forEach(function(item) {
+            that.shutdown_terminal(item.term_name);
+        });
+        // Deselect items after successful shutdown.
+        that.select('select-none');
+    };
+
+    TerminalList.prototype.shutdown_terminal = function(name) {
+        var that = this;
+        var settings = {
+            processData : false,
+            type : "DELETE",
+            dataType : "json",
+            success : function () {
+                that.load_terminals();
+            },
+            error : utils.log_ajax_error,
+        };
+        var url = utils.url_path_join(that.base_url, 'api/terminals',
+            utils.encode_uri_components(name));
+        utils.ajax(url, settings);
+        return false;
+    };
+
+    TerminalList.prototype._selection_changed = function () {
+        var that = this;
+        var selected = [];
+        var total = $('#terminal_list').find('.list_item').length;
+        var checked = $('#terminal_list').find('.list_item :checked').length;
+        var has_terminal = (checked > 0);
+        var has_running_notebook = $('#running_list').find('.list_item :checked').length;
+        $('#terminal_list').find('.list_item :checked').each(function(index, item) {
+            var parent = $(item).parent().parent();
+            selected.push({
+                term_name: parent.data('term-name')
+            });
+        })
+        this.selected = selected;
+
+        // Shutdown is only visible when one or more terminals or running notebooks
+        // are selected and no non-notebook items are selected.
+        if (has_terminal || has_running_notebook) {
+            $('#' + that.element_name + '_toolbar').find('.shutdown-button').css('display', 'inline-block');
+        } else {
+            $('#' + that.element_name + '_toolbar').find('.shutdown-button').css('display', 'none');
+        }
+
+        // Duplicate, Delete, View and Edit aren't visible when a terminal is selected.
+        if (has_running_notebook && !has_terminal) {
+            $('#' + that.element_name + '_toolbar').find('.duplicate-button').css('display', 'inline-block');
+            $('#' + that.element_name + '_toolbar').find('.delete-button').css('display', 'inline-block');
+            $('#' + that.element_name + '_toolbar').find('.view-button').css('display', 'inline-block');
+            $('#' + that.element_name + '_toolbar').find('.edit-button').css('display', 'inline-block');
+        } else {
+            $('#' + that.element_name + '_toolbar').find('.duplicate-button').css('display', 'none');
+            $('#' + that.element_name + '_toolbar').find('.delete-button').css('display', 'none');
+            $('#' + that.element_name + '_toolbar').find('.view-button').css('display', 'none');
+            $('#' + that.element_name + '_toolbar').find('.edit-button').css('display', 'none');
+        }
+
+        var select_all = $(that.selector).find("#select-all");
+        if (checked === 0) {
+            select_all.prop('checked', false);
+            select_all.prop('indeterminate', false);
+            select_all.data('indeterminate', false);
+        } else if (checked === total) {
+            select_all.prop('checked', true);
+            select_all.prop('indeterminate', false);
+            select_all.data('indeterminate', false);
+        } else {
+            select_all.prop('checked', false);
+            select_all.prop('indeterminate', true);
+            select_all.data('indeterminate', true);
+        }
+        // Update total counter
+        checked = bidi.applyBidi(checked);
+        $(that.selector).find('#counter-select-all').html(checked===0 ? '&nbsp;' : checked);
+
+        // If at aleast on item is selected, hide the selection instructions.
+        if (checked > 0 || has_running_notebook) {
+            $('.dynamic-instructions').hide();
+        } else {
+            $('.dynamic-instructions').show();
+        }
     };
 
     return {TerminalList: TerminalList};

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -146,7 +146,19 @@ data-server-root="{{server_root}}"
         <div id="running" class="tab-pane">
           <div id="running_toolbar" class="row">
             <div class="col-sm-8 no-padding">
-              <span id="running_list_info">{% trans %}Currently running Jupyter processes{% endtrans %}</span>
+              <span id="running_list_info" class="dynamic-instructions">
+                {% trans %}Currently running Jupyter processes{% endtrans %}
+              </span>
+              <div class="dynamic-buttons">
+                  <button title="{% trans %}Duplicate selected{% endtrans %}" class="duplicate-button btn btn-default btn-xs">{% trans %}Duplicate{% endtrans %}</button>
+                  <button title="{% trans %}Rename selected{% endtrans %}" class="rename-button btn btn-default btn-xs">{% trans %}Rename{% endtrans %}</button>
+                  <button title="{% trans %}Move selected{% endtrans %}" class="move-button btn btn-default btn-xs">{% trans %}Move{% endtrans %}</button>
+                  <button title="{% trans %}Download selected{% endtrans %}" class="download-button btn btn-default btn-xs">{% trans %}Download{% endtrans %}</button>
+                  <button title="{% trans %}Shutdown selected notebook(s){% endtrans %}" class="shutdown-button btn btn-default btn-xs btn-warning">{% trans %}Shutdown{% endtrans %}</button>
+                  <button title="{% trans %}View selected{% endtrans %}" class="view-button btn btn-default btn-xs">{% trans %}View{% endtrans %}</button>
+                  <button title="{% trans %}Edit selected{% endtrans %}" class="edit-button btn btn-default btn-xs">{% trans %}Edit{% endtrans %}</button>
+                  <button title="{% trans %}Delete selected{% endtrans %}" class="delete-button btn btn-default btn-xs btn-danger"><i class="fa fa-trash"></i></button>
+              </div>
             </div>
             <div class="col-sm-4 no-padding tree-buttons">
               <span id="running_buttons" class="pull-right">
@@ -155,8 +167,13 @@ data-server-root="{{server_root}}"
             </div>
           </div>
           <div class="panel-group" id="accordion" >
-            <div class="panel panel-default">
+            <div class="panel panel-default" id="terminal_list_panel">
               <div class="panel-heading">
+                <div class="btn-group dropdown" id="tree-selector">
+                  <button title="{% trans %}Select All / None{% endtrans %}" type="button" class="btn btn-default btn-xs" id="button-select-all">
+                    <input type="checkbox" class="pull-left tree-selector" id="select-all"><span id="counter-select-all">&nbsp;</span></input>
+                  </button>
+                </div>
                 <a data-toggle="collapse" data-target="#collapseOne" href="#">
                   Terminals
                 </a>
@@ -164,19 +181,24 @@ data-server-root="{{server_root}}"
               <div id="collapseOne" class=" collapse in">
                 <div class="panel-body">
                   <div id="terminal_list">
-                    <div id="terminal_list_header" class="row list_placeholder">
-                    {% if terminals_available %}
-                      <div> {% trans %}There are no terminals running.{% endtrans %} </div>
-                    {% else %}
-                      <div> {% trans %}Terminals are unavailable.{% endtrans %} </div>
-                    {% endif %}
+                    <div id="terminal_list_placeholder" class="row list_placeholder">
+                      {% if terminals_available %}
+                        <div> {% trans %}There are no terminals running.{% endtrans %} </div>
+                      {% else %}
+                        <div> {% trans %}Terminals are unavailable.{% endtrans %} </div>
+                      {% endif %}
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-            <div class="panel panel-default">
+            <div class="panel panel-default" id="running_list_panel">
               <div class="panel-heading">
+                <div class="btn-group dropdown" id="tree-selector">
+                  <button title="{% trans %}Select All / None{% endtrans %}" type="button" class="btn btn-default btn-xs" id="button-select-all">
+                    <input type="checkbox" class="pull-left tree-selector" id="select-all"><span id="counter-select-all">&nbsp;</span></input>
+                  </button>
+                </div>
                 <a data-toggle="collapse" data-target="#collapseTwo" href="#">
                   {% trans %}Notebooks{% endtrans %}
                 </a>


### PR DESCRIPTION
Previously, Jupyter Notebook didn't had options for selecting multiple running items just like it has in the files tab where multiple items can be selected and operations can be performed on them. This functionality was also desired in the running tab which is resolved by this commit.

Since kernelList and terminalList inherits from the notebookList class there is option for including the functionality for selecting multiple items by passing ```true``` as one of the parameter when creating the list items. Although some other modifications had to be done to make it look similar to the files tab in the ```tree.html``` file and accordingly configure other parameters in the ```kernellist.js```, ```main.js```, ```notebooklist.js``` and ```terminallist.js```.

closes #970 