### PR TITLE
MathJax: Support for \gdef

### DIFF
--- a/notebook/static/notebook/js/mathjaxutils.js
+++ b/notebook/static/notebook/js/mathjaxutils.js
@@ -19,6 +19,9 @@ define([
                     processEscapes: true,
                     processEnvironments: true
                 },
+                TeX: {
+                    extensions: ['newcommand.js', 'begingroup.js']  // For \gdef
+                },
                 MathML: {
                     extensions: ['content-mathml.js']
                 },


### PR DESCRIPTION
Backport of https://github.com/jupyterlab/jupyterlab/pull/5997