### PR TITLE
Fix default value for display_url function with fqdn instead of hostname

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1458,7 +1458,7 @@ class NotebookApp(JupyterApp):
                 url += '/'
         else:
             if self.ip in ('', '0.0.0.0'):
-                ip = "%s" % socket.gethostname()
+                ip = "%s" % socket.getfqdn()
             else:
                 ip = self.ip
             url = self._url(ip)


### PR DESCRIPTION
A fully qualified domain name (FQDN) is the complete domain name for a specific computer.
A hostname is the name of a computer.

The DNS should contain an A record of the FQDN and not of the hostname.