### PR TITLE
Use JavaScript to redirect users

### DIFF
--- a/notebook/templates/browser-open.html
+++ b/notebook/templates/browser-open.html
@@ -6,6 +6,11 @@
     <meta charset="UTF-8">
     <meta http-equiv="refresh" content="1;url={{ open_url }}" />
     <title>Opening Jupyter Notebook</title>
+    <script>
+      setTimeout(function() {
+        window.location.href = "{{ open_url }}";
+      }, 1000);
+    </script>
 </head>
 <body>
 


### PR DESCRIPTION
This is a followup to #4260.

This uses JS to do the redirection which works on Firefox (tested on FF 67.0b17 (64-bit)). The meta-refresh is still there so users without JS will be redirected as well.