### PR TITLE
Narrator focus is not in logical order for running notebook links: issue #3978

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ config.rst
 
 package-lock.json
 geckodriver.log
+*.iml

--- a/notebook/static/tree/js/notebooklist.js
+++ b/notebook/static/tree/js/notebooklist.js
@@ -563,15 +563,27 @@ define([
             .addClass("item_name")
             .appendTo(link);
 
-        $("<span/>")
-            .addClass("file_size")
-            .addClass("pull-right")
+        var div = $('<div/>')
+            .addClass('pull-right')
             .appendTo(item);
+
+        var buttons = $('<div/>')
+            .addClass("item_buttons pull-left")
+            .appendTo(div);
+
+        var div2 = $('<div/>')
+            .addClass('pull-right')
+            .appendTo(div);
 
         $("<span/>")
             .addClass("item_modified")
+            .addClass("pull-left")
+            .appendTo(div2);
+
+        $("<span/>")
+            .addClass("file_size")
             .addClass("pull-right")
-            .appendTo(item);
+            .appendTo(div2);
 
         if (selectable === false) {
             checkbox.css('visibility', 'hidden');
@@ -585,10 +597,6 @@ define([
                 that._selection_changed();
             });
         }
-
-        var buttons = $('<div/>')
-            .addClass("item_buttons  pull-right")
-            .appendTo(item);
 
         $('<div/>')
             .addClass('running-indicator')


### PR DESCRIPTION
Fixed issue #3978 by adding a div around the links to change the focus order. This means that focus visits the links in the correct order for each running notebook