### PR TITLE
add missing react-dom js to package data

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -150,6 +150,7 @@ def find_package_data():
         pjoin(components, "jquery-ui", "themes", "smoothness", "images", "*"),
         pjoin(components, "marked", "lib", "marked.js"),
         pjoin(components, "react", "react.production.min.js"),
+        pjoin(components, "react", "react-dom.production.min.js"),
         pjoin(components, "requirejs", "require.js"),
         pjoin(components, "requirejs-plugins", "src", "json.js"),
         pjoin(components, "requirejs-text", "text.js"),


### PR DESCRIPTION
this file was omitted when react was added, so it is not installed.

closes #4771