### PR TITLE
Added main/navigation tags to meet DAP requirements: issue #3217

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ src
 .idea/
 Read the Docs
 config.rst
-
+*.iml
 /.project
 /.pydevproject
 

--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -122,7 +122,7 @@ dir="ltr">
   </div>
 </noscript>
 
-<div id="header" role="navigation" aria-label="Top Menu">
+<div id="header" role="navigation" aria-label="{% trans %}Top Menu{% endtrans %}">
   <div id="header-container" class="container">
   <div id="ipython_notebook" class="nav navbar-brand"><a href="{{default_url}}
     {%- if logged_in and token -%}?token={{token}}{%- endif -%}" title='{% trans %}dashboard{% endtrans %}'>

--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -122,7 +122,7 @@ dir="ltr">
   </div>
 </noscript>
 
-<div id="header">
+<div id="header" role="navigation" aria-label="Top Menu">
   <div id="header-container" class="container">
   <div id="ipython_notebook" class="nav navbar-brand"><a href="{{default_url}}
     {%- if logged_in and token -%}?token={{token}}{%- endif -%}" title='{% trans %}dashboard{% endtrans %}'>
@@ -153,11 +153,12 @@ dir="ltr">
 
   {% block header %}
   {% endblock %}
-</div>
+
+    </div>
 
 <div id="site">
-{% block site %}
-{% endblock %}
+    {% block site %}
+    {% endblock %}
 </div>
 
 {% block after_site %}

--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -153,12 +153,11 @@ dir="ltr">
 
   {% block header %}
   {% endblock %}
-
-    </div>
+</div>
 
 <div id="site">
-    {% block site %}
-    {% endblock %}
+{% block site %}
+{% endblock %}
 </div>
 
 {% block after_site %}

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -1,4 +1,5 @@
 {% extends "page.html" %}
+
 {% block title %}{{page_title}}{% endblock %}
 
 

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -1,5 +1,4 @@
 {% extends "page.html" %}
-
 {% block title %}{{page_title}}{% endblock %}
 
 
@@ -27,7 +26,8 @@ data-server-root="{{server_root}}"
 {% block site %}
 
   <div id="ipython-main-app" class="container">
-    <div id="tab_content" class="tabbable">
+
+    <div id="tab_content" class="tabbable" role="main">
       <ul id="tabs" class="nav nav-tabs">
         <li class="active"><a href="#notebooks" data-toggle="tab">{% trans %}Files{% endtrans %}</a></li>
         <li><a href="#running" data-toggle="tab">{% trans %}Running{% endtrans %}</a></li>

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -26,7 +26,6 @@ data-server-root="{{server_root}}"
 {% block site %}
 
   <div id="ipython-main-app" class="container">
-
     <div id="tab_content" class="tabbable" role="main">
       <ul id="tabs" class="nav nav-tabs">
         <li class="active"><a href="#notebooks" data-toggle="tab">{% trans %}Files{% endtrans %}</a></li>


### PR DESCRIPTION
Fixed issue #3217. Ran the Dynamic Assessment Plugin and fixed some of the errors caused by missing regions by adding main and navigation roles to the tree.html page. The lang attribute error does not seem to appear for us.