### PR TITLE
trigger _ws_closed on any close event

### DIFF
--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -470,33 +470,31 @@ define([
         
         var already_called_onclose = false; // only alert once
         var ws_closed_early = function(evt){
+            console.log("WebSocket closed early", evt);
             if (already_called_onclose){
                 return;
             }
             already_called_onclose = true;
-            if ( ! evt.wasClean ){
-                // If the websocket was closed early, that could mean
-                // that the kernel is actually dead. Try getting
-                // information about the kernel from the API call --
-                // if that fails, then assume the kernel is dead,
-                // otherwise just follow the typical websocket closed
-                // protocol.
-                that.get_info(function () {
-                    that._ws_closed(ws_host_url, false);
-                }, function () {
-                    that.events.trigger('kernel_dead.Kernel', {kernel: that});
-                    that._kernel_dead();
-                });
-            }
+            // If the websocket was closed early, that could mean
+            // that the kernel is actually dead. Try getting
+            // information about the kernel from the API call --
+            // if that fails, then assume the kernel is dead,
+            // otherwise just follow the typical websocket closed
+            // protocol.
+            that.get_info(function () {
+                that._ws_closed(ws_host_url, false);
+            }, function () {
+                that.events.trigger('kernel_dead.Kernel', {kernel: that});
+                that._kernel_dead();
+            });
         };
         var ws_closed_late = function(evt){
+            console.log("WebSocket closed unexpectedly", evt);
             if (already_called_onclose){
                 return;
             }
             already_called_onclose = true;
-            if ( ! evt.wasClean ){
-                that._ws_closed(ws_host_url, false);
-            }
+            that._ws_closed(ws_host_url, false);
         };
         var ws_error = function(evt){
             if (already_called_onclose){


### PR DESCRIPTION
it doesn’t matter if the close was clean or not, we should still handle the close event.

Currently if the server-side closes the connection according to the websocket protocol (e.g. for the ping timeout event), then the UI takes no action and appears to have a working connection even though it doesn't.

we set a different onclose handler prior to the client requesting close, which is likely what the old wasClean checks were for