### PR TITLE
Fix Safari monospace font issue (bug #4517).

### DIFF
--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -99,7 +99,6 @@
       })
 
     document.nbjs_translations = {{ nbjs_translations|safe }};
-    document.documentElement.lang = navigator.language.toLowerCase();
     </script>
 
     {% block meta %}


### PR DESCRIPTION
As can be seen in bug #4517, commit 6b79838 made Notebook more or less unusable for Safari users. This PR reverts the line that triggered the Safari bug.

Yes, it does seem to be a Safari bug. However, reverting (part of) the change does not seem to cause any other problems. I have tested the change in various Notebook version, and everything seems to be fine.

Thanks to @pcr910303 for finding out the cause of the problem.