### PR TITLE
Ctrl-A to select all cells

### DIFF
--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -298,6 +298,15 @@ define([
                 env.notebook.get_selected_cell().element.focus();
             }
         },
+        'select-all' : {
+            cmd: i18n.msg._('select all'),
+            help: i18n.msg._('select all cells'),
+            help_index : 'de',
+            handler : function (env) {
+                env.notebook.select_all();
+                env.notebook.get_selected_cell().element.focus();
+            }
+        },
         'cut-cell' : {
             cmd: i18n.msg._('cut selected cells'),
             help: i18n.msg._('cut selected cells'),

--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -145,6 +145,7 @@ define([
             'shift-j': 'jupyter-notebook:extend-selection-below',
             'shift-up': 'jupyter-notebook:extend-selection-above',
             'shift-down': 'jupyter-notebook:extend-selection-below',
+            'cmdtrl-a': 'jupyter-notebook:select-all',
             'x' : 'jupyter-notebook:cut-cell',
             'c' : 'jupyter-notebook:copy-cell',
             'v' : 'jupyter-notebook:paste-cell-below',

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -835,6 +835,12 @@ define([
         });
     };
 
+
+    Notebook.prototype.select_all = function(){
+        this.select(0, true);
+        this.select(this.ncells()-1, false);
+    };
+
     Notebook.prototype._contract_selection = function(){
         var i = this.get_selected_index();
         this.select(i, true);


### PR DESCRIPTION
The code to do this was very simple and uses the same methods as shift-clicking on a range. Now, when in command mode, Ctrl-A selects all cells

closes #4820