### PR TITLE
Fix filename to open in notebookapp.py after #4260 and #4265

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1747,7 +1747,7 @@ class NotebookApp(JupyterApp):
 
             # Write a temporary file to open in the browser
             fd, open_file = tempfile.mkstemp(suffix='.html')
-            with open(fd, 'w', encoding='utf-8') as fh:
+            with open(open_file, 'w', encoding='utf-8') as fh:
                 self._write_browser_open_file(uri, fh)
         else:
             open_file = self.browser_open_file


### PR DESCRIPTION
This also needs to be backported to the 5.7.x branch and should fix #4303.