### PR TITLE
Update contents API docs

### DIFF
--- a/docs/source/extending/contents.rst
+++ b/docs/source/extending/contents.rst
@@ -100,9 +100,9 @@ model. There are three model types: **notebook**, **file**, and **directory**.
    In certain circumstances, we don't need the full content of an entity to
    complete a Contents API request.  In such cases, we omit the ``content``, and
    ``format`` keys from the model, and the default values for the ``mimetype``
-   field. This most commonly occurs    when listing a directory, in which
-   circumstance we represent files within    the directory as content-less models
-   to avoid having to recursively traverse    and serialize the entire filesystem.
+   field. This most commonly occurs when listing a directory, in which
+   circumstance we represent files within the directory as content-less models
+   to avoid having to recursively traverse and serialize the entire filesystem.
 
 **Sample Models**
 

--- a/docs/source/extending/contents.rst
+++ b/docs/source/extending/contents.rst
@@ -81,7 +81,9 @@ model. There are three model types: **notebook**, **file**, and **directory**.
     - The ``format`` field is either ``"text"`` or ``"base64"``.
     - The ``mimetype`` field can be any mimetype string, but defaults to 
       ``text/plain`` for text-format models and
-      ``application/octet-stream`` for base64-format models.
+      ``application/octet-stream`` for base64-format models. For files with
+      unknown mime types (e.g. unknown file extensions), this field may be
+      `None`.
     - The ``content`` field is always of type ``unicode``.  For text-format
       file models, ``content`` simply contains the file's bytes after decoding
       as UTF-8.  Non-text (``base64``) files are read as bytes, base64 encoded,
@@ -100,9 +102,10 @@ model. There are three model types: **notebook**, **file**, and **directory**.
    In certain circumstances, we don't need the full content of an entity to
    complete a Contents API request.  In such cases, we omit the ``content``, and
    ``format`` keys from the model, and the default values for the ``mimetype``
-   field. This most commonly occurs when listing a directory, in which
-   circumstance we represent files within the directory as content-less models
-   to avoid having to recursively traverse and serialize the entire filesystem.
+   field (see above). This most commonly occurs when listing a directory, in
+   which circumstance we represent files within the directory as content-less
+   models to avoid having to recursively traverse and serialize the entire
+   filesystem.
 
 **Sample Models**
 

--- a/docs/source/extending/contents.rst
+++ b/docs/source/extending/contents.rst
@@ -79,7 +79,7 @@ model. There are three model types: **notebook**, **file**, and **directory**.
 
 - ``file`` models
     - The ``format`` field is either ``"text"`` or ``"base64"``.
-    - The ``mimetype`` field is can be any mimetype string, but defaults to 
+    - The ``mimetype`` field can be any mimetype string, but defaults to 
       ``text/plain`` for text-format models and
       ``application/octet-stream`` for base64-format models.
     - The ``content`` field is always of type ``unicode``.  For text-format

--- a/docs/source/extending/contents.rst
+++ b/docs/source/extending/contents.rst
@@ -79,7 +79,8 @@ model. There are three model types: **notebook**, **file**, and **directory**.
 
 - ``file`` models
     - The ``format`` field is either ``"text"`` or ``"base64"``.
-    - The ``mimetype`` field is ``text/plain`` for text-format models and
+    - The ``mimetype`` field is can be any mimetype string, but defaults to 
+      ``text/plain`` for text-format models and
       ``application/octet-stream`` for base64-format models.
     - The ``content`` field is always of type ``unicode``.  For text-format
       file models, ``content`` simply contains the file's bytes after decoding
@@ -97,11 +98,11 @@ model. There are three model types: **notebook**, **file**, and **directory**.
    .. _contentfree:
 
    In certain circumstances, we don't need the full content of an entity to
-   complete a Contents API request.  In such cases, we omit the ``mimetype``,
-   ``content``, and ``format`` keys from the model. This most commonly occurs
-   when listing a directory, in which circumstance we represent files within
-   the directory as content-less models to avoid having to recursively traverse
-   and serialize the entire filesystem.
+   complete a Contents API request.  In such cases, we omit the ``content``, and
+   ``format`` keys from the model, and the default values for the ``mimetype``
+   field. This most commonly occurs    when listing a directory, in which
+   circumstance we represent files within    the directory as content-less models
+   to avoid having to recursively traverse    and serialize the entire filesystem.
 
 **Sample Models**
 

--- a/docs/source/extending/contents.rst
+++ b/docs/source/extending/contents.rst
@@ -100,9 +100,10 @@ model. There are three model types: **notebook**, **file**, and **directory**.
    .. _contentfree:
 
    In certain circumstances, we don't need the full content of an entity to
-   complete a Contents API request.  In such cases, we omit the ``content``, and
-   ``format`` keys from the model, and the default values for the ``mimetype``
-   field (see above). This most commonly occurs when listing a directory, in
+   complete a Contents API request. In such cases, we omit the ``content``, and
+   ``format`` keys from the model. The default values for the ``mimetype``
+   field will might also not be evaluated, in which case it will be set as `None`.
+   This reduced reply most commonly occurs when listing a directory, in
    which circumstance we represent files within the directory as content-less
    models to avoid having to recursively traverse and serialize the entire
    filesystem.


### PR DESCRIPTION
Now the contents API docs better match the default notebook implementation:

https://github.com/jupyter/notebook/blob/c2d4561ba6b25ec4e0f1f9ec617c3338f4de1ef4/notebook/services/contents/filemanager.py#L362