### PR TITLE
tornado 6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
     - pip install "attrs>=17.4.0"
 
 install:
-    - pip install --pre .[test]
+    - pip install --pre .[test] $EXTRA_PIP
     - pip freeze
     - wget https://github.com/jgm/pandoc/releases/download/1.19.1/pandoc-1.19.1-1-amd64.deb && sudo dpkg -i pandoc-1.19.1-1-amd64.deb
 
@@ -103,6 +103,14 @@ matrix:
           env: GROUP=python
         - python: 3.6
           env: GROUP=docs
+        - python: 3.6
+          env:
+          - GROUP=python
+          - EXTRA_PIP="tornado<5"
+        - python: 2.7
+          env:
+          - GROUP=python
+          - EXTRA_PIP="tornado<5"
 
 after_success:
     - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,8 @@ matrix:
           env: GROUP=python
         - python: 3.5
           env: GROUP=python
-        - python: "3.7-dev"
+        - python: 3.7
+          dist: xenial
           env: GROUP=python
         - python: 3.6
           env: GROUP=docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_install:
 
 install:
     - pip install --pre .[test]
+    - pip freeze
     - wget https://github.com/jgm/pandoc/releases/download/1.19.1/pandoc-1.19.1-1-amd64.deb && sudo dpkg -i pandoc-1.19.1-1-amd64.deb
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,10 +107,6 @@ matrix:
           env:
           - GROUP=python
           - EXTRA_PIP="tornado<5"
-        - python: 2.7
-          env:
-          - GROUP=python
-          - EXTRA_PIP="tornado<5"
 
 after_success:
     - codecov

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,6 +21,15 @@ We strongly recommend that you upgrade pip to version 9+ of pip before upgrading
     Use ``pip install pip --upgrade`` to upgrade pip. Check pip version with
     ``pip --version``.
 
+.. _release-5.7.5:
+
+5.7.5
+-----
+
+- Fix compatibility with tornado 6 (:ghpull:`4392`, :ghpull:`4449`).
+- Fix opening integer filedescriptor during startup on Python 2 (:ghpull:`4349`)
+- Fix compatibility with asynchronous `KernelManager.restart_kernel` methods (:ghpull:`4412`)
+
 .. _release-5.7.4:
 
 5.7.4

--- a/notebook/base/zmqhandlers.py
+++ b/notebook/base/zmqhandlers.py
@@ -172,7 +172,7 @@ class WebSocketMixin(object):
 
     def send_ping(self):
         """send a ping to keep the websocket alive"""
-        if self.stream.closed() and self.ping_callback is not None:
+        if self.ws_connection is None and self.ping_callback is not None:
             self.ping_callback.stop()
             return
 
@@ -237,7 +237,7 @@ class ZMQStreamHandler(WebSocketMixin, WebSocketHandler):
     def _on_zmq_reply(self, stream, msg_list):
         # Sometimes this gets triggered when the on_close method is scheduled in the
         # eventloop but hasn't been called.
-        if self.stream.closed() or stream.closed():
+        if self.ws_connection is None or stream.closed():
             self.log.warning("zmq message arrived on closed channel")
             self.close()
             return

--- a/notebook/gateway/managers.py
+++ b/notebook/gateway/managers.py
@@ -8,7 +8,6 @@ from socket import gaierror
 from tornado import gen, web
 from tornado.escape import json_encode, json_decode, url_escape
 from tornado.httpclient import HTTPClient, AsyncHTTPClient, HTTPError
-from tornado.simple_httpclient import HTTPTimeoutError
 
 from ..services.kernels.kernelmanager import MappingKernelManager
 from ..services.sessions.sessionmanager import SessionManager
@@ -259,9 +258,9 @@ def gateway_request(endpoint, **kwargs):
     except ConnectionRefusedError:
         raise web.HTTPError(503, "Connection refused from Gateway server url '{}'.  " 
               "Check to be sure the Gateway instance is running.".format(GatewayClient.instance().url))
-    except HTTPTimeoutError:
+    except HTTPError:
         # This can occur if the host is valid (e.g., foo.com) but there's nothing there.
-        raise web.HTTPError(504, "Timeout error attempting to connect to Gateway server url '{}'.  " \
+        raise web.HTTPError(504, "Error attempting to connect to Gateway server url '{}'.  " \
                        "Ensure gateway url is valid and the Gateway instance is running.".format(
             GatewayClient.instance().url))
     except gaierror as e:

--- a/notebook/utils.py
+++ b/notebook/utils.py
@@ -13,12 +13,30 @@ import sys
 from distutils.version import LooseVersion
 
 try:
+    from inspect import isawaitable
+except ImportError:
+    def isawaitable(f):
+        """If isawaitable is undefined, nothing is awaitable"""
+        return False
+
+try:
+    from concurrent.futures import Future as ConcurrentFuture
+except ImportError:
+    class ConcurrentFuture:
+        """If concurrent.futures isn't importable, nothing will be a c.f.Future"""
+        pass
+
+try:
     from urllib.parse import quote, unquote, urlparse, urljoin
     from urllib.request import pathname2url
 except ImportError:
     from urllib import quote, unquote, pathname2url
     from urlparse import urlparse, urljoin
 
+# tornado.concurrent.Future is asyncio.Future
+# in tornado >=5 with Python 3
+from tornado.concurrent import Future as TornadoFuture
+from tornado import gen
 from ipython_genutils import py3compat
 
 # UF_HIDDEN is a stat flag not defined in the stat module.
@@ -306,3 +324,34 @@ if sys.platform == 'win32':
     check_pid = _check_pid_win32
 else:
     check_pid = _check_pid_posix
+
+
+def maybe_future(obj):
+    """Like tornado's gen.maybe_future
+
+    but more compatible with asyncio for recent versions
+    of tornado
+    """
+    if isinstance(obj, TornadoFuture):
+        return obj
+    elif isawaitable(obj):
+        return asyncio.ensure_future(obj)
+    elif isinstance(obj, ConcurrentFuture):
+        return asyncio.wrap_future(obj)
+    else:
+        # not awaitable, wrap scalar in future
+        f = TornadoFuture()
+        f.set_result(obj)
+        return f
+
+# monkeypatch tornado gen.maybe_future
+# on Python 3
+# TODO: remove monkeypatch after backporting smaller fix to 5.x
+try:
+    import asyncio
+except ImportError:
+    pass
+else:
+    import tornado.gen
+    tornado.gen.maybe_future = maybe_future
+

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ for more information.
     zip_safe = False,
     install_requires = [
         'jinja2',
-        'tornado>=4, <6',
+        'tornado>=4.1',
         # pyzmq>=17 is not technically necessary,
         # but hopefully avoids incompatibilities with Tornado 5. April 2018
         'pyzmq>=17',


### PR DESCRIPTION
to get testing 6.0 again

We usually try to test prereleases to catch this kind of issue, but stopped testing tornado 6 when we found out about a compatibility problem. Whenever we merge a PR to pin dependencies as a band-aid to get tests passing (AOK to get things unblocked), let's try to open a WIP PR unpinning the dependency immediately so we can fix the issue, because it's always a real thing we need to fix, ideally with a release before the upstream package gets its final release.

once this works:

closes #4437
closes #4439
