### PR TITLE
Implemented Split Cell for multicursor

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -235,8 +235,8 @@ define([
             }
         },
         'split-cell-at-cursor': {
-            cmd: i18n.msg._('split cell at cursor'),
-            help    : i18n.msg._('split cell at cursor'),
+            cmd: i18n.msg._('split cell at cursor(s)'),
+            help    : i18n.msg._('split cell at cursor(s)'),
             help_index : 'ea',
             handler : function (env) {
                 env.notebook.split_cell();

--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -586,6 +586,53 @@ define([
         return text;
     };
 
+
+    /**
+     * @return {Array} - the text between cursors and within selections (multicursor/sorted)
+     * @method get_split_text
+     **/
+    Cell.prototype.get_split_text = function () {
+        var ranges = this.code_mirror.listSelections();
+
+        var cursors = [{line: 0, ch: 0}];
+
+        for (var i = 0; i < ranges.length; i++) {
+            // append both to handle selections
+            if (ranges[i].head.sticky == 'before') {
+                cursors.push(ranges[i].anchor);
+                cursors.push(ranges[i].head);
+            } else {
+                cursors.push(ranges[i].head);
+                cursors.push(ranges[i].anchor);
+            }
+        }
+
+        var last_line_num = this.code_mirror.lineCount()-1;
+        var last_line_len = this.code_mirror.getLine(last_line_num).length;
+        var end = {line:last_line_num, ch:last_line_len};
+        cursors.push(end);
+
+        // Cursors is now sorted, but likely has duplicates due to anchor and head being the same for cursors
+        var locations = [cursors[0]];
+        for (var i = 1; i < cursors.length; i++) {
+            if (cursors[i] != locations[locations.length-1]) {
+                locations.push(cursors[i]);
+            }
+        }
+
+        // Split text
+        var text_list = [];
+        for (var i = 1; i < locations.length; i++) {
+            var text = this.code_mirror.getRange(locations[i-1], locations[i]);
+            text = text.replace(/^\n+/, '').replace(/\n+$/, ''); // removes newlines at beginning and end
+            if ($.trim(text) != '') {
+                // No cells full of whitespace
+                text_list.push(text);
+            }
+        }
+        return text_list;
+    };
+
     /**
      * Show/Hide CodeMirror LineNumber
      * @method show_line_numbers

--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -615,7 +615,9 @@ define([
         // Cursors is now sorted, but likely has duplicates due to anchor and head being the same for cursors
         var locations = [cursors[0]];
         for (var i = 1; i < cursors.length; i++) {
-            if (cursors[i] != locations[locations.length-1]) {
+            var last = locations[locations.length-1];
+            var current = cursors[i];
+            if ((last.line != current.line) || (last.ch != current.ch)) {
                 locations.push(cursors[i]);
             }
         }
@@ -625,10 +627,7 @@ define([
         for (var i = 1; i < locations.length; i++) {
             var text = this.code_mirror.getRange(locations[i-1], locations[i]);
             text = text.replace(/^\n+/, '').replace(/\n+$/, ''); // removes newlines at beginning and end
-            if ($.trim(text) != '') {
-                // No cells full of whitespace
-                text_list.push(text);
-            }
+            text_list.push(text);
         }
         return text_list;
     };

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1755,18 +1755,19 @@ define([
     Notebook.prototype.split_cell = function () {
         var cell = this.get_selected_cell();
         if (cell.is_splittable()) {
-            var texta = cell.get_pre_cursor();
-            var textb = cell.get_post_cursor();
-            // current cell becomes the second one
+            var text_list = cell.get_split_text();
+            for (var i = 0; i < text_list.length-1; i++) {
+                // Create new cell with same type
+                var new_cell = this.insert_cell_above(cell.cell_type);
+                // Unrender the new cell so we can call set_text.
+                new_cell.unrender();
+                new_cell.set_text(text_list[i]);
+                // Duplicate metadata
+                new_cell.metadata = JSON.parse(JSON.stringify(cell.metadata));
+            }
+            // Original cell becomes the last one
             // so we don't need to worry about selection
-            cell.set_text(textb);
-            // create new cell with same type
-            var new_cell = this.insert_cell_above(cell.cell_type);
-            // Unrender the new cell so we can call set_text.
-            new_cell.unrender();
-            new_cell.set_text(texta);
-            // duplicate metadata
-            new_cell.metadata = JSON.parse(JSON.stringify(cell.metadata));
+            cell.set_text(text_list[text_list.length-1]);
         }
     };
 


### PR DESCRIPTION
I took the current split cell functionality and made it work for multicursor. The help message for split cell is also updated to imply multicursor splitting is possible.

This can be done by putting the cursor at multiple locations (Alt+Drag/Ctrl+Click) and pressing Ctrl+Shift+Minus. The result should be new cells split at each of the cursors.

Additionally, this PR now makes cell splitting handles selections, so if you select a piece of code/text, then hit Ctrl+Shift+Minus, it'll put the selected text in a new cell with the text before/after the text going into their own cells. It is able to handle a combination of cursors and selections.

I retained the functionality of removing newlines at the beginning and end of the created cells, so the original single cursor behavior remains the same.
