### PR TITLE
surface config.d nbserver_extensions to the NotebookApp config object

### DIFF
--- a/notebook/tests/test_serverextensions.py
+++ b/notebook/tests/test_serverextensions.py
@@ -147,6 +147,7 @@ class TestInstallServerExtension(MockEnvTestCase):
         toggle_serverextension_python('mockext_both', enabled=False, user=True)
 
         app = NotebookApp(nbserver_extensions={'mockext_py': True})
+        app.init_server_extension_config()
         app.init_server_extensions()
 
         assert mock_user.loaded


### PR DESCRIPTION
This PR comes from a discussion that arose around surfacing information about whether a server_extension is enabled from within another server_extension when the server_extension has been automatically enabled through the use of a `jupyter_notebook_config.d/` directory. 

Basically if you autoenable a server_extension, it's never discovered by the core JupyterApp, and so while the server_extension is enabled, this information doesn't appear in the resulting config object surfaced within `config.NotebookApp.nbserver_extensions`.

This arose when trying to surface whether [bookstore](https://github.com/nteract/bookstore)(a s3 publishing service) is enabled in nteract (see discussion in https://github.com/nteract/nteract/pull/4144). 

- separates nbserver_extension config loading into new 
init_server_extension_config method 
- adds init_server_extension_config to the initialize funciton before 
the init_webapp call
- adds nbserver_extension configuration found in config.d files (by the 
BaseJSONConfigLoader) to both the underlying NotebookApp config object 
and the self.nbserver_extensions value
- makes self.nbserver_extensions the canonical location for identifying 
all nbserver_extensions rather than temporary extensions variable