### PR TITLE
Name of the "EditTextbox" is missing: #3977

### DIFF
--- a/notebook/static/notebook/js/celltoolbarpresets/tags.js
+++ b/notebook/static/notebook/js/celltoolbarpresets/tags.js
@@ -166,6 +166,7 @@ define([
             "is treated as tag separators.");
 
         var textarea = $('<textarea/>')
+            .attr('aria-label', 'Edit the tags in the text area')
             .attr('rows', '13')
             .attr('cols', '80')
             .attr('name', 'tags')

--- a/notebook/static/notebook/js/celltoolbarpresets/tags.js
+++ b/notebook/static/notebook/js/celltoolbarpresets/tags.js
@@ -166,7 +166,7 @@ define([
             "is treated as tag separators.");
 
         var textarea = $('<textarea/>')
-            .attr('aria-label', 'Edit the tags in the text area')
+            .attr('aria-label', i18n.msg._('Edit the tags in the text area'))
             .attr('rows', '13')
             .attr('cols', '80')
             .attr('name', 'tags')


### PR DESCRIPTION
I have fixed the issue #3977 by adding the aria-label attribute. So now the name of the edit textbox is announced by the narrator.