### PR TITLE
Make tooltip buttons have consistent appearance

### DIFF
--- a/notebook/static/notebook/js/tooltip.js
+++ b/notebook/static/notebook/js/tooltip.js
@@ -37,8 +37,8 @@ define([
 
         // build the buttons menu on the upper right
         // expand the tooltip to see more
-        var expandlink = $('<a/>').attr('href', "#").addClass("ui-corner-all") //rounded corner
-        .attr('role', "button").attr('id', 'expanbutton').attr('title', i18n.msg._('Grow the tooltip vertically (press shift-tab twice)')).click(function () {
+        var expandlink = $('<a/>').attr('href', "#").attr('role', "button").addClass('ui-button')
+        .attr('id', 'expanbutton').attr('title', i18n.msg._('Grow the tooltip vertically (press shift-tab twice)')).click(function () {
             that.expand();
             event.preventDefault();
         }).append(


### PR DESCRIPTION
Change class of `expandlink` from `ui-corner-all` to `ui-button` to be consistent with `morelink` and `closelink`

Current appearance of tooltip:

![image](https://user-images.githubusercontent.com/3360192/57575939-bd96d680-7422-11e9-9743-f0e8b3294062.png)


In the added red rectangle, the "+" sign is different in appearance compared to surrounding "^" and "x" signs.

Current html:

![image](https://user-images.githubusercontent.com/3360192/57575905-d2bf3580-7421-11e9-871f-12a3d9208021.png)

Changing the html within the browser inspector to the following:

![image](https://user-images.githubusercontent.com/3360192/57575915-1e71df00-7422-11e9-889f-092a329a03e4.png)

Produces:

![image](https://user-images.githubusercontent.com/3360192/57575917-2a5da100-7422-11e9-8599-a4f011ca5f07.png)

The changes within this commit are aimed to reproduce this appearance. 