### PR TITLE
fix duplicates in download as menu

### DIFF
--- a/notebook/notebook/handlers.py
+++ b/notebook/notebook/handlers.py
@@ -18,17 +18,18 @@ from ..transutils import _
 def get_frontend_exporters():
     from nbconvert.exporters.base import get_export_names, get_exporter
 
+    # name=exporter_name, display=export_from_notebook+extension
     ExporterInfo = namedtuple('ExporterInfo', ['name', 'display'])
 
     default_exporters = [
-        ExporterInfo(name='html', display='html (.html)'),
-        ExporterInfo(name='latex', display='latex (.tex)'),
-        ExporterInfo(name='markdown', display='markdown (.md)'),
-        ExporterInfo(name='notebook', display='notebook (.ipynb)'),
-        ExporterInfo(name='pdf', display='pdf (.pdf)'),
-        ExporterInfo(name='rst', display='rst (.rst)'),
-        ExporterInfo(name='script', display='script (.txt)'),
-        ExporterInfo(name='slides', display='slides (.slides.html)')
+        ExporterInfo(name='html', display='HTML (.html)'),
+        ExporterInfo(name='latex', display='LaTeX (.tex)'),
+        ExporterInfo(name='markdown', display='Markdown (.md)'),
+        ExporterInfo(name='notebook', display='Notebook (.ipynb)'),
+        ExporterInfo(name='pdf', display='PDF via LaTeX (.pdf)'),
+        ExporterInfo(name='rst', display='reST (.rst)'),
+        ExporterInfo(name='script', display='Script (.txt)'),
+        ExporterInfo(name='slides', display='Reveal.js slides (.slides.html)')
     ]
 
     frontend_exporters = []
@@ -46,11 +47,16 @@ def get_frontend_exporters():
             frontend_exporters.append(ExporterInfo(name, display))
 
     # Ensure default_exporters are in frontend_exporters if not already
-    # This protects againts nbconvert versions lower than 5.5
+    # This protects against nbconvert versions lower than 5.5
     names = set(exporter.name.lower() for exporter in frontend_exporters)
     for exporter in default_exporters:
-        if exporter.name.lower() not in names:
+        if exporter.name not in names:
             frontend_exporters.append(exporter)
+
+    # Protect against nbconvert 5.5.0
+    python_exporter = ExporterInfo(name='python', display='python (.py)')
+    if python_exporter in frontend_exporters:
+        frontend_exporters.remove(python_exporter)
 
     # Protect against nbconvert 5.4.x
     template_exporter = ExporterInfo(name='custom', display='custom (.txt)')

--- a/notebook/templates/notebook.html
+++ b/notebook/templates/notebook.html
@@ -111,15 +111,7 @@ data-notebook-path="{{notebook_path | urlencode}}"
                         <li id="print_preview"><a href="#">{% trans %}Print Preview{% endtrans %}</a></li>
                         <li class="dropdown-submenu"><a href="#">{% trans %}Download as{% endtrans %}</a>
                             <ul id="download_menu" class="dropdown-menu">
-                                <li id="download_ipynb"><a href="#">{% trans %}Notebook (.ipynb){% endtrans %}</a></li>
-                                <li id="download_script"><a href="#">{% trans %}Script{% endtrans %}</a></li>
-                                <li id="download_html"><a href="#">{% trans %}HTML (.html){% endtrans %}</a></li>
-                                <li id="download_slides"><a href="#">{% trans %}Reveal.js slides (.html){% endtrans %}</a></li>
-                                <li id="download_markdown"><a href="#">{% trans %}Markdown (.md){% endtrans %}</a></li>
-                                <li id="download_rst"><a href="#">{% trans %}reST (.rst){% endtrans %}</a></li>
-                                <li id="download_latex"><a href="#">{% trans %}LaTeX (.tex){% endtrans %}</a></li>
-                                <li id="download_pdf"><a href="#">{% trans %}PDF via LaTeX (.pdf){% endtrans %}</a></li>
-                                {% for exporter in get_custom_frontend_exporters() %}
+                                {% for exporter in get_frontend_exporters() %}
                                 <li id="download_{{ exporter.name }}">
                                     <a href="#">{{ exporter.display }}</a>
                                 </li>


### PR DESCRIPTION
fixes #4560. nbconvert 5.4.0 implemented the ```export_from_notebook``` to the built-in exporters. This means that due to the hardcoding of the built-in exporters in the menu that they are duplicated. I also included a safeguard to ensure that exporters explicitly define an ```export_from_notebook``` that is different from its superclass, so that custom exporters must be explicitly added to the menu, and don't create confusion with duplicate names.

Before:
![before](https://user-images.githubusercontent.com/18018386/56709771-ec4d4700-66d7-11e9-969f-db717ac97ac6.png)

After:
![image](https://user-images.githubusercontent.com/18018386/56709781-f7a07280-66d7-11e9-9351-28db000291be.png)

Unfortunately, currently nbconvert 5.4 does not define ```export_from_notebook``` for the html exporter and it inherits ```export_from_notebook``` meaning that it will not appear in the list after this change. This was however fixed in [nbconvert 5.5](https://github.com/jupyter/nbconvert/pull/1001) which released today.

Should you wish to put in this change without relying on nbconvert 5.5, I can remove the safeguard that checks the superclass. (the html exporter will then appear as ```custom (.html)``` until the nbconvert fix).