### PR TITLE
Update document.title to a more descriptive name

### DIFF
--- a/notebook/static/edit/js/savewidget.js
+++ b/notebook/static/edit/js/savewidget.js
@@ -122,7 +122,7 @@ define([
         if(filename){
             this._filename = filename;
         }
-        document.title = (dirty?'*':'')+this._filename;
+        document.title = (dirty?'*':'')+this._filename+' - Jupyter Notebook';
     };
 
     SaveWidget.prototype.update_address_bar = function (path) {

--- a/notebook/static/notebook/js/savewidget.js
+++ b/notebook/static/notebook/js/savewidget.js
@@ -141,7 +141,7 @@ define([
 
     SaveWidget.prototype.update_document_title = function () {
         var nbname = this.notebook.get_notebook_name();
-        document.title = nbname;
+        document.title = nbname + ' - Jupyter Notebook';
     };
 
     SaveWidget.prototype.update_address_bar = function(){


### PR DESCRIPTION
Changes `document.title` to `NOTEBOOK_NAME - Jupyter Notebook`.

Sometimes having `Untitled - Google Chrome` or `Lesson 1 - Google Chrome` as a window/tab name is not very descriptive. Especially in situations where favicon is not visible.
Adding `- Jupyter Notebook` at the end makes it so much more descriptive.