### PR TITLE
Fix case sensitive notebook file extension 

### DIFF
--- a/notebook/files/handlers.py
+++ b/notebook/files/handlers.py
@@ -57,7 +57,7 @@ class FilesHandler(IPythonHandler):
             self.set_attachment_header(name)
         
         # get mimetype from filename
-        if name.endswith('.ipynb'):
+        if name.lower().endswith('.ipynb'):
             self.set_header('Content-Type', 'application/x-ipynb+json')
         else:
             cur_mime = mimetypes.guess_type(name)[0]


### PR DESCRIPTION
In case a notebook file extension is not all lower case (e.g. NOTE.IPYNB) then notebook will identify it as plain text.
My fix is making the notebook file extension check to be case insensitive