### PR TITLE
Port NB2KG PRs to Gateway

### DIFF
--- a/notebook/gateway/handlers.py
+++ b/notebook/gateway/handlers.py
@@ -10,7 +10,7 @@ from ..utils import url_path_join
 
 from tornado import gen, web
 from tornado.concurrent import Future
-from tornado.ioloop import IOLoop
+from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.websocket import WebSocketHandler, websocket_connect
 from tornado.httpclient import HTTPRequest
 from tornado.escape import url_escape, json_decode, utf8
@@ -21,12 +21,16 @@ from traitlets.config.configurable import LoggingConfigurable
 
 from .managers import GatewayClient
 
+# Keepalive ping interval (default: 30 seconds)
+GATEWAY_WS_PING_INTERVAL_SECS = int(os.getenv('GATEWAY_WS_PING_INTERVAL_SECS', 30))
+
 
 class WebSocketChannelsHandler(WebSocketHandler, IPythonHandler):
 
     session = None
     gateway = None
     kernel_id = None
+    ping_callback = None
 
     def set_default_headers(self):
         """Undo the set_default_headers in IPythonHandler which doesn't make sense for websockets"""
@@ -63,8 +67,18 @@ class WebSocketChannelsHandler(WebSocketHandler, IPythonHandler):
         self.kernel_id = cast_unicode(kernel_id, 'ascii')
         super(WebSocketChannelsHandler, self).get(kernel_id=kernel_id, *args, **kwargs)
 
+    def send_ping(self):
+        if self.ws_connection is None and self.ping_callback is not None:
+            self.ping_callback.stop()
+            return
+
+        self.ping(b'')
+
     def open(self, kernel_id, *args, **kwargs):
         """Handle web socket connection open to notebook server and delegate to gateway web socket handler """
+        self.ping_callback = PeriodicCallback(self.send_ping, GATEWAY_WS_PING_INTERVAL_SECS * 1000)
+        self.ping_callback.start()
+
         self.gateway.on_open(
             kernel_id=kernel_id,
             message_callback=self.write_message,

--- a/notebook/gateway/managers.py
+++ b/notebook/gateway/managers.py
@@ -191,7 +191,7 @@ class GatewayClient(SingletonConfigurable):
 
     @default('auth_token')
     def _auth_token_default(self):
-        return os.environ.get(self.auth_token_env)
+        return os.environ.get(self.auth_token_env, '')
 
     validate_cert_default_value = True
     validate_cert_env = 'JUPYTER_GATEWAY_VALIDATE_CERT'
@@ -240,7 +240,10 @@ class GatewayClient(SingletonConfigurable):
             self.request_timeout = float(GatewayClient.KERNEL_LAUNCH_TIMEOUT + GatewayClient.LAUNCH_TIMEOUT_PAD)
 
         self._static_args['headers'] = json.loads(self.headers)
-        self._static_args['headers'].update({'Authorization': 'token {}'.format(self.auth_token)})
+        if 'Authorization' not in self._static_args['headers'].keys():
+            self._static_args['headers'].update({
+                'Authorization': 'token {}'.format(self.auth_token)
+            })
         self._static_args['connect_timeout'] = self.connect_timeout
         self._static_args['request_timeout'] = self.request_timeout
         self._static_args['validate_cert'] = self.validate_cert

--- a/notebook/gateway/managers.py
+++ b/notebook/gateway/managers.py
@@ -226,7 +226,7 @@ class GatewayClient(SingletonConfigurable):
 
     # Ensure KERNEL_LAUNCH_TIMEOUT has a default value.
     KERNEL_LAUNCH_TIMEOUT = int(os.environ.get('KERNEL_LAUNCH_TIMEOUT', 40))
-    os.environ['KERNEL_LAUNCH_TIMEOUT'] = KERNEL_LAUNCH_TIMEOUT
+    os.environ['KERNEL_LAUNCH_TIMEOUT'] = str(KERNEL_LAUNCH_TIMEOUT)
 
     LAUNCH_TIMEOUT_PAD = int(os.environ.get('LAUNCH_TIMEOUT_PAD', 2))
 

--- a/notebook/gateway/managers.py
+++ b/notebook/gateway/managers.py
@@ -35,6 +35,7 @@ class GatewayClient(SingletonConfigurable):
     )
 
     url_env = 'JUPYTER_GATEWAY_URL'
+
     @default('url')
     def _url_default(self):
         return os.environ.get(self.url_env)
@@ -55,6 +56,7 @@ class GatewayClient(SingletonConfigurable):
     )
 
     ws_url_env = 'JUPYTER_GATEWAY_WS_URL'
+
     @default('ws_url')
     def _ws_url_default(self):
         default_value = os.environ.get(self.ws_url_env)
@@ -100,7 +102,7 @@ class GatewayClient(SingletonConfigurable):
     def _kernelspecs_resource_endpoint_default(self):
         return os.environ.get(self.kernelspecs_resource_endpoint_env, self.kernelspecs_resource_endpoint_default_value)
 
-    connect_timeout_default_value = 20.0
+    connect_timeout_default_value = 60.0
     connect_timeout_env = 'JUPYTER_GATEWAY_CONNECT_TIMEOUT'
     connect_timeout = Float(default_value=connect_timeout_default_value, config=True,
         help="""The time allowed for HTTP connection establishment with the Gateway server.
@@ -110,7 +112,7 @@ class GatewayClient(SingletonConfigurable):
     def connect_timeout_default(self):
         return float(os.environ.get('JUPYTER_GATEWAY_CONNECT_TIMEOUT', self.connect_timeout_default_value))
 
-    request_timeout_default_value = 20.0
+    request_timeout_default_value = 60.0
     request_timeout_env = 'JUPYTER_GATEWAY_REQUEST_TIMEOUT'
     request_timeout = Float(default_value=request_timeout_default_value, config=True,
         help="""The time allowed for HTTP request completion. (JUPYTER_GATEWAY_REQUEST_TIMEOUT env var)""")
@@ -171,7 +173,7 @@ class GatewayClient(SingletonConfigurable):
 
     headers_default_value = '{}'
     headers_env = 'JUPYTER_GATEWAY_HEADERS'
-    headers = Unicode(default_value=headers_default_value, allow_none=True,config=True,
+    headers = Unicode(default_value=headers_default_value, allow_none=True, config=True,
         help="""Additional HTTP headers to pass on the request.  This value will be converted to a dict.
           (JUPYTER_GATEWAY_HEADERS env var)
         """
@@ -222,11 +224,21 @@ class GatewayClient(SingletonConfigurable):
     def gateway_enabled(self):
         return bool(self.url is not None and len(self.url) > 0)
 
+    # Ensure KERNEL_LAUNCH_TIMEOUT has a default value.
+    KERNEL_LAUNCH_TIMEOUT = int(os.environ.get('KERNEL_LAUNCH_TIMEOUT', 40))
+    os.environ['KERNEL_LAUNCH_TIMEOUT'] = KERNEL_LAUNCH_TIMEOUT
+
+    LAUNCH_TIMEOUT_PAD = int(os.environ.get('LAUNCH_TIMEOUT_PAD', 2))
+
     def init_static_args(self):
         """Initialize arguments used on every request.  Since these are static values, we'll
         perform this operation once.
 
         """
+        # Ensure that request timeout is at least "pad" greater than launch timeout.
+        if self.request_timeout < float(GatewayClient.KERNEL_LAUNCH_TIMEOUT + GatewayClient.LAUNCH_TIMEOUT_PAD):
+            self.request_timeout = float(GatewayClient.KERNEL_LAUNCH_TIMEOUT + GatewayClient.LAUNCH_TIMEOUT_PAD)
+
         self._static_args['headers'] = json.loads(self.headers)
         self._static_args['headers'].update({'Authorization': 'token {}'.format(self.auth_token)})
         self._static_args['connect_timeout'] = self.connect_timeout
@@ -270,13 +282,13 @@ def gateway_request(endpoint, **kwargs):
               "Check to be sure the Gateway instance is running.".format(GatewayClient.instance().url))
     except HTTPError:
         # This can occur if the host is valid (e.g., foo.com) but there's nothing there.
-        raise web.HTTPError(504, "Error attempting to connect to Gateway server url '{}'.  " \
-                       "Ensure gateway url is valid and the Gateway instance is running.".format(
-            GatewayClient.instance().url))
+        raise web.HTTPError(504, "Error attempting to connect to Gateway server url '{}'.  "
+                       "Ensure gateway url is valid and the Gateway instance is running.".
+                            format(GatewayClient.instance().url))
     except gaierror as e:
         raise web.HTTPError(404, "The Gateway server specified in the gateway_url '{}' doesn't appear to be valid.  "
-                       "Ensure gateway url is valid and the Gateway instance is running.".format(
-            GatewayClient.instance().url))
+                       "Ensure gateway url is valid and the Gateway instance is running.".
+                            format(GatewayClient.instance().url))
 
     raise gen.Return(response)
 
@@ -409,7 +421,7 @@ class GatewayKernelManager(MappingKernelManager):
         self.log.debug("Request list kernels: %s", kernel_url)
         response = yield gateway_request(kernel_url, method='GET')
         kernels = json_decode(response.body)
-        self._kernels = {x['id']:x for x in kernels}
+        self._kernels = {x['id']: x for x in kernels}
         raise gen.Return(kernels)
 
     @gen.coroutine
@@ -420,6 +432,10 @@ class GatewayKernelManager(MappingKernelManager):
         ==========
         kernel_id : uuid
             The id of the kernel to shutdown.
+        now : bool
+            Shutdown the kernel immediately (True) or gracefully (False)
+        restart : bool
+            The purpose of this shutdown is to restart the kernel (True)
         """
         kernel_url = self._get_kernel_endpoint_url(kernel_id)
         self.log.debug("Request shutdown kernel at: %s", kernel_url)


### PR DESCRIPTION
As the winds of a Notebook 6.0 release are blowing, we need to get some of the recent fixes in NB2KG into the Gateway module for Notebook since 6.0 marks the first release in which the extension is embedded in Notebook.

The ported changes are the following:

1. https://github.com/jupyter/nb2kg/pull/35, https://github.com/jupyter/nb2kg/pull/38: Modify/add various timeout values and ensure the request timeout is greater than the kernel launch timeout.  
2. https://github.com/jupyter/nb2kg/pull/30: Add authorization token to header only if no authorization already present.  @chuyqa - could you please confirm these changes are correct.
3. https://github.com/jupyter/nb2kg/pull/29: Add keepalive ping on gateway websocket.  @esevan - could you please confirm these changes are correct.

Once Notebook 6.0 is available, we will move NB2KG into maintenance mode.

cc: @Zsailer - we'll want this PR included in the list at https://github.com/jupyter/jupyter_server/issues/53.  Thanks!