### PR TITLE
fix: respect --no-browser

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1825,7 +1825,7 @@ class NotebookApp(JupyterApp):
         self.write_server_info_file()
         self.write_browser_open_file()
 
-        if self.open_browser or self.file_to_run:
+        if self.open_browser:
             self.launch_browser()
 
         if self.token and self._token_generated:


### PR DESCRIPTION
When I run:
```
$ jupyter notebook ~/src/QuantStack/voila/notebooks/bqplot.ipynb --no-browser
```
I still get a browser window opened, which I don't want. One might argue that "what is the point of giving the path on the command line?".

I often run the notebook of voila like this, and keep 1 browser tab open, kill the server, and start voila or notebook again (after a fix, or reinstallation of some other package). Having it open a browser each time is annoying and unexpected.

I wanted to fix this in jupyter server, but it makes more sense to have this consistent, and first discuss it here.

cc @minrk this is introduced in 26a1cc7ee21d8569e09349167f66ef9260b1429b 