### PR TITLE
Missing yield statement on WebSocketChannelsHandler

### DIFF
--- a/notebook/gateway/handlers.py
+++ b/notebook/gateway/handlers.py
@@ -65,7 +65,7 @@ class WebSocketChannelsHandler(WebSocketHandler, IPythonHandler):
     def get(self, kernel_id, *args, **kwargs):
         self.authenticate()
         self.kernel_id = cast_unicode(kernel_id, 'ascii')
-        super(WebSocketChannelsHandler, self).get(kernel_id=kernel_id, *args, **kwargs)
+        yield super(WebSocketChannelsHandler, self).get(kernel_id=kernel_id, *args, **kwargs)
 
     def send_ping(self):
         if self.ws_connection is None and self.ping_callback is not None:
@@ -92,7 +92,6 @@ class WebSocketChannelsHandler(WebSocketHandler, IPythonHandler):
 
     def write_message(self, message, binary=False):
         """Send message back to notebook client.  This is called via callback from self.gateway._read_messages."""
-        self.log.debug("Receiving message from gateway: {}".format(message))
         if self.ws_connection:  # prevent WebSocketClosedError
             if isinstance(message, bytes):
                 binary = True


### PR DESCRIPTION
We were missing a yield statement in the deferral of `get()` to
the superclass.  This issue was occurring only when Tornado 6+
was deployed.

Also removed a debug message producing way too much information.

Note: This should be included for Notebook 6.0.