### PR TITLE
Fix regressions in 5.7.x

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,6 +21,16 @@ We strongly recommend that you upgrade pip to version 9+ of pip before upgrading
     Use ``pip install pip --upgrade`` to upgrade pip. Check pip version with
     ``pip --version``.
 
+.. _release-5.7.7:
+
+5.7.7
+-----
+
+- Fix regression in restarting kernels in 5.7.5.
+  The restart handler would return before restart was completed.
+- Further improve compatibility with tornado 6 with improved
+  checks for when websockets are closed.
+
 .. _release-5.7.6:
 
 5.7.6

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -30,6 +30,7 @@ We strongly recommend that you upgrade pip to version 9+ of pip before upgrading
   The restart handler would return before restart was completed.
 - Further improve compatibility with tornado 6 with improved
   checks for when websockets are closed.
+- Fix regression in 5.7.6 on Windows where .js files could have the wrong mime-type.
 
 .. _release-5.7.6:
 

--- a/notebook/services/kernels/kernelmanager.py
+++ b/notebook/services/kernels/kernelmanager.py
@@ -342,7 +342,8 @@ class MappingKernelManager(MultiKernelManager):
         channel.on_recv(on_reply)
         loop = IOLoop.current()
         timeout = loop.add_timeout(loop.time() + self.kernel_info_timeout, on_timeout)
-        raise gen.Return(future)
+        # wait for restart to complete
+        yield future
 
     def notify_connect(self, kernel_id):
         """Notice a new connection to a kernel"""


### PR DESCRIPTION
Fixes some closed-socket issues with direct-checks for closed or closing sockets, which seems to change across tornado versions.

for backport to 5.7.x

debugging issues in https://github.com/jupyterlab/jupyterlab/pull/6138