### PR TITLE
Label is missing for form textarea element on notebook page: issue #3939

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -178,7 +178,7 @@ define([
             cell: this, 
             notebook: this.notebook});
         inner_cell.append(this.celltoolbar.element);
-        var input_area = $('<div/>').addClass('input_area');
+        var input_area = $('<div/>').addClass('input_area').attr("aria-label", "Edit code here");
         this.code_mirror = new CodeMirror(input_area.get(0), this._options.cm_config);
         // In case of bugs that put the keyboard manager into an inconsistent state,
         // ensure KM is enabled when CodeMirror is focused:

--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -178,7 +178,7 @@ define([
             cell: this, 
             notebook: this.notebook});
         inner_cell.append(this.celltoolbar.element);
-        var input_area = $('<div/>').addClass('input_area').attr("aria-label", "Edit code here");
+        var input_area = $('<div/>').addClass('input_area').attr("aria-label", i18n.msg._("Edit code here"));
         this.code_mirror = new CodeMirror(input_area.get(0), this._options.cm_config);
         // In case of bugs that put the keyboard manager into an inconsistent state,
         // ensure KM is enabled when CodeMirror is focused:

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1212,7 +1212,7 @@ define([
         // This will put all the deleted cells back in one location, rather than
         // where they came from. It will do until we have proper undo support.
         undelete_backup.index = cursor_ix_after;
-        $('#undelete_cell').removeClass('disabled').removeAttr("aria-label");
+        $('#undelete_cell').removeClass('disabled');
 
         this.undelete_backup_stack.push(undelete_backup);
         this.set_dirty(true);
@@ -1617,13 +1617,13 @@ define([
         if (!this.paste_enabled) {
             $('#paste_cell_replace').removeClass('disabled')
                 .on('click', function () {that.keyboard_manager.actions.call(
-                    'jupyter-notebook:paste-cell-replace');}).removeAttr("aria-label");
+                    'jupyter-notebook:paste-cell-replace');});
             $('#paste_cell_above').removeClass('disabled')
                 .on('click', function () {that.keyboard_manager.actions.call(
-                    'jupyter-notebook:paste-cell-above');}).removeAttr("aria-label");
+                    'jupyter-notebook:paste-cell-above');});
             $('#paste_cell_below').removeClass('disabled')
                 .on('click', function () {that.keyboard_manager.actions.call(
-                    'jupyter-notebook:paste-cell-below');}).removeAttr("aria-label");
+                    'jupyter-notebook:paste-cell-below');});
             this.paste_enabled = true;
         }
     };
@@ -1933,7 +1933,7 @@ define([
      */
     Notebook.prototype.enable_attachments_paste = function () {
         if (!this.paste_attachments_enabled) {
-            $('#paste_cell_attachments').removeClass('disabled').removeAttr("aria-label");
+            $('#paste_cell_attachments').removeClass('disabled');
             this.paste_attachments_enabled = true;
         }
     };
@@ -1943,7 +1943,7 @@ define([
      */
     Notebook.prototype.set_insert_image_enabled = function(enabled) {
         if (enabled) {
-            $('#insert_image').removeClass('disabled').removeAttr("aria-label");
+            $('#insert_image').removeClass('disabled');
         } else {
             $('#insert_image').addClass('disabled');
         }

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1212,7 +1212,7 @@ define([
         // This will put all the deleted cells back in one location, rather than
         // where they came from. It will do until we have proper undo support.
         undelete_backup.index = cursor_ix_after;
-        $('#undelete_cell').removeClass('disabled');
+        $('#undelete_cell').removeClass('disabled').removeAttr("aria-label");
 
         this.undelete_backup_stack.push(undelete_backup);
         this.set_dirty(true);
@@ -1617,13 +1617,13 @@ define([
         if (!this.paste_enabled) {
             $('#paste_cell_replace').removeClass('disabled')
                 .on('click', function () {that.keyboard_manager.actions.call(
-                    'jupyter-notebook:paste-cell-replace');});
+                    'jupyter-notebook:paste-cell-replace');}).removeAttr("aria-label");
             $('#paste_cell_above').removeClass('disabled')
                 .on('click', function () {that.keyboard_manager.actions.call(
-                    'jupyter-notebook:paste-cell-above');});
+                    'jupyter-notebook:paste-cell-above');}).removeAttr("aria-label");
             $('#paste_cell_below').removeClass('disabled')
                 .on('click', function () {that.keyboard_manager.actions.call(
-                    'jupyter-notebook:paste-cell-below');});
+                    'jupyter-notebook:paste-cell-below');}).removeAttr("aria-label");
             this.paste_enabled = true;
         }
     };
@@ -1933,7 +1933,7 @@ define([
      */
     Notebook.prototype.enable_attachments_paste = function () {
         if (!this.paste_attachments_enabled) {
-            $('#paste_cell_attachments').removeClass('disabled');
+            $('#paste_cell_attachments').removeClass('disabled').removeAttr("aria-label");
             this.paste_attachments_enabled = true;
         }
     };
@@ -1943,7 +1943,7 @@ define([
      */
     Notebook.prototype.set_insert_image_enabled = function(enabled) {
         if (enabled) {
-            $('#insert_image').removeClass('disabled');
+            $('#insert_image').removeClass('disabled').removeAttr("aria-label");
         } else {
             $('#insert_image').addClass('disabled');
         }

--- a/notebook/static/notebook/js/textcell.js
+++ b/notebook/static/notebook/js/textcell.js
@@ -98,7 +98,7 @@ define([
             cell: this, 
             notebook: this.notebook});
         inner_cell.append(this.celltoolbar.element);
-        var input_area = $('<div/>').addClass('input_area');
+        var input_area = $('<div/>').addClass('input_area').attr("aria-label", "Edit Markup Text here");;
         this.code_mirror = new CodeMirror(input_area.get(0), this._options.cm_config);
         // In case of bugs that put the keyboard manager into an inconsistent state,
         // ensure KM is enabled when CodeMirror is focused:

--- a/notebook/static/notebook/js/textcell.js
+++ b/notebook/static/notebook/js/textcell.js
@@ -98,7 +98,7 @@ define([
             cell: this, 
             notebook: this.notebook});
         inner_cell.append(this.celltoolbar.element);
-        var input_area = $('<div/>').addClass('input_area').attr("aria-label", "Edit Markup Text here");;
+        var input_area = $('<div/>').addClass('input_area').attr("aria-label", i18n.msg._("Edit Markup Text here"));
         this.code_mirror = new CodeMirror(input_area.get(0), this._options.cm_config);
         // In case of bugs that put the keyboard manager into an inconsistent state,
         // ensure KM is enabled when CodeMirror is focused:


### PR DESCRIPTION
I have fixed the issue #3939 by using the aria-label attribute. So now the type of the textarea on notebook page is announced by narrator.