### PR TITLE
Workaround for socket permission errors on Cygwin

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1739,7 +1739,7 @@ class NotebookApp(JupyterApp):
                         self.log.info(_('The port %i is already in use.') % port)
                     continue
                 elif e.errno in eacces:
-                    self.log.warning(_("Permission to listen on port %i denied") % port)
+                    self.log.warning(_("Permission to listen on port %i denied.") % port)
                     continue
                 else:
                     raise

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1725,14 +1725,21 @@ class NotebookApp(JupyterApp):
             try:
                 self.http_server.listen(port, self.ip)
             except socket.error as e:
+                eacces = (errno.EACCES, getattr(errno, 'WSAEACCES', errno.EACCES))
+                if sys.platform == 'cygwin':
+                    # Cygwin has a bug that causes EPERM to be returned in this
+                    # case instead of EACCES:
+                    # https://cygwin.com/ml/cygwin/2019-04/msg00160.html
+                    eacces += (errno.EPERM,)
+
                 if e.errno == errno.EADDRINUSE:
                     if self.port_retries:
                         self.log.info(_('The port %i is already in use, trying another port.') % port)
                     else:
                         self.log.info(_('The port %i is already in use.') % port)
                     continue
-                elif e.errno in (errno.EACCES, getattr(errno, 'WSAEACCES', errno.EACCES)):
-                    self.log.warning(_("Permission to listen on port %i denied.") % port)
+                elif e.errno in eacces:
+                    self.log.warning(_("Permission to listen on port %i denied") % port)
                     continue
                 else:
                     raise


### PR DESCRIPTION
As reported first [here](https://ask.sagemath.org/question/46075/sage-notebook-crashes-immediately), when running on Cygwin if the notebook server tries to bind on the default port (say 8888) and this results in a permission error for some reason (perhaps a service is installed that as exclusive permission to use that port) the notebook server crashes instead of automatically trying another port.

I confirmed that this is likely due to a [bug in Cygwin](https://cygwin.com/ml/cygwin/2019-04/msg00160.html) such that it does not properly map the `WSAEACCES` winsock error code to the POSIX `EACCES`.

This provides a simple workaround--unfortunately the workaround can in principle mask other errors (since the `EPERM` set by Cygwin is a default fallback for unrecognized winsock errors), but this is going to be the most likely culprit for users.