### PR TITLE
fix default file name for make a copy

### DIFF
--- a/notebook/services/contents/manager.py
+++ b/notebook/services/contents/manager.py
@@ -331,7 +331,10 @@ class ContentsManager(LoggingConfigurable):
         """
         # Extract the full suffix from the filename (e.g. .tar.gz)
         path = path.strip('/')
-        basename, dot, ext = filename.partition('.')
+        basename, dot, ext = filename.rpartition('.')
+        if ext != 'ipynb':
+                basename, dot, ext = filename.partition('.')
+                
         suffix = dot + ext
 
         for i in itertools.count():
@@ -425,6 +428,8 @@ class ContentsManager(LoggingConfigurable):
 
         If to_path not specified, it will be the parent directory of from_path.
         If to_path is a directory, filename will increment `from_path-Copy#.ext`.
+        Considering multi-part extensions, the Copy# part will be placed before the first dot for all the extensions except `ipynb`.
+        For easier manual searching in case of notebooks, the Copy# part will be placed before the last dot. 
 
         from_path must be a full path to a file.
         """


### PR DESCRIPTION
If  a copy of notebook is created using _File>Make a Copy..._, the default filename is copied after partitioning the filename by dot (.) and appending _-Copy1_ (for the first copy) to the name of the file as shown in the picture below. In case, a filename itself contains dot (.), then it will partition from left instead of the right dot(.). I have fixed this issue by partitioning from the right side instead of the left which is more logical. I have attached the screenshots for the same.

Original file:
![before](https://user-images.githubusercontent.com/8968547/57484526-e0ac7380-72c6-11e9-9fd4-559c2afd2fed.png)

On making a copy of the notebook (before fix):
![before_1](https://user-images.githubusercontent.com/8968547/57484569-fc177e80-72c6-11e9-9b5b-dd65920fa943.png)

On making a copy of the notebook (after fix):
![after](https://user-images.githubusercontent.com/8968547/57484587-08034080-72c7-11e9-8209-e66fcb639e1b.png)