### PR TITLE
Solved Issue #4006

### DIFF
--- a/notebook/static/base/js/dialog.js
+++ b/notebook/static/base/js/dialog.js
@@ -234,6 +234,7 @@ define(['jquery',
         });
 
         modal_obj.on('shown.bs.modal', function(){ editor.refresh(); });
+        modal_obj.on('hide.bs.modal', function(){options.edit_metadata_button.focus(); });
     };
 
     var edit_attachments = function (options) {

--- a/notebook/static/base/js/dialog.js
+++ b/notebook/static/base/js/dialog.js
@@ -235,7 +235,7 @@ define(['jquery',
 
         modal_obj.on('shown.bs.modal', function(){ editor.refresh(); });
         modal_obj.on('hide.bs.modal', function(){
-            options.edit_metadata_button ? options.edit_metadata_button.focus() : ""});
+            options.edit_metadata_button ? options.edit_metadata_button.focus() : "";});
     };
 
     var edit_attachments = function (options) {

--- a/notebook/static/base/js/dialog.js
+++ b/notebook/static/base/js/dialog.js
@@ -234,7 +234,8 @@ define(['jquery',
         });
 
         modal_obj.on('shown.bs.modal', function(){ editor.refresh(); });
-        modal_obj.on('hide.bs.modal', function(){options.edit_metadata_button.focus(); });
+        modal_obj.on('hide.bs.modal', function(){
+            options.edit_metadata_button ? options.edit_metadata_button.focus() : ""});
     };
 
     var edit_attachments = function (options) {

--- a/notebook/static/notebook/js/celltoolbarpresets/default.js
+++ b/notebook/static/notebook/js/celltoolbarpresets/default.js
@@ -10,7 +10,7 @@ define([
 
     var CellToolbar = celltoolbar.CellToolbar;
 
-    var raw_edit = function (cell) {
+    var raw_edit = function (cell , edit_metadata_button) {
         dialog.edit_metadata({
             md: cell.metadata,
             callback: function (md) {
@@ -18,7 +18,8 @@ define([
             },
             name: i18n.msg._('Cell'),
             notebook: this.notebook,
-            keyboard_manager: this.keyboard_manager
+            keyboard_manager: this.keyboard_manager,
+            edit_metadata_button: edit_metadata_button
         });
     };
 
@@ -28,9 +29,10 @@ define([
             .addClass("btn btn-default btn-xs")
             .text(i18n.msg._("Edit Metadata"))
             .click( function () {
-                raw_edit(cell);
+                raw_edit(cell, this);
                 return false;
             });
+
         button_container.append(button);
     };
 

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -938,6 +938,7 @@ define([
         if (this.mode !== 'command') {
             cell.command_mode();
             this.mode = 'command';
+            $('div[class*="code_cell"]')
             this.events.trigger('command_mode.Notebook');
             this.keyboard_manager.command_mode();
         }
@@ -965,6 +966,10 @@ define([
         if (cell && this.mode !== 'edit') {
             cell.edit_mode();
             this.mode = 'edit';
+<<<<<<< HEAD
+=======
+            $('div[class*="code_cell"]')
+>>>>>>> 1dbabaa0a... #4006: fixed the edit-metadata button so that focus returns to it after closing the popup
             this.events.trigger('edit_mode.Notebook');
             this.keyboard_manager.edit_mode();
         }

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -938,7 +938,6 @@ define([
         if (this.mode !== 'command') {
             cell.command_mode();
             this.mode = 'command';
-            $('div[class*="code_cell"]')
             this.events.trigger('command_mode.Notebook');
             this.keyboard_manager.command_mode();
         }
@@ -966,10 +965,6 @@ define([
         if (cell && this.mode !== 'edit') {
             cell.edit_mode();
             this.mode = 'edit';
-<<<<<<< HEAD
-=======
-            $('div[class*="code_cell"]')
->>>>>>> 1dbabaa0a... #4006: fixed the edit-metadata button so that focus returns to it after closing the popup
             this.events.trigger('edit_mode.Notebook');
             this.keyboard_manager.edit_mode();
         }


### PR DESCRIPTION
Fixed issue #4006. To ensure focus returns to the "Edit Metadata" button after closing the popup, we stored the button once created (in JS) and then set it to focus on the button once the popup is hidden.


