### PR TITLE
Update core and client dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,8 +104,8 @@ for more information.
         'pyzmq>=17',
         'ipython_genutils',
         'traitlets>=4.2.1',
-        'jupyter_core>=4.4.0',
-        'jupyter_client>=5.3.1',
+        'jupyter_core>=4.6.0',
+        'jupyter_client>=5.3.4',
         'nbformat',
         'nbconvert',
         'ipykernel', # bless IPython kernel for now


### PR DESCRIPTION
Due to recent changes surrounding updates to [jupyter_client](https://github.com/jupyter/jupyter_client/pull/483) and [jupyter_core](https://github.com/jupyter/jupyter_core/pull/163), it would be good to increase their minimum dependencies.

Please include this in the next maintenance release: `6.0.2`