### PR TITLE
Remove verbose debug statement in gateway mode

### DIFF
--- a/notebook/gateway/handlers.py
+++ b/notebook/gateway/handlers.py
@@ -87,7 +87,6 @@ class WebSocketChannelsHandler(WebSocketHandler, IPythonHandler):
 
     def on_message(self, message):
         """Forward message to gateway web socket handler."""
-        self.log.debug("Sending message to gateway: {}".format(message))
         self.gateway.on_message(message)
 
     def write_message(self, message, binary=False):


### PR DESCRIPTION
I removed the mirroring 'Receiving' debug statement previously and
didn't realize there's a 'Sending' statement.  This change removes
that statement.

This should be part of the 6.0 release, just not signficant enough
to warrant include in rc1.