### PR TITLE
Enable restart_kernel for async usage

### DIFF
--- a/notebook/services/kernels/kernelmanager.py
+++ b/notebook/services/kernels/kernelmanager.py
@@ -302,10 +302,11 @@ class MappingKernelManager(MultiKernelManager):
 
         return super(MappingKernelManager, self).shutdown_kernel(kernel_id, now=now)
 
+    @gen.coroutine
     def restart_kernel(self, kernel_id):
         """Restart a kernel by kernel_id"""
         self._check_kernel_id(kernel_id)
-        super(MappingKernelManager, self).restart_kernel(kernel_id)
+        yield gen.maybe_future(super(MappingKernelManager, self).restart_kernel(kernel_id))
         kernel = self.get_kernel(kernel_id)
         # return a Future that will resolve when the kernel has successfully restarted
         channel = kernel.connect_shell()
@@ -341,7 +342,7 @@ class MappingKernelManager(MultiKernelManager):
         channel.on_recv(on_reply)
         loop = IOLoop.current()
         timeout = loop.add_timeout(loop.time() + self.kernel_info_timeout, on_timeout)
-        return future
+        raise gen.Return(future)
 
     def notify_connect(self, kernel_id):
         """Notice a new connection to a kernel"""


### PR DESCRIPTION
Converted `MappingKernelManager.restart_kernel` to a coroutine so that projects that take advantage of async kernel startup can also realize appropriate behavior relative to restarts.  To take full advantage of async kernel startup (with restarts), this PR along with its "[sibling PR](https://github.com/jupyter/jupyter_client/pull/425)" will be required.

Please note, however, that each of these PRs can be independently installed w/o affecting today's notebook applications (as far as I can determine via testing the possible combinations).  That said, BOTH of these PRs will be required for usage by Enterprise Gateway - which incurs very long kernel startup times - or other projects that require concurrent kernel starts.

It would be ideal to have this PR back-ported to python 2.7-relative release since EG has an immediate need. 