### PR TITLE
Modified python3 to python

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -81,9 +81,9 @@ running other instances of Jupyter Notebook. You can try the following steps:
 
 1. Uninstall all instances of the notebook package. These include any installations you made using
    pip or conda
-2. Run ``python3 -m pip install -e .`` in the notebook repository to install the notebook from there
+2. Run ``python -m pip install -e .`` in the notebook repository to install the notebook from there
 3. Run ``npm run build`` to make sure the Javascript and CSS are updated and compiled
-4. Launch with ``python3 -m notebook --port 8989``, and check that the browser is pointing to ``localhost:8989``
+4. Launch with ``python -m notebook --port 8989``, and check that the browser is pointing to ``localhost:8989``
    (rather than the default 8888). You don't necessarily have to launch with port 8989, as long as you use
    a port that is neither the default nor in use, then it should be fine.
 5. Verify the installation with the steps in the previous section.


### PR DESCRIPTION
python2 is going to be deprecated in Jan 2020 and so changed it to python (and also so it is consistent with the other documentation)