### PR TITLE
add support for more RTL languages

### DIFF
--- a/notebook/static/bidi/bidi.js
+++ b/notebook/static/bidi/bidi.js
@@ -23,7 +23,7 @@ define(['bidi/numericshaping'], function(numericshaping) {
   };
 
   var _isMirroringEnabled = function() {
-    return new RegExp('^(ar|he)').test(_uiLang());
+    return new RegExp('^(ar|ara|arc|ae|ave|egy|he|heb|nqo|pal|phn|sam|syc|syr|fa|per|fas|ckb|ur|urd)').test(_uiLang());
   };
 
   /**


### PR DESCRIPTION
The notebook switches to right-to-left layout when the browser language is set to Arabic or Hebrew. However there are more RTL languages in the world, e.g. Persian and Urdu.

This patch adds the ISO 639 codes for more RTL languages. It's *almost* a copy-paste from [a ruby gem](https://github.com/abarrak/rtl) and [here](http://www.i18nguy.com/temp/rtl.html) is their reference for the language list.