### PR TITLE
Use io.open in notebookapp.py to fix #4303

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1739,7 +1739,7 @@ class NotebookApp(JupyterApp):
 
             # Write a temporary file to open in the browser
             fd, open_file = tempfile.mkstemp(suffix='.html')
-            with open(fd, 'w', encoding='utf-8') as fh:
+            with io.open(fd, 'w', encoding='utf-8') as fh:
                 self._write_browser_open_file(uri, fh)
         else:
             open_file = self.browser_open_file


### PR DESCRIPTION
Following the discussion at #4340, in Python 2 we need `io.open` rather than `open` if using a file descriptor rather than a file name.

This is the first commit from #4348; I got confused and asked @slel to make further changes, which weren't useful.