### PR TITLE
Improve comms.rst example

### DIFF
--- a/docs/source/comms.rst
+++ b/docs/source/comms.rst
@@ -88,8 +88,7 @@ And then open the comm from the frontend:
 
 .. code-block:: javascript
 
-    comm = Jupyter.notebook.kernel.comm_manager.new_comm('my_comm_target',
-                                                         {'foo': 6})
+    const comm = Jupyter.notebook.kernel.comm_manager.new_comm('my_comm_target', {'foo': 6})
     // Send data
     comm.send({'foo': 7})
 

--- a/docs/source/comms.rst
+++ b/docs/source/comms.rst
@@ -65,7 +65,7 @@ containing Javascript to connect to it.
 
 .. code-block:: python
 
-    def target_func(comm, msg):
+    def target_func(comm, open_msg):
         # comm is the kernel Comm instance
         # msg is the comm_open message
 
@@ -73,8 +73,9 @@ containing Javascript to connect to it.
         @comm.on_msg
         def _recv(msg):
             # Use msg['content']['data'] for the data in the message
+            comm.send({'echo': msg['content']['data']})
 
-        # Send data to the frontend
+        # Send data to the frontend on creation
         comm.send({'foo': 5})
 
     get_ipython().kernel.comm_manager.register_target('my_comm_target', target_func)


### PR DESCRIPTION
This improves the example by making it more copy/pastable out of the box and demoing how you can send a message at various places. It also fixes a poor usage of shadowed variables