### PR TITLE
Updated config to listen on all interfaces

### DIFF
--- a/docs/source/public_server.rst
+++ b/docs/source/public_server.rst
@@ -213,7 +213,7 @@ following::
      c.NotebookApp.certfile = u'/absolute/path/to/your/certificate/mycert.pem'
      c.NotebookApp.keyfile = u'/absolute/path/to/your/certificate/mykey.key'
      # Set ip to '*' to bind on all interfaces (ips) for the public server
-     c.NotebookApp.ip = '*'
+     c.NotebookApp.ip = '0.0.0.0'
      c.NotebookApp.password = u'sha1:bcd259ccf...<your hashed password here>'
      c.NotebookApp.open_browser = False
 


### PR DESCRIPTION
As per https://github.com/jupyter/notebook/pull/3714, the ip address for listening on all interfaces has changed from '*' to '0.0.0.0'