### PR TITLE
Compress and download folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ config.rst
 package-lock.json
 geckodriver.log
 *.iml
+.vscode/


### PR DESCRIPTION
The goal to this PR is to integrate https://github.com/hadim/jupyter-archive to Jupyter. 

Two others to JLab and `jupyter_server` will also be submitted.

For now, there is nothing in this commit because I need some guidance on how to integrate the Python code to the notebook.

My idea was to create a class called `ArchiveHandler` next to `FilesHandler` in `files/handlers.py` but it appears that `FilesHandler.get` is never called when downloading a file from notebook or Jlab.

Instead `web.StaticFileHandler` is used `base.handlers.AuthenticatedFileHandler.get`.

Two questions:

- What is the point of `FilesHandler` then?
- Where should I implement the `ArchiveHandler`? The code is here: https://github.com/hadim/jupyter-archive/blob/master/jupyter_archive/handlers.py#L45
