### PR TITLE
Solved Issue #3967: added more descriptive title for tree page

### DIFF
--- a/notebook/tree/handlers.py
+++ b/notebook/tree/handlers.py
@@ -32,7 +32,7 @@ class TreeHandler(IPythonHandler):
         if page_title:
             return page_title+'/'
         else:
-            return 'Home'
+            return 'Home Page - Select or create a notebook'
 
     @web.authenticated
     def get(self, path=''):


### PR DESCRIPTION
Fixed issue #3967. The title of the tree.html page is undescriptive meaning that user will not know what page they are on from reading/screen reading the tab. We have updated the title to make it more descriptive.