### PR TITLE
move rtl fixes to page.less from custom.css

### DIFF
--- a/notebook/static/base/less/page.less
+++ b/notebook/static/base/less/page.less
@@ -172,3 +172,17 @@ span#login_widget > .button,
         margin-right: @padding-base-horizontal;
     }
 }
+
+/* rtl fixes for the error, connecting, and renaming window */
+
+[dir="rtl"] .modal-footer {
+    text-align : left !important;
+}
+
+[dir="rtl"] .close {
+    float : left;
+}
+
+[dir="rtl"] .fa-step-forward::before {
+    content: "\f048";
+}

--- a/notebook/static/custom/custom.css
+++ b/notebook/static/custom/custom.css
@@ -3,19 +3,6 @@ Placeholder for custom user CSS
 
 mainly to be overridden in profile/static/custom/custom.css
 
-This will always be an empty file in IPython
+This will always be an empty file
 */
 
-/*for the error , connecting & renaming window*/
-
-[dir="rtl"] .modal-footer {
-	text-align : left !important;
-}
-
-[dir="rtl"] .close {
-	float : left;
-}
-
-[dir="rtl"] .fa-step-forward::before {
-    content: "\f048";
-}


### PR DESCRIPTION
custom.css should always be empty since it will be overridden

these rules were added to custom.css accidentally by #2357