### PR TITLE
.travis.yml: The 'sudo' tag is now deprecated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,4 +101,3 @@ matrix:
 
 after_success:
     - codecov
-   

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,3 +101,4 @@ matrix:
 
 after_success:
     - codecov
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,4 +101,4 @@ matrix:
 
 after_success:
     - codecov
-    
+   

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ cache:
 python:
     - 3.6
 
-sudo: required
-
 
 env:
   global:


### PR DESCRIPTION
`sudo: required` no longer is. "If you currently specify sudo: in your .travis.yml, we recommend removing that configuration".

[Travis are now recommending removing the sudo tag.](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)


