### PR TITLE
Fix for recursive symlink issue #4669

### DIFF
--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -342,7 +342,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
                             )
                 except OSError as e:
                     # Ignore recursive links and move on
-                    if e.errno==62 or e.errno==40:
+                    if e.errno==errno.ELOOP:
                         continue
                     else:
                         raise e

--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -334,12 +334,18 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
                     self.log.debug("%s not a regular file", os_path)
                     continue
 
-                if self.should_list(name):
-                    if self.allow_hidden or not is_file_hidden(os_path, stat_res=st):
-                        contents.append(
-                                self.get(path='%s/%s' % (path, name), content=False)
-                        )
-
+                try:
+                    if self.should_list(name):
+                        if self.allow_hidden or not is_file_hidden(os_path, stat_res=st):
+                            contents.append(
+                                    self.get(path='%s/%s' % (path, name), content=False)
+                            )
+                except OSError as e:
+                    # Ignore recursive links and move on
+                    if e.errno==62:
+                        continue
+                    else:
+                        raise e
             model['format'] = 'json'
 
         return model

--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -342,7 +342,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
                             )
                 except OSError as e:
                     # Ignore recursive links and move on
-                    if e.errno==62:
+                    if e.errno==62 or e.errno==40:
                         continue
                     else:
                         raise e

--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -341,11 +341,13 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
                                     self.get(path='%s/%s' % (path, name), content=False)
                             )
                 except OSError as e:
-                    # Ignore recursive links and move on
-                    if e.errno==errno.ELOOP:
-                        continue
-                    else:
-                        raise e
+                    # ELOOP: recursive symlink
+                    if e.errno != errno.ELOOP:
+                        self.log.warning(
+                            "Unknown error checking if file %r is hidden",
+                            os_path,
+                            exc_info=True,
+                        )
             model['format'] = 'json'
 
         return model

--- a/notebook/services/contents/tests/test_manager.py
+++ b/notebook/services/contents/tests/test_manager.py
@@ -130,6 +130,26 @@ class TestFileContentsManager(TestCase):
             self.assertTrue('bad symlink' in contents)
 
     @dec.skipif(sys.platform == 'win32' and sys.version_info[0] < 3)
+    def test_recursive_symlink(self):
+        with TemporaryDirectory() as td:
+            cm = FileContentsManager(root_dir=td)
+            path = 'test recursive symlink'
+            _make_dir(cm, path)
+            os_path = cm._get_os_path(path)
+            os.symlink("recursive", os.path.join(os_path, "recursive"))
+            file_model = cm.new_untitled(path=path, ext='.txt')
+
+            model = cm.get(path)
+
+            contents = {
+                content['name']: content for content in model['content']
+            }
+            self.assertTrue('untitled.txt' in contents)
+            self.assertEqual(contents['untitled.txt'], file_model)
+            # recusrive symlinks should not be shown in the contents manager
+            self.assertFalse('recusrive' in contents)
+
+    @dec.skipif(sys.platform == 'win32' and sys.version_info[0] < 3)
     def test_good_symlink(self):
         with TemporaryDirectory() as td:
             cm = FileContentsManager(root_dir=td)

--- a/notebook/services/contents/tests/test_manager.py
+++ b/notebook/services/contents/tests/test_manager.py
@@ -149,7 +149,7 @@ class TestFileContentsManager(TestCase):
             # recursive symlinks should not be shown in the contents manager
             self.assertNotIn('recursive', contents)
 
-    @dec.skipif(sys.platform == 'win32' and sys.version_info[0] < 3)
+    @dec.skipif(sys.platform == 'win32')
     def test_good_symlink(self):
         with TemporaryDirectory() as td:
             cm = FileContentsManager(root_dir=td)

--- a/notebook/services/contents/tests/test_manager.py
+++ b/notebook/services/contents/tests/test_manager.py
@@ -144,10 +144,10 @@ class TestFileContentsManager(TestCase):
             contents = {
                 content['name']: content for content in model['content']
             }
-            self.assertTrue('untitled.txt' in contents)
+            self.assertIn('untitled.txt', contents)
             self.assertEqual(contents['untitled.txt'], file_model)
-            # recusrive symlinks should not be shown in the contents manager
-            self.assertFalse('recusrive' in contents)
+            # recursive symlinks should not be shown in the contents manager
+            self.assertNotIn('recursive', contents)
 
     @dec.skipif(sys.platform == 'win32' and sys.version_info[0] < 3)
     def test_good_symlink(self):

--- a/notebook/services/contents/tests/test_manager.py
+++ b/notebook/services/contents/tests/test_manager.py
@@ -129,7 +129,7 @@ class TestFileContentsManager(TestCase):
             # broken symlinks should still be shown in the contents manager
             self.assertTrue('bad symlink' in contents)
 
-    @dec.skipif(sys.platform == 'win32' and sys.version_info[0] < 3)
+    @dec.skipif(sys.platform == 'win32')
     def test_recursive_symlink(self):
         with TemporaryDirectory() as td:
             cm = FileContentsManager(root_dir=td)
@@ -149,7 +149,7 @@ class TestFileContentsManager(TestCase):
             # recursive symlinks should not be shown in the contents manager
             self.assertNotIn('recursive', contents)
 
-    @dec.skipif(sys.platform == 'win32')
+    @dec.skipif(sys.platform == 'win32' and sys.version_info[0] < 3)
     def test_good_symlink(self):
         with TemporaryDirectory() as td:
             cm = FileContentsManager(root_dir=td)


### PR DESCRIPTION
This is a potential fix to issue #4669.  The fix simply catches the
recursive symlink error and moves on.  It is possible that the
try/except belongs in the utils but I wanted to limit the scope.