### PR TITLE
Setting to disable redirect file browser launch

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -223,7 +223,6 @@ class NotebookWebApplication(web.Application):
             base_url=base_url,
             default_url=default_url,
             template_path=template_path,
-            use_redirect_file=jupyter_app.use_redirect_file,
             static_path=jupyter_app.static_file_path,
             static_custom_path=jupyter_app.static_custom_path,
             static_handler_class = FileFindHandler,


### PR DESCRIPTION
When it was originally added, the PR for launching a browser via a redirect file (jupyter#4260) created some issues for some environments-namely WSL, Chromebook, and Android (jupyter#4346 (comment), jupyter/help#496). The reason for the break in these environments is due to the file structure/path differences between the runtime and the browser. 

This commit adds a setting to the `jupyter_notebook_config.py` that allows users to disable the use of redirect file for launching a browser in favor of the original, yet visible, URL + token approach. This setting: `c.NotebookApp.use_redirect_file` will be set to True by default.