### PR TITLE
Backport PR #4449

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,10 @@ matrix:
           env:
           - GROUP=python
           - EXTRA_PIP="tornado<5"
+        - python: 2.7
+          env:
+          - GROUP=python
+          - EXTRA_PIP="tornado<5"
 
 after_success:
     - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,8 @@ before_install:
       fi
 
 install:
-    - pip install --pre .[test]
+    - pip install --pre .[test] $EXTRA_PIP
+    - pip freeze
     - wget https://github.com/jgm/pandoc/releases/download/1.19.1/pandoc-1.19.1-1-amd64.deb && sudo dpkg -i pandoc-1.19.1-1-amd64.deb
 
 
@@ -96,10 +97,15 @@ matrix:
           env: GROUP=python
         - python: 3.5
           env: GROUP=python
-        - python: "3.7-dev"
+        - python: 3.7
+          dist: xenial
           env: GROUP=python
         - python: 3.6
           env: GROUP=docs
+        - python: 3.6
+          env:
+          - GROUP=python
+          - EXTRA_PIP="tornado<5"
 
 after_success:
     - codecov

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,6 +21,15 @@ We strongly recommend that you upgrade pip to version 9+ of pip before upgrading
     Use ``pip install pip --upgrade`` to upgrade pip. Check pip version with
     ``pip --version``.
 
+.. _release-5.7.5:
+
+5.7.5
+-----
+
+- Fix compatibility with tornado 6 (:ghpull:`4392`, :ghpull:`4449`).
+- Fix opening integer filedescriptor during startup on Python 2 (:ghpull:`4349`)
+- Fix compatibility with asynchronous `KernelManager.restart_kernel` methods (:ghpull:`4412`)
+
 .. _release-5.7.4:
 
 5.7.4

--- a/notebook/_version.py
+++ b/notebook/_version.py
@@ -9,5 +9,5 @@ store the current version info of the notebook.
 
 # Next beta/alpha/rc release: The version number for beta is X.Y.ZbN **without dots**.
 
-version_info = (5, 7, 5, '.dev0')
+version_info = (5, 7, 5)
 __version__ = '.'.join(map(str, version_info[:3])) + ''.join(version_info[3:])

--- a/notebook/base/zmqhandlers.py
+++ b/notebook/base/zmqhandlers.py
@@ -172,7 +172,7 @@ class WebSocketMixin(object):
 
     def send_ping(self):
         """send a ping to keep the websocket alive"""
-        if self.stream.closed() and self.ping_callback is not None:
+        if self.ws_connection is None and self.ping_callback is not None:
             self.ping_callback.stop()
             return
 
@@ -237,7 +237,7 @@ class ZMQStreamHandler(WebSocketMixin, WebSocketHandler):
     def _on_zmq_reply(self, stream, msg_list):
         # Sometimes this gets triggered when the on_close method is scheduled in the
         # eventloop but hasn't been called.
-        if self.stream.closed() or stream.closed():
+        if self.ws_connection is None or stream.closed():
             self.log.warning("zmq message arrived on closed channel")
             self.close()
             return

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -73,7 +73,7 @@ define(function(){
     // tree
     jglobal('SessionList','tree/js/sessionlist');
 
-    Jupyter.version = "5.7.5.dev0";
+    Jupyter.version = "5.7.5";
     Jupyter._target = '_blank';
     return Jupyter;
 });

--- a/notebook/utils.py
+++ b/notebook/utils.py
@@ -13,12 +13,30 @@ import sys
 from distutils.version import LooseVersion
 
 try:
+    from inspect import isawaitable
+except ImportError:
+    def isawaitable(f):
+        """If isawaitable is undefined, nothing is awaitable"""
+        return False
+
+try:
+    from concurrent.futures import Future as ConcurrentFuture
+except ImportError:
+    class ConcurrentFuture:
+        """If concurrent.futures isn't importable, nothing will be a c.f.Future"""
+        pass
+
+try:
     from urllib.parse import quote, unquote, urlparse, urljoin
     from urllib.request import pathname2url
 except ImportError:
     from urllib import quote, unquote, pathname2url
     from urlparse import urlparse, urljoin
 
+# tornado.concurrent.Future is asyncio.Future
+# in tornado >=5 with Python 3
+from tornado.concurrent import Future as TornadoFuture
+from tornado import gen
 from ipython_genutils import py3compat
 
 # UF_HIDDEN is a stat flag not defined in the stat module.
@@ -306,3 +324,33 @@ if sys.platform == 'win32':
     check_pid = _check_pid_win32
 else:
     check_pid = _check_pid_posix
+
+
+def maybe_future(obj):
+    """Like tornado's gen.maybe_future
+
+    but more compatible with asyncio for recent versions
+    of tornado
+    """
+    if isinstance(obj, TornadoFuture):
+        return obj
+    elif isawaitable(obj):
+        return asyncio.ensure_future(obj)
+    elif isinstance(obj, ConcurrentFuture):
+        return asyncio.wrap_future(obj)
+    else:
+        # not awaitable, wrap scalar in future
+        f = TornadoFuture()
+        f.set_result(obj)
+        return f
+
+# monkeypatch tornado gen.maybe_future
+# on Python 3
+# TODO: remove monkeypatch after backporting smaller fix to 5.x
+try:
+    import asyncio
+except ImportError:
+    pass
+else:
+    import tornado.gen
+    tornado.gen.maybe_future = maybe_future

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ for more information.
     zip_safe = False,
     install_requires = [
         'jinja2',
-        'tornado>=4, <6',
+        'tornado>=4.1',
         # pyzmq>=17 is not technically necessary,
         # but hopefully avoids incompatibilities with Tornado 5. April 2018
         'pyzmq>=17',

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ for more information.
     zip_safe = False,
     install_requires = [
         'jinja2',
-        'tornado>=4.1',
+        'tornado>=4.1,<7',
         # pyzmq>=17 is not technically necessary,
         # but hopefully avoids incompatibilities with Tornado 5. April 2018
         'pyzmq>=17',


### PR DESCRIPTION
apply #4449 (conflict was due to change in gateway, which isn't in 5.7)

additionally, pin tornado<7 and cover tornado4+py2 in tests

ready to release 5.7.5 on merge