### PR TITLE
Finish transition to our own maybe_future

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,9 +93,6 @@ matrix:
           - MOZ_HEADLESS=1
           addons:
             firefox: 57.0
-
-        - python: 3.4
-          env: GROUP=python
         - python: 3.5
           env: GROUP=python
         - python: 3.7
@@ -103,10 +100,6 @@ matrix:
           env: GROUP=python
         - python: 3.6
           env: GROUP=docs
-        - python: 3.6
-          env:
-          - GROUP=python
-          - EXTRA_PIP="tornado<5"
 
 after_success:
     - codecov

--- a/notebook/base/zmqhandlers.py
+++ b/notebook/base/zmqhandlers.py
@@ -4,16 +4,10 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import os
 import json
 import struct
-import warnings
 import sys
-
-try:
-    from urllib.parse import urlparse # Py 3
-except ImportError:
-    from urlparse import urlparse # Py 2
+from urllib.parse import urlparse
 
 import tornado
 from tornado import gen, ioloop, web
@@ -23,7 +17,9 @@ from jupyter_client.session import Session
 from jupyter_client.jsonutil import date_default, extract_dates
 from ipython_genutils.py3compat import cast_unicode
 
+from notebook.utils import maybe_future
 from .handlers import IPythonHandler
+
 
 def serialize_binary_message(msg):
     """serialize a message as a binary blob
@@ -251,17 +247,17 @@ class ZMQStreamHandler(WebSocketMixin, WebSocketHandler):
 
 
 class AuthenticatedZMQStreamHandler(ZMQStreamHandler, IPythonHandler):
-    
+
     def set_default_headers(self):
         """Undo the set_default_headers in IPythonHandler
-        
+
         which doesn't make sense for websockets
         """
         pass
-    
+
     def pre_get(self):
         """Run before finishing the GET request
-        
+
         Extend this method to add logic that should fire before
         the websocket finishes completing.
         """
@@ -269,21 +265,21 @@ class AuthenticatedZMQStreamHandler(ZMQStreamHandler, IPythonHandler):
         if self.get_current_user() is None:
             self.log.warning("Couldn't authenticate WebSocket connection")
             raise web.HTTPError(403)
-        
+
         if self.get_argument('session_id', False):
             self.session.session = cast_unicode(self.get_argument('session_id'))
         else:
             self.log.warning("No session ID specified")
-    
+
     @gen.coroutine
     def get(self, *args, **kwargs):
         # pre_get can be a coroutine in subclasses
         # assign and yield in two step to avoid tornado 3 issues
         res = self.pre_get()
-        yield gen.maybe_future(res)
+        yield maybe_future(res)
         res = super(AuthenticatedZMQStreamHandler, self).get(*args, **kwargs)
-        yield gen.maybe_future(res)
-    
+        yield maybe_future(res)
+
     def initialize(self):
         self.log.debug("Initializing websocket connection %s", self.request.path)
         self.session = Session(config=self.config)

--- a/notebook/bundler/handlers.py
+++ b/notebook/bundler/handlers.py
@@ -2,12 +2,15 @@
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-from . import tools
-from notebook.utils import url2path
-from notebook.base.handlers import IPythonHandler
-from notebook.services.config import ConfigManager
+
 from ipython_genutils.importstring import import_item
 from tornado import web, gen
+
+from notebook.utils import maybe_future, url2path
+from notebook.base.handlers import IPythonHandler
+from notebook.services.config import ConfigManager
+
+from . import tools
 
 
 class BundlerHandler(IPythonHandler):
@@ -74,7 +77,7 @@ class BundlerHandler(IPythonHandler):
 
         # Let the bundler respond in any way it sees fit and assume it will
         # finish the request
-        yield gen.maybe_future(bundler_mod.bundle(self, model))
+        yield maybe_future(bundler_mod.bundle(self, model))
 
 _bundler_id_regex = r'(?P<bundler_id>[A-Za-z0-9_]+)'
 

--- a/notebook/files/handlers.py
+++ b/notebook/files/handlers.py
@@ -5,16 +5,12 @@
 
 import mimetypes
 import json
+from base64 import decodebytes
 
-try: #PY3
-    from base64 import decodebytes
-except ImportError: #PY2
-    from base64 import decodestring as decodebytes
-
-
-from tornado import gen, web
+from tornado import web
 
 from notebook.base.handlers import IPythonHandler
+from notebook.utils import maybe_future
 
 
 class FilesHandler(IPythonHandler):
@@ -51,7 +47,7 @@ class FilesHandler(IPythonHandler):
         else:
             name = path
         
-        model = yield gen.maybe_future(cm.get(path, type='file', content=include_body))
+        model = yield maybe_future(cm.get(path, type='file', content=include_body))
         
         if self.get_argument("download", False):
             self.set_attachment_header(name)

--- a/notebook/services/api/handlers.py
+++ b/notebook/services/api/handlers.py
@@ -3,15 +3,15 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from itertools import chain
 import json
+import os
 
 from tornado import gen, web
 
 from ...base.handlers import IPythonHandler, APIHandler
 from notebook._tz import utcfromtimestamp, isoformat
+from notebook.utils import maybe_future
 
-import os
 
 class APISpecHandler(web.StaticFileHandler, IPythonHandler):
 
@@ -22,9 +22,10 @@ class APISpecHandler(web.StaticFileHandler, IPythonHandler):
     def get(self):
         self.log.warning("Serving api spec (experimental, incomplete)")
         return web.StaticFileHandler.get(self, 'api.yaml')
-        
+
     def get_content_type(self):
         return 'text/x-yaml'
+
 
 class APIStatusHandler(APIHandler):
 
@@ -37,7 +38,7 @@ class APIStatusHandler(APIHandler):
         started = self.settings.get('started', utcfromtimestamp(0))
         started = isoformat(started)
 
-        kernels = yield gen.maybe_future(self.kernel_manager.list_kernels())
+        kernels = yield maybe_future(self.kernel_manager.list_kernels())
         total_connections = sum(k['connections'] for k in kernels)
         last_activity = isoformat(self.application.last_activity())
         model = {
@@ -47,6 +48,7 @@ class APIStatusHandler(APIHandler):
             'connections': total_connections,
         }
         self.finish(json.dumps(model, sort_keys=True))
+
 
 default_handlers = [
     (r"/api/spec.yaml", APISpecHandler),

--- a/notebook/services/contents/handlers.py
+++ b/notebook/services/contents/handlers.py
@@ -10,7 +10,7 @@ import json
 
 from tornado import gen, web
 
-from notebook.utils import url_path_join, url_escape
+from notebook.utils import maybe_future, url_path_join, url_escape
 from jupyter_client.jsonutil import date_default
 
 from notebook.base.handlers import (
@@ -108,7 +108,7 @@ class ContentsHandler(APIHandler):
             raise web.HTTPError(400, u'Content %r is invalid' % content)
         content = int(content)
         
-        model = yield gen.maybe_future(self.contents_manager.get(
+        model = yield maybe_future(self.contents_manager.get(
             path=path, type=type, format=format, content=content,
         ))
         validate_model(model, expect_content=content)
@@ -122,7 +122,7 @@ class ContentsHandler(APIHandler):
         model = self.get_json_body()
         if model is None:
             raise web.HTTPError(400, u'JSON body missing')
-        model = yield gen.maybe_future(cm.update(model, path))
+        model = yield maybe_future(cm.update(model, path))
         validate_model(model, expect_content=False)
         self._finish_model(model)
     
@@ -133,7 +133,7 @@ class ContentsHandler(APIHandler):
             copy_from=copy_from,
             copy_to=copy_to or '',
         ))
-        model = yield gen.maybe_future(self.contents_manager.copy(copy_from, copy_to))
+        model = yield maybe_future(self.contents_manager.copy(copy_from, copy_to))
         self.set_status(201)
         validate_model(model, expect_content=False)
         self._finish_model(model)
@@ -142,7 +142,7 @@ class ContentsHandler(APIHandler):
     def _upload(self, model, path):
         """Handle upload of a new file to path"""
         self.log.info(u"Uploading file to %s", path)
-        model = yield gen.maybe_future(self.contents_manager.new(model, path))
+        model = yield maybe_future(self.contents_manager.new(model, path))
         self.set_status(201)
         validate_model(model, expect_content=False)
         self._finish_model(model)
@@ -151,7 +151,7 @@ class ContentsHandler(APIHandler):
     def _new_untitled(self, path, type='', ext=''):
         """Create a new, empty untitled entity"""
         self.log.info(u"Creating new %s in %s", type or 'file', path)
-        model = yield gen.maybe_future(self.contents_manager.new_untitled(path=path, type=type, ext=ext))
+        model = yield maybe_future(self.contents_manager.new_untitled(path=path, type=type, ext=ext))
         self.set_status(201)
         validate_model(model, expect_content=False)
         self._finish_model(model)
@@ -162,7 +162,7 @@ class ContentsHandler(APIHandler):
         chunk = model.get("chunk", None) 
         if not chunk or chunk == -1:  # Avoid tedious log information
             self.log.info(u"Saving file at %s", path)  
-        model = yield gen.maybe_future(self.contents_manager.save(model, path))
+        model = yield maybe_future(self.contents_manager.save(model, path))
         validate_model(model, expect_content=False)
         self._finish_model(model)
 
@@ -182,11 +182,11 @@ class ContentsHandler(APIHandler):
 
         cm = self.contents_manager
 
-        file_exists = yield gen.maybe_future(cm.file_exists(path))
+        file_exists = yield maybe_future(cm.file_exists(path))
         if file_exists:
             raise web.HTTPError(400, "Cannot POST to files, use PUT instead.")
 
-        dir_exists = yield gen.maybe_future(cm.dir_exists(path))
+        dir_exists = yield maybe_future(cm.dir_exists(path))
         if not dir_exists:
             raise web.HTTPError(404, "No such directory: %s" % path)
 
@@ -220,13 +220,13 @@ class ContentsHandler(APIHandler):
         if model:
             if model.get('copy_from'):
                 raise web.HTTPError(400, "Cannot copy with PUT, only POST")
-            exists = yield gen.maybe_future(self.contents_manager.file_exists(path))
+            exists = yield maybe_future(self.contents_manager.file_exists(path))
             if exists:
-                yield gen.maybe_future(self._save(model, path))
+                yield maybe_future(self._save(model, path))
             else:
-                yield gen.maybe_future(self._upload(model, path))
+                yield maybe_future(self._upload(model, path))
         else:
-            yield gen.maybe_future(self._new_untitled(path))
+            yield maybe_future(self._new_untitled(path))
 
     @web.authenticated
     @gen.coroutine
@@ -234,7 +234,7 @@ class ContentsHandler(APIHandler):
         """delete a file in the given path"""
         cm = self.contents_manager
         self.log.warning('delete %s', path)
-        yield gen.maybe_future(cm.delete(path))
+        yield maybe_future(cm.delete(path))
         self.set_status(204)
         self.finish()
 
@@ -246,7 +246,7 @@ class CheckpointsHandler(APIHandler):
     def get(self, path=''):
         """get lists checkpoints for a file"""
         cm = self.contents_manager
-        checkpoints = yield gen.maybe_future(cm.list_checkpoints(path))
+        checkpoints = yield maybe_future(cm.list_checkpoints(path))
         data = json.dumps(checkpoints, default=date_default)
         self.finish(data)
 
@@ -255,7 +255,7 @@ class CheckpointsHandler(APIHandler):
     def post(self, path=''):
         """post creates a new checkpoint"""
         cm = self.contents_manager
-        checkpoint = yield gen.maybe_future(cm.create_checkpoint(path))
+        checkpoint = yield maybe_future(cm.create_checkpoint(path))
         data = json.dumps(checkpoint, default=date_default)
         location = url_path_join(self.base_url, 'api/contents',
             url_escape(path), 'checkpoints', url_escape(checkpoint['id']))
@@ -271,7 +271,7 @@ class ModifyCheckpointsHandler(APIHandler):
     def post(self, path, checkpoint_id):
         """post restores a file from a checkpoint"""
         cm = self.contents_manager
-        yield gen.maybe_future(cm.restore_checkpoint(checkpoint_id, path))
+        yield maybe_future(cm.restore_checkpoint(checkpoint_id, path))
         self.set_status(204)
         self.finish()
 
@@ -280,7 +280,7 @@ class ModifyCheckpointsHandler(APIHandler):
     def delete(self, path, checkpoint_id):
         """delete clears a checkpoint for a given file"""
         cm = self.contents_manager
-        yield gen.maybe_future(cm.delete_checkpoint(checkpoint_id, path))
+        yield maybe_future(cm.delete_checkpoint(checkpoint_id, path))
         self.set_status(204)
         self.finish()
 
@@ -307,7 +307,7 @@ class TrustNotebooksHandler(IPythonHandler):
     @gen.coroutine
     def post(self,path=''):
         cm = self.contents_manager
-        yield gen.maybe_future(cm.trust_notebook(path))
+        yield maybe_future(cm.trust_notebook(path))
         self.set_status(201)
         self.finish()
 #-----------------------------------------------------------------------------

--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -14,14 +14,14 @@ from tornado import gen, web
 from tornado.concurrent import Future
 from tornado.ioloop import IOLoop
 
+from jupyter_client import protocol_version as client_protocol_version
 from jupyter_client.jsonutil import date_default
 from ipython_genutils.py3compat import cast_unicode
-from notebook.utils import url_path_join, url_escape
+from notebook.utils import maybe_future, url_path_join, url_escape
 
 from ...base.handlers import APIHandler
 from ...base.zmqhandlers import AuthenticatedZMQStreamHandler, deserialize_binary_message
 
-from jupyter_client import protocol_version as client_protocol_version
 
 class MainKernelHandler(APIHandler):
 
@@ -29,7 +29,7 @@ class MainKernelHandler(APIHandler):
     @gen.coroutine
     def get(self):
         km = self.kernel_manager
-        kernels = yield gen.maybe_future(km.list_kernels())
+        kernels = yield maybe_future(km.list_kernels())
         self.finish(json.dumps(kernels, default=date_default))
 
     @web.authenticated
@@ -44,8 +44,8 @@ class MainKernelHandler(APIHandler):
         else:
             model.setdefault('name', km.default_kernel_name)
 
-        kernel_id = yield gen.maybe_future(km.start_kernel(kernel_name=model['name']))
-        model = yield gen.maybe_future(km.kernel_model(kernel_id))
+        kernel_id = yield maybe_future(km.start_kernel(kernel_name=model['name']))
+        model = yield maybe_future(km.kernel_model(kernel_id))
         location = url_path_join(self.base_url, 'api', 'kernels', url_escape(kernel_id))
         self.set_header('Location', location)
         self.set_status(201)
@@ -64,7 +64,7 @@ class KernelHandler(APIHandler):
     @gen.coroutine
     def delete(self, kernel_id):
         km = self.kernel_manager
-        yield gen.maybe_future(km.shutdown_kernel(kernel_id))
+        yield maybe_future(km.shutdown_kernel(kernel_id))
         self.set_status(204)
         self.finish()
 
@@ -81,12 +81,12 @@ class KernelActionHandler(APIHandler):
         if action == 'restart':
 
             try:
-                yield gen.maybe_future(km.restart_kernel(kernel_id))
+                yield maybe_future(km.restart_kernel(kernel_id))
             except Exception as e:
                 self.log.error("Exception restarting kernel", exc_info=True)
                 self.set_status(500)
             else:
-                model = yield gen.maybe_future(km.kernel_model(kernel_id))
+                model = yield maybe_future(km.kernel_model(kernel_id))
                 self.write(json.dumps(model, default=date_default))
         self.finish()
 

--- a/notebook/services/kernels/kernelmanager.py
+++ b/notebook/services/kernels/kernelmanager.py
@@ -22,7 +22,7 @@ from traitlets import (Any, Bool, Dict, List, Unicode, TraitError, Integer,
        Float, Instance, default, validate
 )
 
-from notebook.utils import to_os_path, exists
+from notebook.utils import maybe_future, to_os_path, exists
 from notebook._tz import utcnow, isoformat
 from ipython_genutils.py3compat import getcwd
 
@@ -164,7 +164,7 @@ class MappingKernelManager(MultiKernelManager):
         if kernel_id is None:
             if path is not None:
                 kwargs['cwd'] = self.cwd_for_path(path)
-            kernel_id = yield gen.maybe_future(
+            kernel_id = yield maybe_future(
                 super(MappingKernelManager, self).start_kernel(**kwargs)
             )
             self._kernel_connections[kernel_id] = 0
@@ -306,7 +306,7 @@ class MappingKernelManager(MultiKernelManager):
     def restart_kernel(self, kernel_id):
         """Restart a kernel by kernel_id"""
         self._check_kernel_id(kernel_id)
-        yield gen.maybe_future(super(MappingKernelManager, self).restart_kernel(kernel_id))
+        yield maybe_future(super(MappingKernelManager, self).restart_kernel(kernel_id))
         kernel = self.get_kernel(kernel_id)
         # return a Future that will resolve when the kernel has successfully restarted
         channel = kernel.connect_shell()

--- a/notebook/services/kernelspecs/handlers.py
+++ b/notebook/services/kernelspecs/handlers.py
@@ -14,7 +14,8 @@ pjoin = os.path.join
 from tornado import web, gen
 
 from ...base.handlers import APIHandler
-from ...utils import url_path_join, url_unescape
+from ...utils import maybe_future, url_path_join, url_unescape
+
 
 
 def kernelspec_model(handler, name, spec_dict, resource_dir):
@@ -62,7 +63,7 @@ class MainKernelSpecHandler(APIHandler):
         model = {}
         model['default'] = km.default_kernel_name
         model['kernelspecs'] = specs = {}
-        kspecs = yield gen.maybe_future(ksm.get_all_specs())
+        kspecs = yield maybe_future(ksm.get_all_specs())
         for kernel_name, kernel_info in kspecs.items():
             try:
                 if is_kernelspec_model(kernel_info):
@@ -85,7 +86,7 @@ class KernelSpecHandler(APIHandler):
         ksm = self.kernel_spec_manager
         kernel_name = url_unescape(kernel_name)
         try:
-            spec = yield gen.maybe_future(ksm.get_kernel_spec(kernel_name))
+            spec = yield maybe_future(ksm.get_kernel_spec(kernel_name))
         except KeyError:
             raise web.HTTPError(404, u'Kernel spec %s not found' % kernel_name)
         if is_kernelspec_model(spec):

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ for more information.
     zip_safe = False,
     install_requires = [
         'jinja2',
-        'tornado>=4.1',
+        'tornado>=5.0',
         # pyzmq>=17 is not technically necessary,
         # but hopefully avoids incompatibilities with Tornado 5. April 2018
         'pyzmq>=17',

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ for more information.
                  'nbval', 'nose-exclude', 'selenium', 'pytest', 'pytest-cov'],
         'test:sys_platform == "win32"': ['nose-exclude'],
     },
-    python_requires = '>=3.4', 
+    python_requires = '>=3.5',
     entry_points = {
         'console_scripts': [
             'jupyter-notebook = notebook.notebookapp:main',


### PR DESCRIPTION
Tornado's gen.maybe_future is deprecated in 5.0 and doesn't suppport asyncio coroutines, which start showing up in some base methods (WebSocketHandler.get) in tornado 6.

#4449 monkeypatches the deprecated tornado gen.maybe_future for compatibility with asyncio, to keep the patch small for backporting.

This removes the monkeypatch, adopting our own multi_future throughout.