### PR TITLE
Use io.open in notebookapp.py to fix #4303

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1671,7 +1671,7 @@ class NotebookApp(JupyterApp):
     def write_server_info_file(self):
         """Write the result of server_info() to the JSON file info_file."""
         try:
-            with open(self.info_file, 'w') as f:
+            with io.open(self.info_file, 'w') as f:
                 json.dump(self.server_info(), f, indent=2, sort_keys=True)
         except OSError as e:
             self.log.error(_("Failed to write server-info to %s: %s"),

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1739,7 +1739,7 @@ class NotebookApp(JupyterApp):
 
             # Write a temporary file to open in the browser
             fd, open_file = tempfile.mkstemp(suffix='.html')
-            with open(fd, 'w', encoding='utf-8') as fh:
+            with io.open(fd, 'w', encoding='utf-8') as fh:
                 self._write_browser_open_file(uri, fh)
         else:
             open_file = self.browser_open_file

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1671,7 +1671,7 @@ class NotebookApp(JupyterApp):
     def write_server_info_file(self):
         """Write the result of server_info() to the JSON file info_file."""
         try:
-            with io.open(self.info_file, 'w') as f:
+            with io.open(self.info_file, 'w', encoding='utf-8') as f:
                 json.dump(self.server_info(), f, indent=2, sort_keys=True)
         except OSError as e:
             self.log.error(_("Failed to write server-info to %s: %s"),


### PR DESCRIPTION
Following the discussion at #4340, in Python 2 we need `io.open`
rather than `open` if using a file descriptor rather than a file name.