### PR TITLE
Make markdown cells stay RTL in edit mode

### DIFF
--- a/notebook/static/notebook/js/textcell.js
+++ b/notebook/static/notebook/js/textcell.js
@@ -13,7 +13,8 @@ define([
     'components/marked/lib/marked',
     'codemirror/lib/codemirror',
     'codemirror/mode/gfm/gfm',
-    'notebook/js/codemirror-ipythongfm'
+    'notebook/js/codemirror-ipythongfm',
+    'bidi/bidi'
 ], function(
     $,
     utils,
@@ -26,7 +27,8 @@ define([
     marked,
     CodeMirror,
     gfm,
-    ipgfm
+    ipgfm,
+    bidi
     ) {
     "use strict";
     function encodeURIandParens(uri){return encodeURI(uri).replace('(','%28').replace(')','%29')}
@@ -300,7 +302,8 @@ define([
 
     MarkdownCell.options_default = {
         cm_config: {
-            mode: 'ipythongfm'
+            mode: 'ipythongfm',
+            direction: bidi.isMirroringEnabled() ? 'rtl' : 'ltr'
         },
         placeholder: "Type *Markdown* and LaTeX: $\\alpha^2$"
     };


### PR DESCRIPTION
In RTL mode, *rendered* markdown cells show in RTL direction. However, when I want to edit them, they become LTR. This makes them unusable for writing as the problem is not merely about the alignment, but also the direction of text flow. See below:

---

### BEFORE ENTERING EDIT MODE:

![ja](https://user-images.githubusercontent.com/26688819/68354252-1ff63880-0121-11ea-9675-2eabc3c45b49.png)

---

### AFTER ENTERING EDIT MODE:

![jb](https://user-images.githubusercontent.com/26688819/68354259-2389bf80-0121-11ea-8ac3-85c2072c2a23.png)

---

This PR fixes the bug, without affecting the actual code cells:

![jc](https://user-images.githubusercontent.com/26688819/68354361-6055b680-0121-11ea-93c4-9b4ba9e88caf.png)
