### PR TITLE
Fix incorrect MIME/Content-Type for JavaScript

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1619,10 +1619,12 @@ class NotebookApp(JupyterApp):
 
     def init_mime_overrides(self):
         # On some Windows machines, an application has registered an incorrect
-        # mimetype for CSS in the registry. Tornado uses this when serving
-        # .css files, causing browsers to reject the stylesheet. We know the
-        # mimetype always needs to be text/css, so we override it here.
+        # mimetype for CSS and JavaScript in the registry.
+        # Tornado uses this when serving .css files, causing browsers to reject the stylesheet.
+        # We know the mimetype always needs to be text/css for css
+        # and application/javascript for JS, so we override it here.
         mimetypes.add_type('text/css', '.css')
+        mimetypes.add_type('application/javascript', '.js')
 
 
     def shutdown_no_activity(self):

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1620,8 +1620,8 @@ class NotebookApp(JupyterApp):
     def init_mime_overrides(self):
         # On some Windows machines, an application has registered an incorrect
         # mimetype for CSS and JavaScript in the registry.
-        # Tornado uses this when serving .css files, causing browsers to reject the stylesheet.
-        # We know the mimetype always needs to be text/css for css
+        # Tornado uses this when serving .css and .js files, causing browsers to
+        # reject these files. We know the mimetype always needs to be text/css for css
         # and application/javascript for JS, so we override it here.
         mimetypes.add_type('text/css', '.css')
         mimetypes.add_type('application/javascript', '.js')


### PR DESCRIPTION
# Problem
Tornado serves JavaScript files with `Content-Type: text/plain`, which causes the browser to reject loading the JavaScript, due to Strict MIME checking enabled in the last version. This problem appears to manifest only on Windows hosted notebooks.

# Solution
Similar to the CSS fix, add in a mimetypes override for .js files

closes #4467 