### PR TITLE
Add UNIX socket support to notebook server.

### DIFF
--- a/notebook/__init__.py
+++ b/notebook/__init__.py
@@ -20,6 +20,8 @@ DEFAULT_TEMPLATE_PATH_LIST = [
     os.path.join(os.path.dirname(__file__), "templates"),
 ]
 
+DEFAULT_NOTEBOOK_PORT = 8888
+
 del os
 
 from .nbextensions import install_nbextension

--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -471,10 +471,6 @@ class IPythonHandler(AuthenticatedHandler):
         if host.startswith('[') and host.endswith(']'):
             host = host[1:-1]
 
-        if not PY3:
-            # ip_address only accepts unicode on Python 2
-            host = host.decode('utf8', 'replace')
-
         # UNIX socket handling
         check_host = urldecode_unix_socket_path(host)
         if check_host.startswith('/') and os.path.exists(check_host):

--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -32,7 +32,7 @@ from ipython_genutils.py3compat import string_types
 import notebook
 from notebook._tz import utcnow
 from notebook.i18n import combine_translations
-from notebook.utils import is_hidden, url_path_join, url_is_absolute, url_escape
+from notebook.utils import is_hidden, url_path_join, url_is_absolute, url_escape, urldecode_unix_socket_path
 from notebook.services.security import csp_report_uri
 
 #-----------------------------------------------------------------------------
@@ -471,13 +471,22 @@ class IPythonHandler(AuthenticatedHandler):
         if host.startswith('[') and host.endswith(']'):
             host = host[1:-1]
 
-        try:
-            addr = ipaddress.ip_address(host)
-        except ValueError:
-            # Not an IP address: check against hostnames
-            allow = host in self.settings.get('local_hostnames', ['localhost'])
+        if not PY3:
+            # ip_address only accepts unicode on Python 2
+            host = host.decode('utf8', 'replace')
+
+        # UNIX socket handling
+        check_host = urldecode_unix_socket_path(host)
+        if check_host.startswith('/') and os.path.exists(check_host):
+            allow = True
         else:
-            allow = addr.is_loopback
+            try:
+                addr = ipaddress.ip_address(host)
+            except ValueError:
+                # Not an IP address: check against hostnames
+                allow = host in self.settings.get('local_hostnames', ['localhost'])
+            else:
+                allow = addr.is_loopback
 
         if not allow:
             self.log.warning(

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -620,7 +620,7 @@ aliases.update({
     'port': 'NotebookApp.port',
     'port-retries': 'NotebookApp.port_retries',
     'sock': 'NotebookApp.sock',
-    'sock-umask': 'NotebookApp.sock_umask',
+    'sock-mode': 'NotebookApp.sock_mode',
     'transport': 'KernelManager.transport',
     'keyfile': 'NotebookApp.keyfile',
     'certfile': 'NotebookApp.certfile',
@@ -786,8 +786,8 @@ class NotebookApp(JupyterApp):
         help=_("The UNIX socket the notebook server will listen on.")
     )
 
-    sock_umask = Unicode(u'0600', config=True,
-        help=_("The UNIX socket umask to set on creation (default: 0600).")
+    sock_mode = Unicode(u'0600', config=True,
+        help=_("The permissions mode/umask for UNIX socket creation (default: 0600).")
     )
 
     port_retries = Integer(50, config=True,
@@ -1616,7 +1616,7 @@ class NotebookApp(JupyterApp):
 
     def _bind_http_server_unix(self):
         try:
-            sock = bind_unix_socket(self.sock, mode=int(self.sock_umask.encode(), 8))
+            sock = bind_unix_socket(self.sock, mode=int(self.sock_mode.encode(), 8))
             self.http_server.add_socket(sock)
         except socket.error as e:
             if e.errno == errno.EADDRINUSE:

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -2105,7 +2105,7 @@ class NotebookApp(JupyterApp):
                     (
                         'UNIX sockets are not browser-connectable, but you can tunnel to '
                         'the instance via e.g.`ssh -L 8888:%s -N user@this_host` and then '
-                        'opening e.g. %s in a browser.'
+                        'open e.g. %s in a browser.'
                     ) % (self.sock, self._concat_token(self._tcp_url('localhost', 8888)))
                 ]))
             else:

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -66,8 +66,11 @@ from tornado import httpserver
 from tornado import web
 from tornado.httputil import url_concat
 from tornado.log import LogFormatter, app_log, access_log, gen_log
+if not sys.platform.startswith('win'):
+    from tornado.netutil import bind_unix_socket
 
 from notebook import (
+    DEFAULT_NOTEBOOK_PORT,
     DEFAULT_STATIC_FILES_PATH,
     DEFAULT_TEMPLATE_PATH_LIST,
     __version__,
@@ -107,7 +110,17 @@ from jupyter_core.paths import jupyter_runtime_dir, jupyter_path
 from notebook._sysinfo import get_sys_info
 
 from ._tz import utcnow, utcfromtimestamp
-from .utils import url_path_join, check_pid, url_escape, urljoin, pathname2url, run_sync
+from .utils import (
+    check_pid,
+    pathname2url,
+    run_sync,
+    url_escape,
+    url_path_join,
+    urldecode_unix_socket_path,
+    urlencode_unix_socket,
+    urlencode_unix_socket_path,
+    urljoin,
+)
 
 # Check if we can use async kernel management
 try:
@@ -218,7 +231,7 @@ class NotebookWebApplication(web.Application):
             warnings.warn(_("The `ignore_minified_js` flag is deprecated and will be removed in Notebook 6.0"), DeprecationWarning)
 
         now = utcnow()
-        
+
         root_dir = contents_manager.root_dir
         home = py3compat.str_to_unicode(os.path.expanduser('~'), encoding=sys.getfilesystemencoding()) 
         if root_dir.startswith(home + os.path.sep):
@@ -403,6 +416,7 @@ class NotebookPasswordApp(JupyterApp):
         set_password(config_file=self.config_file)
         self.log.info("Wrote hashed password to %s" % self.config_file)
 
+
 def shutdown_server(server_info, timeout=5, log=None):
     """Shutdown a notebook server in a separate process.
 
@@ -415,14 +429,39 @@ def shutdown_server(server_info, timeout=5, log=None):
     Returns True if the server was stopped by any means, False if stopping it
     failed (on Windows).
     """
-    from tornado.httpclient import HTTPClient, HTTPRequest
+    from tornado import gen
+    from tornado.httpclient import AsyncHTTPClient, HTTPClient, HTTPRequest
+    from tornado.netutil import bind_unix_socket, Resolver
     url = server_info['url']
     pid = server_info['pid']
+    resolver = None
+
+    # UNIX Socket handling.
+    if url.startswith('http+unix://'):
+        # This library doesn't understand our URI form, but it's just HTTP.
+        url = url.replace('http+unix://', 'http://')
+
+        class UnixSocketResolver(Resolver):
+            def initialize(self, resolver):
+                self.resolver = resolver
+
+            def close(self):
+                self.resolver.close()
+
+            @gen.coroutine
+            def resolve(self, host, port, *args, **kwargs):
+                raise gen.Return([
+                    (socket.AF_UNIX, urldecode_unix_socket_path(host))
+                ])
+
+        resolver = UnixSocketResolver(resolver=Resolver())
+
     req = HTTPRequest(url + 'api/shutdown', method='POST', body=b'', headers={
         'Authorization': 'token ' + server_info['token']
     })
     if log: log.debug("POST request to %sapi/shutdown", url)
-    HTTPClient().fetch(req)
+    AsyncHTTPClient.configure(None, resolver=resolver)
+    HTTPClient(AsyncHTTPClient).fetch(req)
 
     # Poll to see if it shut down.
     for _ in range(timeout*10):
@@ -453,13 +492,20 @@ class NbserverStopApp(JupyterApp):
     version = __version__
     description="Stop currently running notebook server for a given port"
 
-    port = Integer(8888, config=True,
-        help="Port of the server to be killed. Default 8888")
+    port = Integer(DEFAULT_NOTEBOOK_PORT, config=True,
+        help="Port of the server to be killed. Default %s" % DEFAULT_NOTEBOOK_PORT)
+
+    sock = Unicode(u'', config=True,
+        help="UNIX socket of the server to be killed.")
 
     def parse_command_line(self, argv=None):
         super(NbserverStopApp, self).parse_command_line(argv)
         if self.extra_args:
-            self.port=int(self.extra_args[0])
+            try:
+                self.port = int(self.extra_args[0])
+            except ValueError:
+                # self.extra_args[0] was not an int, so it must be a string (unix socket).
+                self.sock = self.extra_args[0]
 
     def shutdown_server(self, server):
         return shutdown_server(server, log=self.log)
@@ -469,16 +515,16 @@ class NbserverStopApp(JupyterApp):
         if not servers:
             self.exit("There are no running servers")
         for server in servers:
-            if server['port'] == self.port:
-                print("Shutting down server on port", self.port, "...")
+            if server.get('sock') == self.sock or server['port'] == self.port:
+                print("Shutting down server on %s..." % self.sock or self.port)
                 if not self.shutdown_server(server):
                     sys.exit("Could not stop server")
                 return
         else:
             print("There is currently no server running on port {}".format(self.port), file=sys.stderr)
-            print("Ports currently in use:", file=sys.stderr)
+            print("Ports/sockets currently in use:", file=sys.stderr)
             for server in servers:
-                print("  - {}".format(server['port']), file=sys.stderr)
+                print("  - {}".format(server.get('sock', server['port'])), file=sys.stderr)
             self.exit(1)
 
 
@@ -558,6 +604,8 @@ aliases.update({
     'ip': 'NotebookApp.ip',
     'port': 'NotebookApp.port',
     'port-retries': 'NotebookApp.port_retries',
+    'sock': 'NotebookApp.sock',
+    'sock-umask': 'NotebookApp.sock_umask',
     'transport': 'KernelManager.transport',
     'keyfile': 'NotebookApp.keyfile',
     'certfile': 'NotebookApp.certfile',
@@ -715,8 +763,16 @@ class NotebookApp(JupyterApp):
         or containerized setups for example).""")
     )
 
-    port = Integer(8888, config=True,
+    port = Integer(DEFAULT_NOTEBOOK_PORT, config=True,
         help=_("The port the notebook server will listen on.")
+    )
+
+    sock = Unicode(u'', config=True,
+        help=_("The UNIX socket the notebook server will listen on.")
+    )
+
+    sock_umask = Unicode(u'0600', config=True,
+        help=_("The UNIX socket umask to set on creation (default: 0600).")
     )
 
     port_retries = Integer(50, config=True,
@@ -1469,6 +1525,27 @@ class NotebookApp(JupyterApp):
             self.log.critical(_("\t$ python -m notebook.auth password"))
             sys.exit(1)
 
+        # Socket options validation.
+        if self.sock:
+            if self.port != DEFAULT_NOTEBOOK_PORT:
+                self.log.critical(
+                    _('Options --port and --sock are mutually exclusive. Aborting.'),
+                )
+                sys.exit(1)
+
+            if self.open_browser:
+                # If we're bound to a UNIX socket, we can't reliably connect from a browser.
+                self.log.critical(
+                    _('Options --open-browser and --sock are mutually exclusive. Aborting.'),
+                )
+                sys.exit(1)
+
+            if sys.platform.startswith('win'):
+                self.log.critical(
+                    _('Option --sock is not supported on Windows, but got value of %s. Aborting.' % self.sock),
+                )
+                sys.exit(1)
+
         self.web_app = NotebookWebApplication(
             self, self.kernel_manager, self.contents_manager,
             self.session_manager, self.kernel_spec_manager,
@@ -1505,6 +1582,32 @@ class NotebookApp(JupyterApp):
                                                  max_body_size=self.max_body_size,
                                                  max_buffer_size=self.max_buffer_size)
 
+        success = self._bind_http_server()
+        if not success:
+            self.log.critical(_('ERROR: the notebook server could not be started because '
+                              'no available port could be found.'))
+            self.exit(1)
+
+    def _bind_http_server(self):
+        return self._bind_http_server_unix() if self.sock else self._bind_http_server_tcp()
+
+    def _bind_http_server_unix(self):
+        try:
+            sock = bind_unix_socket(self.sock, mode=int(self.sock_umask.encode(), 8))
+            self.http_server.add_socket(sock)
+        except socket.error as e:
+            if e.errno == errno.EADDRINUSE:
+                self.log.info(_('The socket %s is already in use.') % self.sock)
+                return False
+            elif e.errno in (errno.EACCES, getattr(errno, 'WSAEACCES', errno.EACCES)):
+                self.log.warning(_("Permission to listen on sock %s denied") % self.sock)
+                return False
+            else:
+                raise
+        else:
+            return True
+
+    def _bind_http_server_tcp(self):
         success = None
         for port in random_ports(self.port, self.port_retries+1):
             try:
@@ -1533,35 +1636,45 @@ class NotebookApp(JupyterApp):
                 self.log.critical(_('ERROR: the notebook server could not be started because '
                               'port %i is not available.') % port)
             self.exit(1)
-    
+        return success
+
+    def _concat_token(self, url):
+        token = self.token if self._token_generated else '...'
+        return url_concat(url, {'token': token})
+
     @property
     def display_url(self):
         if self.custom_display_url:
             url = self.custom_display_url
             if not url.endswith('/'):
                 url += '/'
+        elif self.sock:
+            url = self._unix_sock_url()
         else:
             if self.ip in ('', '0.0.0.0'):
                 ip = "%s" % socket.gethostname()
             else:
                 ip = self.ip
-            url = self._url(ip)
-        if self.token:
-            # Don't log full token if it came from config
-            token = self.token if self._token_generated else '...'
-            url = (url_concat(url, {'token': token})
-                  + '\n or '
-                  + url_concat(self._url('127.0.0.1'), {'token': token}))
+            url = self._tcp_url(ip)
+        if self.token and not self.sock:
+            url = self._concat_token(url)
+            url += '\n or %s' % self._concat_token(self._tcp_url('127.0.0.1'))
         return url
 
     @property
     def connection_url(self):
-        ip = self.ip if self.ip else 'localhost'
-        return self._url(ip)
+        if self.sock:
+            return self._unix_sock_url()
+        else:
+            ip = self.ip if self.ip else 'localhost'
+            return self._tcp_url(ip)
 
-    def _url(self, ip):
+    def _unix_sock_url(self, token=None):
+        return '%s%s' % (urlencode_unix_socket(self.sock), self.base_url)
+
+    def _tcp_url(self, ip, port=None):
         proto = 'https' if self.certfile else 'http'
-        return "%s://%s:%i%s" % (proto, ip, self.port, self.base_url)
+        return "%s://%s:%i%s" % (proto, ip, port or self.port, self.base_url)
 
     def init_terminals(self):
         if not self.terminals_enabled:
@@ -1825,6 +1938,7 @@ class NotebookApp(JupyterApp):
         return {'url': self.connection_url,
                 'hostname': self.ip if self.ip else 'localhost',
                 'port': self.port,
+                'sock': self.sock,
                 'secure': bool(self.certfile),
                 'base_url': self.base_url,
                 'token': self.token,
@@ -1954,19 +2068,31 @@ class NotebookApp(JupyterApp):
         self.write_server_info_file()
         self.write_browser_open_file()
 
-        if self.open_browser or self.file_to_run:
+        if (self.open_browser or self.file_to_run) and not self.sock:
             self.launch_browser()
 
         if self.token and self._token_generated:
             # log full URL with generated token, so there's a copy/pasteable link
             # with auth info.
-            self.log.critical('\n'.join([
-                '\n',
-                'To access the notebook, open this file in a browser:',
-                '    %s' % urljoin('file:', pathname2url(self.browser_open_file)),
-                'Or copy and paste one of these URLs:',
-                '    %s' % self.display_url,
-            ]))
+            if self.sock:
+                self.log.critical('\n'.join([
+                    '\n',
+                    'Notebook is listening on %s' % self.display_url,
+                    '',
+                    (
+                        'UNIX sockets are not browser-connectable, but you can tunnel to '
+                        'the instance via e.g.`ssh -L 8888:%s -N user@this_host` and then '
+                        'opening e.g. %s in a browser.'
+                    ) % (self.sock, self._concat_token(self._tcp_url('localhost', 8888)))
+                ]))
+            else:
+                self.log.critical('\n'.join([
+                    '\n',
+                    'To access the notebook, open this file in a browser:',
+                    '    %s' % urljoin('file:', pathname2url(self.browser_open_file)),
+                    'Or copy and paste one of these URLs:',
+                    '    %s' % self.display_url,
+                ]))
 
         self.io_loop = ioloop.IOLoop.current()
         if sys.platform.startswith('win'):

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1553,7 +1553,7 @@ class NotebookApp(JupyterApp):
 
             if self.open_browser:
                 # If we're bound to a UNIX socket, we can't reliably connect from a browser.
-                self.log.warning(
+                self.log.info(
                     _('Ignoring --NotebookApp.open_browser due to --sock being used.'),
                 )
 

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -517,6 +517,13 @@ class NbserverStopApp(JupyterApp):
         if not self.shutdown_server(server):
             sys.exit("Could not stop server on %s" % target_endpoint)
 
+    @staticmethod
+    def _maybe_remove_unix_socket(socket_path):
+        try:
+            os.unlink(socket_path)
+        except (OSError, IOError):
+            pass
+
     def start(self):
         servers = list(list_running_servers(self.runtime_dir))
         if not servers:
@@ -527,6 +534,8 @@ class NbserverStopApp(JupyterApp):
                 sock = server.get('sock', None)
                 if sock and sock == self.sock:
                     self._shutdown_or_exit(sock, server)
+                    # Attempt to remove the UNIX socket after stopping.
+                    self._maybe_remove_unix_socket(sock)
                     return
             elif self.port:
                 port = server.get('port', None)

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -490,7 +490,7 @@ def shutdown_server(server_info, timeout=5, log=None):
 
 class NbserverStopApp(JupyterApp):
     version = __version__
-    description="Stop currently running notebook server for a given port"
+    description="Stop currently running notebook server."
 
     port = Integer(DEFAULT_NOTEBOOK_PORT, config=True,
         help="Port of the server to be killed. Default %s" % DEFAULT_NOTEBOOK_PORT)

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1553,10 +1553,9 @@ class NotebookApp(JupyterApp):
 
             if self.open_browser:
                 # If we're bound to a UNIX socket, we can't reliably connect from a browser.
-                self.log.critical(
-                    _('Options --open-browser and --sock are mutually exclusive. Aborting.'),
+                self.log.warning(
+                    _('Ignoring --NotebookApp.open_browser due to --sock being used.'),
                 )
-                sys.exit(1)
 
             if sys.platform.startswith('win'):
                 self.log.critical(

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1557,6 +1557,12 @@ class NotebookApp(JupyterApp):
                     _('Ignoring --NotebookApp.open_browser due to --sock being used.'),
                 )
 
+            if self.file_to_run:
+                self.log.critical(
+                    _('Options --NotebookApp.file_to_run and --sock are mutually exclusive.'),
+                )
+                sys.exit(1)
+
             if sys.platform.startswith('win'):
                 self.log.critical(
                     _('Option --sock is not supported on Windows, but got value of %s. Aborting.' % self.sock),

--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -16,12 +16,13 @@ pjoin = os.path.join
 from unittest.mock import patch
 
 import requests
+import requests_unixsocket
 from tornado.ioloop import IOLoop
 import zmq
 
 import jupyter_core.paths
 from traitlets.config import Config
-from ..notebookapp import NotebookApp
+from ..notebookapp import NotebookApp, urlencode_unix_socket
 from ..utils import url_path_join
 from ipython_genutils.tempdir import TemporaryDirectory
 
@@ -52,7 +53,7 @@ class NotebookTestBase(TestCase):
         url = cls.base_url() + 'api/contents'
         for _ in range(int(MAX_WAITTIME/POLL_INTERVAL)):
             try:
-                requests.get(url)
+                cls.fetch_url(url)
             except Exception as e:
                 if not cls.notebook_thread.is_alive():
                     raise RuntimeError("The notebook server failed to start")
@@ -75,6 +76,10 @@ class NotebookTestBase(TestCase):
         if cls.token:
             headers['Authorization'] = 'token %s' % cls.token
         return headers
+
+    @staticmethod
+    def fetch_url(url):
+        return requests.get(url)
 
     @classmethod
     def request(cls, verb, path, **kwargs):
@@ -104,7 +109,11 @@ class NotebookTestBase(TestCase):
     @classmethod
     def get_argv(cls):
         return []
-    
+
+    @classmethod
+    def get_bind_args(cls):
+        return dict(port=cls.port)
+
     @classmethod
     def setup_class(cls):
         cls.tmp_dir = TemporaryDirectory()
@@ -116,7 +125,7 @@ class NotebookTestBase(TestCase):
                 if e.errno != errno.EEXIST:
                     raise
             return path
-        
+
         cls.home_dir = tmp('home')
         data_dir = cls.data_dir = tmp('data')
         config_dir = cls.config_dir = tmp('config')
@@ -143,6 +152,34 @@ class NotebookTestBase(TestCase):
 
         started = Event()
         def start_thread():
+            if 'asyncio' in sys.modules:
+                import asyncio
+                asyncio.set_event_loop(asyncio.new_event_loop())
+            bind_args = cls.get_bind_args()
+            app = cls.notebook = NotebookApp(
+                port_retries=0,
+                open_browser=False,
+                config_dir=cls.config_dir,
+                data_dir=cls.data_dir,
+                runtime_dir=cls.runtime_dir,
+                notebook_dir=cls.notebook_dir,
+                base_url=cls.url_prefix,
+                config=config,
+                allow_root=True,
+                token=cls.token,
+                **bind_args
+            )
+            # don't register signal handler during tests
+            app.init_signal = lambda : None
+            # clear log handlers and propagate to root for nose to capture it
+            # needs to be redone after initialize, which reconfigures logging
+            app.log.propagate = True
+            app.log.handlers = []
+            app.initialize(argv=cls.get_argv())
+            app.log.propagate = True
+            app.log.handlers = []
+            loop = IOLoop.current()
+            loop.add_callback(started.set)
             try:
                 app = cls.notebook = NotebookApp(
                     port=cls.port,
@@ -204,6 +241,25 @@ class NotebookTestBase(TestCase):
     @classmethod
     def base_url(cls):
         return 'http://localhost:%i%s' % (cls.port, cls.url_prefix)
+
+
+class UNIXSocketNotebookTestBase(NotebookTestBase):
+    # Rely on `/tmp` to avoid any Linux socket length max buffer
+    # issues. Key on PID for process-wise concurrency.
+    sock = '/tmp/.notebook.%i.sock' % os.getpid()
+
+    @classmethod
+    def get_bind_args(cls):
+        return dict(sock=cls.sock)
+
+    @classmethod
+    def base_url(cls):
+        return '%s%s' % (urlencode_unix_socket(cls.sock), cls.url_prefix)
+
+    @staticmethod
+    def fetch_url(url):
+        with requests_unixsocket.monkeypatch():
+            return requests.get(url)
 
 
 @contextmanager

--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -152,34 +152,6 @@ class NotebookTestBase(TestCase):
 
         started = Event()
         def start_thread():
-            if 'asyncio' in sys.modules:
-                import asyncio
-                asyncio.set_event_loop(asyncio.new_event_loop())
-            bind_args = cls.get_bind_args()
-            app = cls.notebook = NotebookApp(
-                port_retries=0,
-                open_browser=False,
-                config_dir=cls.config_dir,
-                data_dir=cls.data_dir,
-                runtime_dir=cls.runtime_dir,
-                notebook_dir=cls.notebook_dir,
-                base_url=cls.url_prefix,
-                config=config,
-                allow_root=True,
-                token=cls.token,
-                **bind_args
-            )
-            # don't register signal handler during tests
-            app.init_signal = lambda : None
-            # clear log handlers and propagate to root for nose to capture it
-            # needs to be redone after initialize, which reconfigures logging
-            app.log.propagate = True
-            app.log.handlers = []
-            app.initialize(argv=cls.get_argv())
-            app.log.propagate = True
-            app.log.handlers = []
-            loop = IOLoop.current()
-            loop.add_callback(started.set)
             try:
                 app = cls.notebook = NotebookApp(
                     port=cls.port,

--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -153,8 +153,8 @@ class NotebookTestBase(TestCase):
         started = Event()
         def start_thread():
             try:
+                bind_args = cls.get_bind_args()
                 app = cls.notebook = NotebookApp(
-                    port=cls.port,
                     port_retries=0,
                     open_browser=False,
                     config_dir=cls.config_dir,
@@ -165,6 +165,7 @@ class NotebookTestBase(TestCase):
                     config=config,
                     allow_root=True,
                     token=cls.token,
+                    **bind_args
                 )
                 if 'asyncio' in sys.modules:
                           app._init_asyncio_patch()

--- a/notebook/tests/test_notebookapp.py
+++ b/notebook/tests/test_notebookapp.py
@@ -22,7 +22,7 @@ from notebook import notebookapp, __version__
 from notebook.auth.security import passwd_check
 NotebookApp = notebookapp.NotebookApp
 
-from .launchnotebook import NotebookTestBase
+from .launchnotebook import NotebookTestBase, UNIXSocketNotebookTestBase
 
 
 def test_help_output():
@@ -189,3 +189,15 @@ class NotebookAppTests(NotebookTestBase):
         servers = list(notebookapp.list_running_servers())
         assert len(servers) >= 1
         assert self.port in {info['port'] for info in servers}
+
+
+# UNIX sockets aren't available on Windows.
+if not sys.platform.startswith('win'):
+    class NotebookUnixSocketTests(UNIXSocketNotebookTestBase):
+        def test_run(self):
+            self.fetch_url(self.base_url() + 'api/contents')
+
+        def test_list_running_sock_servers(self):
+            servers = list(notebookapp.list_running_servers())
+            assert len(servers) >= 1
+            assert self.sock in {info['sock'] for info in servers}

--- a/notebook/tests/test_notebookapp_integration.py
+++ b/notebook/tests/test_notebookapp_integration.py
@@ -3,7 +3,7 @@ import stat
 import subprocess
 import time
 
-from ipython_genutils.testing.decorators import skip_win32
+from ipython_genutils.testing.decorators import skip_win32, onlyif
 from notebook import DEFAULT_NOTEBOOK_PORT
 
 from .launchnotebook import UNIXSocketNotebookTestBase
@@ -62,7 +62,7 @@ def _ensure_stopped(check_msg='There are no running servers'):
         raise AssertionError('expected all servers to be stopped')
 
 
-@skip_win32
+@onlyif(bool(os.environ.get('RUN_NB_INTEGRATION_TESTS', False)), 'for local testing')
 def test_stop_multi_integration():
     """Tests lifecycle behavior for mixed-mode server types w/ default ports.
 

--- a/notebook/tests/test_notebookapp_integration.py
+++ b/notebook/tests/test_notebookapp_integration.py
@@ -16,7 +16,7 @@ def test_shutdown_sock_server_integration():
     encoded_sock_path = urlencode_unix_socket_path(sock)
 
     p = subprocess.Popen(
-        ['jupyter', 'notebook', '--no-browser', '--sock=%s' % sock],
+        ['jupyter-notebook', '--no-browser', '--sock=%s' % sock],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
 
@@ -27,13 +27,13 @@ def test_shutdown_sock_server_integration():
 
     assert complete, 'did not find socket URL in stdout when launching notebook'
 
-    assert encoded_sock_path.encode() in subprocess.check_output(['jupyter', 'notebook', 'list'])
+    assert encoded_sock_path.encode() in subprocess.check_output(['jupyter-notebook', 'list'])
 
     # Ensure default umask is properly applied.
     assert stat.S_IMODE(os.lstat(sock).st_mode) == 0o600
 
-    subprocess.check_output(['jupyter', 'notebook', 'stop', sock])
+    subprocess.check_output(['jupyter-notebook', 'stop', sock])
 
-    assert encoded_sock_path.encode() not in subprocess.check_output(['jupyter', 'notebook', 'list'])
+    assert encoded_sock_path.encode() not in subprocess.check_output(['jupyter-notebook', 'list'])
 
     p.wait()

--- a/notebook/tests/test_notebookapp_integration.py
+++ b/notebook/tests/test_notebookapp_integration.py
@@ -23,7 +23,7 @@ def test_shutdown_sock_server_integration():
 
     complete = False
     for line in iter(p.stderr.readline, b''):
-        print(line)
+        print(line.decode())
         if url in line:
             complete = True
             break

--- a/notebook/tests/test_notebookapp_integration.py
+++ b/notebook/tests/test_notebookapp_integration.py
@@ -4,6 +4,7 @@ import subprocess
 import time
 
 from ipython_genutils.testing.decorators import skip_win32
+from notebook import DEFAULT_NOTEBOOK_PORT
 
 from .launchnotebook import UNIXSocketNotebookTestBase
 from ..utils import urlencode_unix_socket, urlencode_unix_socket_path
@@ -12,7 +13,7 @@ from ..utils import urlencode_unix_socket, urlencode_unix_socket_path
 @skip_win32
 def test_shutdown_sock_server_integration():
     sock = UNIXSocketNotebookTestBase.sock
-    url = urlencode_unix_socket(sock)
+    url = urlencode_unix_socket(sock).encode()
     encoded_sock_path = urlencode_unix_socket_path(sock)
 
     p = subprocess.Popen(
@@ -21,7 +22,7 @@ def test_shutdown_sock_server_integration():
     )
 
     for line in iter(p.stderr.readline, b''):
-        if url.encode() in line:
+        if url in line:
             complete = True
             break
 
@@ -37,3 +38,66 @@ def test_shutdown_sock_server_integration():
     assert encoded_sock_path.encode() not in subprocess.check_output(['jupyter-notebook', 'list'])
 
     p.wait()
+
+
+
+def _ensure_stopped(check_msg='There are no running servers'):
+    try:
+        subprocess.check_output(
+            ['jupyter-notebook', 'stop'],
+            stderr=subprocess.STDOUT
+        )
+    except subprocess.CalledProcessError as e:
+        assert check_msg in e.output.decode()
+    else:
+        raise AssertionError('expected all servers to be stopped')
+
+
+@skip_win32
+def test_stop_multi():
+    """Tests lifecycle behavior for mixed-mode server types w/ default ports.
+
+    Suitable for local dev testing only due to reliance on default port binding.
+    """
+    TEST_PORT = '9797'
+    MSG_TMPL = 'Shutting down server on {}...'
+
+    _ensure_stopped()
+
+    # Default port.
+    p1 = subprocess.Popen(
+        ['jupyter-notebook', '--no-browser']
+    )
+
+    # Unix socket.
+    sock = UNIXSocketNotebookTestBase.sock
+    p2 = subprocess.Popen(
+        ['jupyter-notebook', '--no-browser', '--sock=%s' % sock]
+    )
+
+    # Specified port
+    p3 = subprocess.Popen(
+        ['jupyter-notebook', '--no-browser', '--port=%s' % TEST_PORT]
+    )
+
+    time.sleep(3)
+
+    assert MSG_TMPL.format(DEFAULT_NOTEBOOK_PORT) in subprocess.check_output(
+        ['jupyter-notebook', 'stop']
+    ).decode()
+
+    _ensure_stopped('There is currently no server running on 8888')
+
+    assert MSG_TMPL.format(sock) in subprocess.check_output(
+        ['jupyter-notebook', 'stop', sock]
+    ).decode()
+
+    assert MSG_TMPL.format(TEST_PORT) in subprocess.check_output(
+        ['jupyter-notebook', 'stop', TEST_PORT]
+    ).decode()
+
+    _ensure_stopped()
+
+    p1.wait()
+    p2.wait()
+    p3.wait()

--- a/notebook/tests/test_notebookapp_integration.py
+++ b/notebook/tests/test_notebookapp_integration.py
@@ -57,7 +57,7 @@ def _ensure_stopped(check_msg='There are no running servers'):
 def test_stop_multi():
     """Tests lifecycle behavior for mixed-mode server types w/ default ports.
 
-    Suitable for local dev testing only due to reliance on default port binding.
+    Mostly suitable for local dev testing due to reliance on default port binding.
     """
     TEST_PORT = '9797'
     MSG_TMPL = 'Shutting down server on {}...'

--- a/notebook/tests/test_notebookapp_integration.py
+++ b/notebook/tests/test_notebookapp_integration.py
@@ -1,0 +1,39 @@
+import os
+import stat
+import subprocess
+import time
+
+from ipython_genutils.testing.decorators import skip_win32
+
+from .launchnotebook import UNIXSocketNotebookTestBase
+from ..utils import urlencode_unix_socket, urlencode_unix_socket_path
+
+
+@skip_win32
+def test_shutdown_sock_server_integration():
+    sock = UNIXSocketNotebookTestBase.sock
+    url = urlencode_unix_socket(sock)
+    encoded_sock_path = urlencode_unix_socket_path(sock)
+
+    p = subprocess.Popen(
+        ['jupyter', 'notebook', '--no-browser', '--sock=%s' % sock],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+
+    for line in iter(p.stderr.readline, b''):
+        if url.encode() in line:
+            complete = True
+            break
+
+    assert complete, 'did not find socket URL in stdout when launching notebook'
+
+    assert encoded_sock_path.encode() in subprocess.check_output(['jupyter', 'notebook', 'list'])
+
+    # Ensure default umask is properly applied.
+    assert stat.S_IMODE(os.lstat(sock).st_mode) == 0o600
+
+    subprocess.check_output(['jupyter', 'notebook', 'stop', sock])
+
+    assert encoded_sock_path.encode() not in subprocess.check_output(['jupyter', 'notebook', 'list'])
+
+    p.wait()

--- a/notebook/utils.py
+++ b/notebook/utils.py
@@ -367,3 +367,18 @@ def run_sync(maybe_async):
                 result = asyncio.ensure_future(maybe_async)
         return result
     return wrapped()
+
+
+def urlencode_unix_socket_path(socket_path):
+    """Encodes a UNIX socket path string from a socket path for the `http+unix` URI form."""
+    return socket_path.replace('/', '%2F')
+
+
+def urldecode_unix_socket_path(socket_path):
+    """Decodes a UNIX sock path string from an encoded sock path for the `http+unix` URI form."""
+    return socket_path.replace('%2F', '/')
+
+
+def urlencode_unix_socket(socket_path):
+    """Encodes a UNIX socket URL from a socket path for the `http+unix` URI form."""
+    return 'http+unix://%s' % urlencode_unix_socket_path(socket_path)

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,8 @@ for more information.
     ],
     extras_require = {
         'test': ['nose', 'coverage', 'requests', 'nose_warnings_filters',
-                 'nbval', 'nose-exclude', 'selenium', 'pytest', 'pytest-cov'],
+                 'nbval', 'nose-exclude', 'selenium', 'pytest', 'pytest-cov',
+                 'requests-unixsocket'],
         'test:sys_platform == "win32"': ['nose-exclude'],
     },
     python_requires = '>=3.5',


### PR DESCRIPTION
This change permits the notebook server to bind to a configurable UNIX socket for cases where UNIX filesystem permissions may be useful to help guard access to the notebook server instance (e.g. such as a shared shell machine). This is mainly useful when paired with SSH tunneling, which directly supports binding TCP ports to UNIX sockets via either of these two option forms:

```
     -L [bind_address:]port:remote_socket
     -L local_socket:remote_socket
```

running the notebook server against a test socket:

```
[omerta ~]$ jupyter notebook --sock /tmp/test.sock --no-browser
[I 22:57:52.941 NotebookApp] It looks like you're running the notebook from source.
        If you're working on the Javascript of the notebook, try running
    
        npm run build:watch
    
        in another terminal window to have the system incrementally
        watch and build the notebook's JavaScript for you, as you make changes.
[I 22:57:53.151 NotebookApp] Serving notebooks from local directory: /Users/kwilson
[I 22:57:53.151 NotebookApp] The Jupyter Notebook is running at:
[I 22:57:53.151 NotebookApp] http+unix://%2Ftmp%2Ftest.sock/
[I 22:57:53.151 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
[I 22:57:53.151 NotebookApp] Welcome to Project Jupyter! Explore the various tools available and their corresponding documentation. If you are interested in contributing to the platform, please visit the communityresources section at https://jupyter.org/community.html.
[C 22:57:53.155 NotebookApp] 
    
    Notebook is listening on http+unix://%2Ftmp%2Ftest.sock/
    
    UNIX sockets are not browser-connectable, but you can tunnel to the instance via e.g.`ssh -L 8888:/tmp/test.sock -N user@this_host` and then opening e.g. http://localhost:8888/?token=0c29e0eb0de85fff9f5d8367d74b58155771fc7df10ab056 in a browser.
[I 00:38:08.283 NotebookApp] 302 GET / (0.0.0.0) 0.83ms
```

vs client:

```
[omerta ~]$ nc -U /tmp/test.sock
GET / HTTP/1.0

HTTP/1.1 302 Found
Server: TornadoServer/6.0.3
Content-Type: text/html; charset=UTF-8
Date: Wed, 21 Aug 2019 07:38:08 GMT
Location: /tree?
Content-Length: 0
```

testing lifecycle (which roundtrips a shutdown request through the server):

```
[omerta notebook (kwlzn/notebook_unix_socket)]$ jupyter notebook list
Currently running servers:
http://localhost:8889/?token=3f8b4d55ad2348342641c042b5d39ac053ea0c10524bc5bf :: /Users/kwilson
http+unix://%2Ftmp%2Ftest.sock/?token=c3071bb578b9d418ab14908fb915053560e3be9748f9bf74 :: /Users/kwilson
[omerta notebook (kwlzn/notebook_unix_socket)]$ jupyter notebook stop 8889
Shutting down server on ...
[omerta notebook (kwlzn/notebook_unix_socket)]$ jupyter notebook list
Currently running servers:
http+unix://%2Ftmp%2Ftest.sock/?token=c3071bb578b9d418ab14908fb915053560e3be9748f9bf74 :: /Users/kwilson
[omerta notebook (kwlzn/notebook_unix_socket)]$ jupyter notebook stop /tmp/test.sock
Shutting down server on /tmp/test.sock...
[omerta notebook (kwlzn/notebook_unix_socket)]$ jupyter notebook list
Currently running servers:
[omerta notebook (kwlzn/notebook_unix_socket)]$ 
```

```
[I 00:25:10.492 NotebookApp] Shutting down on /api/shutdown request.
[I 00:25:10.493 NotebookApp] Shutting down 0 kernels
```

Closes #2503