### PR TITLE
Add newer python excursions on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - cmd: '%CONDA_ACTIVATE% && conda upgrade -y -c conda-forge conda'
   - cmd: '%CONDA_ACTIVATE% && conda create -y -n notebook-test -c conda-forge -c defaults "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1'
   - cmd: '%CONDA_ACTIVATE% notebook-test && npm install && python setup.py build sdist bdist_wheel || exit 1'
-  - cmd: '%CONDA_ACTIVATE% notebook-test && cd dist && for %%whl in (*.whl) do (python -m pip install --no-deps %%whl) || exit 1'
+  - cmd: '%CONDA_ACTIVATE% notebook-test && cd dist && for %whl in (*.whl) do (python -m pip install --no-deps %whl) || exit 1'
 
 test_script:
   - '%CONDA_ACTIVATE% notebook-test && md tst_tmp && cd tst_tmp && nosetests -vv --with-cov --traverse-namespace --cov notebook notebook || exit 1'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,8 +45,8 @@ build: off
 install:
   - cmd: '%CONDA_ACTIVATE% && conda upgrade -y -c conda-forge conda'
   - cmd: '%CONDA_ACTIVATE% && conda create -y -n notebook-test -c conda-forge -c defaults "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1'
-  - cmd: '%CONDA_ACTIVATE% notebook-test && npm install && python setup.py build sdist bdist_wheel || exit 1'
-  - cmd: '%CONDA_ACTIVATE% notebook-test && python -m pip install --no-deps --find-links=dist notebook'
+  - cmd: '%CONDA_ACTIVATE% notebook-test && npm install && python setup.py sdist bdist_wheel || exit 1'
+  - cmd: '%CONDA_ACTIVATE% notebook-test && cd dist && python -m pip install --no-deps --ignore-installed --find-links=. notebook'
 
 test_script:
   - '%CONDA_ACTIVATE% notebook-test && md tst_tmp && cd tst_tmp && nosetests -vv --with-cov --traverse-namespace --cov notebook notebook || exit 1'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,4 +32,4 @@ install:
   - cmd: call activate notebook-test && python -m pip install . --no-deps
 
 test_script:
-  - call activate notebook-test && md tst_tmp && cd tst_tmp && python -m nose -v notebook
+  - call activate notebook-test && md tst_tmp && cd tst_tmp && python -m nose -v notebook --traverse-namespace

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,9 @@ matrix:
   fast_finish: true
 
 environment:
-  CONDA_BUILD_DEPS: nodejs
+  CONDA_BUILD_DEPS: nodejs pip
   CONDA_RUN_DEPS: jinja2 tornado pyzmq ipython_genutils traitlets jupyter_core jupyter_client nbformat nbconvert ipykernel send2trash terminado prometheus_client
-  CONDA_TEST_DEPS: nose coverage requests nbval nose-exclude selenium pytest pytest-cov
+  CONDA_TEST_DEPS: nose coverage requests nbval nose-exclude selenium pytest pytest-cov firefox geckodriver
   CUSTOM_CHANNELS: -c conda-forge -c defaults
   matrix:
     - CONDA_PY: 38
@@ -27,8 +27,7 @@ install:
   - cmd: conda config --set show_channel_urls true
   - cmd: conda create -yn notebook-test %CUSTOM_CHANNELS% "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
   - cmd: call activate notebook-test && python setup.py build
-  # basically for nose_warnings_filter at this point
-  - cmd: call activate notebook-test && pip install . --no-deps
+  - cmd: call activate notebook-test && python -m pip install . --no-deps
 
 test_script:
-  - call activate notebook-test && md tst_tmp && cd tst_tmp && nosetests -v notebook --ignore-files selenium
+  - call activate notebook-test && md tst_tmp && cd tst_tmp && python -m nosetests -v notebook

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,19 +1,15 @@
-# miniconda bootstrap from conda-forge recipe
-matrix:
-  fast_finish: true
-
 environment:
   CONDA_RUN_DEPS: jinja2 tornado pyzmq ipython_genutils traitlets jupyter_core jupyter_client nbformat nbconvert ipykernel send2trash terminado prometheus_client
   CONDA_TEST_DEPS: nose coverage requests nbval nose-exclude selenium pytest pytest-cov
   matrix:
-    - CONDA_PY: 36
-      CONDA_PY_SPEC: ">=3.6,<3.7.0a0"
+    - CONDA_PY: 38
+      CONDA_PY_SPEC: ">=3.8,<3.9.0a0"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
     - CONDA_PY: 37
       CONDA_PY_SPEC: ">=3.7,<3.8.0a0"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
-    - CONDA_PY: 38
-      CONDA_PY_SPEC: ">=3.8,<3.9.0a0"
+    - CONDA_PY: 36
+      CONDA_PY_SPEC: ">=3.6,<3.7.0a0"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
 
 platform:
@@ -24,9 +20,10 @@ build: off
 install:
   - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
   - cmd: conda config --set show_channel_urls true
+  - cmd: conda config --set always_yes true
   - cmd: conda config --add channels conda-forge
-  #- cmd: conda update --yes --quiet conda
-  - cmd: conda install -y "python %CONDA_PY_SPEC%" %CONDA_RUN_DEPS% %CONDA_TEST_DEPS%
+  - cmd: conda update conda
+  - cmd: conda install "python %CONDA_PY_SPEC%" %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
   - cmd: python setup.py build
   # basically for nose_warnings_filter at this point
   - cmd: pip install .[test]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,40 +40,9 @@ platform:
 build: off
 
 install:
-  - cmd: >-
-      %CONDA_ACTIVATE%
-      && conda upgrade -y
-        -c conda-forge
-        conda
-  - cmd: >-
-      %CONDA_ACTIVATE%
-      && conda create -y
-        -n notebook-test
-        -c conda-forge
-        -c defaults
-        "python %CONDA_PY_SPEC%"
-        %CONDA_BUILD_DEPS%
-        %CONDA_RUN_DEPS%
-        %CONDA_TEST_DEPS%
-      || exit 1
-  - cmd: >-
-      %CONDA_ACTIVATE% notebook-test
-      && npm install
-      && python setup.py build sdist bdist_wheel
-      || exit 1
-  - cmd: >-
-      %CONDA_ACTIVATE% notebook-test
-      && cd build
-      && dir /b /a-d *.whl > whl.txt
-      && set /p WHL=<whl.txt
-      && python -m pip install --no-deps %WHL%
-      || exit 1
+  - cmd: %CONDA_ACTIVATE% && conda upgrade -y -c conda-forge conda
+  - cmd: %CONDA_ACTIVATE% && conda create -y -n notebook-test -c conda-forge -c defaults "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
+  - cmd: %CONDA_ACTIVATE% notebook-test && npm install && python setup.py build sdist bdist_wheel || exit 1
+  - cmd: %CONDA_ACTIVATE% notebook-test && cd build && dir /b /a-d *.whl > whl.txt && set /p WHL=<whl.txt && python -m pip install --no-deps %WHL% || exit 1
 test_script:
-  - >-
-    %CONDA_ACTIVATE% notebook-test
-    && md tst_tmp
-    && cd tst_tmp
-    && nosetests -vv --with-cov --traverse-namespace
-      --cov notebook
-      notebook
-    || exit 1
+  - %CONDA_ACTIVATE% notebook-test && md tst_tmp && cd tst_tmp && nosetests -vv --with-cov --traverse-namespace --cov notebook notebook || exit 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 environment:
+  CONDA_BUILD_DEPS: nodejs
   CONDA_RUN_DEPS: jinja2 tornado pyzmq ipython_genutils traitlets jupyter_core jupyter_client nbformat nbconvert ipykernel send2trash terminado prometheus_client
   CONDA_TEST_DEPS: nose coverage requests nbval nose-exclude selenium pytest pytest-cov
+  CONDA_CHANNELS: -c conda-forge -c defaults
   matrix:
     - CONDA_PY: 38
       CONDA_PY_SPEC: ">=3.8,<3.9.0a0"
@@ -20,10 +22,8 @@ build: off
 install:
   - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
   - cmd: conda config --set show_channel_urls true
-  - cmd: conda config --set always_yes true
-  - cmd: conda config --add channels conda-forge
-  - cmd: conda update conda
-  - cmd: conda install "python %CONDA_PY_SPEC%" %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
+  - cmd: conda update -y %CONDA_CHANNELS% conda
+  - cmd: conda install -y %CONDA_CHANNELS% "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
   - cmd: python setup.py build
   # basically for nose_warnings_filter at this point
   - cmd: pip install .[test]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,10 @@ environment:
   matrix:
     - CONDA_PY: 36
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
+    - CONDA_PY: 37
+      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
+    - CONDA_PY: 38
+      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
 
 platform:
   - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - cmd: conda create -yn notebook-test %CUSTOM_CHANNELS% "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
   - cmd: call activate notebook-test && python setup.py build
   # basically for nose_warnings_filter at this point
-  - cmd: call activate notebook-test && pip install .[test]
+  - cmd: call activate notebook-test && pip install . --no-deps
 
 test_script:
-  - call activate notebook-test && nosetests -v notebook --exclude-dir notebook\tests\selenium
+  - call activate notebook-test && md tst_tmp && cd tst_tmp && nosetests -v notebook --ignore-files selenium

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,9 +40,15 @@ platform:
 build: off
 
 install:
-  - cmd: conda upgrade conda
   - cmd: >-
-      conda create -y
+      %CONDA_ACTIVATE%
+      && conda upgrade -y
+        -n base
+        -c conda-forge
+        conda
+  - cmd: >-
+      %CONDA_ACTIVATE%
+      && conda create -y
         -n notebook-test
         -c conda-forge
         -c defaults

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,7 @@ install:
   - cmd: '%CONDA_ACTIVATE% && conda upgrade -y -c conda-forge conda'
   - cmd: '%CONDA_ACTIVATE% && conda create -y -n notebook-test -c conda-forge -c defaults "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1'
   - cmd: '%CONDA_ACTIVATE% notebook-test && npm install && python setup.py build sdist bdist_wheel || exit 1'
-  - cmd: '%CONDA_ACTIVATE% notebook-test && cd dist && dir && dir /b /a-d *.whl > whl.txt && set /p WHL=<whl.txt && python -m pip install --no-deps %WHL% || exit 1'
+  - cmd: '%CONDA_ACTIVATE% notebook-test && cd dist && for %%whl in (*.whl) do (python -m pip install --no-deps %%whl) || exit 1'
+
 test_script:
   - '%CONDA_ACTIVATE% notebook-test && md tst_tmp && cd tst_tmp && nosetests -vv --with-cov --traverse-namespace --cov notebook notebook || exit 1'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
   - cmd: conda upgrade conda
   - cmd: conda create -n notebook-test %CUSTOM_CHANNELS% "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
   - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat notebook-test && python setup.py build
-  - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat notebook-test && python -m pip install . --no-deps
+  - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat notebook-test && python -m pip install . jupyter_client jupyter_core --no-deps
 
 test_script:
   - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat notebook-test && md tst_tmp && cd tst_tmp && nosetests -v notebook --with-cov --cov notebook --traverse-namespace

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,9 @@
 matrix:
   fast_finish: true
 
+cache:
+  - '%LOCALAPPDATA%\bower\cache\packages -> bower.json'
+
 environment:
   CONDA_ACTIVATE: "call C:\\Miniconda36-x64\\Scripts\\activate.bat"
   CONDA_BUILD_DEPS: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,41 +40,40 @@ platform:
 build: off
 
 install:
-  - cmd: >-
-      %CONDA_ACTIVATE%
-      && conda upgrade -y
-        -n base
-        -c conda-forge
+  - cmd: |-
+      %CONDA_ACTIVATE% ^
+      && conda upgrade -y ^
+        -c conda-forge ^
         conda
-  - cmd: >-
-      %CONDA_ACTIVATE%
-      && conda create -y
-        -n notebook-test
-        -c conda-forge
-        -c defaults
-        "python %CONDA_PY_SPEC%"
-        %CONDA_BUILD_DEPS%
-        %CONDA_RUN_DEPS%
-        %CONDA_TEST_DEPS%
+  - cmd: |-
+      %CONDA_ACTIVATE% ^
+      && conda create -y ^
+        -n notebook-test ^
+        -c conda-forge ^
+        -c defaults ^
+        "python %CONDA_PY_SPEC%" ^
+        %CONDA_BUILD_DEPS% ^
+        %CONDA_RUN_DEPS% ^
+        %CONDA_TEST_DEPS% ^
       || exit 1
-  - cmd: >-
-      %CONDA_ACTIVATE% notebook-test
-      && npm install
-      && python setup.py build sdist bdist_wheel
+  - cmd: |-
+      %CONDA_ACTIVATE% notebook-test ^
+      && npm install ^
+      && python setup.py build sdist bdist_wheel ^
       || exit 1
-  - cmd: >-
-      %CONDA_ACTIVATE% notebook-test
-      && cd build
-      && dir /b /a-d *.whl > whl.txt
-      && set /p WHL=<whl.txt
-      && python -m pip install --no-deps %WHL%
+  - cmd: |-
+      %CONDA_ACTIVATE% notebook-test ^
+      && cd build ^
+      && dir /b /a-d *.whl > whl.txt ^
+      && set /p WHL=<whl.txt ^
+      && python -m pip install --no-deps %WHL% ^
       || exit 1
 test_script:
-  - >-
-    %CONDA_ACTIVATE% notebook-test
-    && md tst_tmp
-    && cd tst_tmp
-    && nosetests -vv --with-cov --traverse-namespace
-      --cov notebook
-      notebook
+  - |-
+    %CONDA_ACTIVATE% notebook-test ^
+    && md tst_tmp ^
+    && cd tst_tmp ^
+    && nosetests -vv --with-cov --traverse-namespace ^
+      --cov notebook ^
+      notebook ^
     || exit 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   CONDA_BUILD_DEPS: nodejs
   CONDA_RUN_DEPS: jinja2 tornado pyzmq ipython_genutils traitlets jupyter_core jupyter_client nbformat nbconvert ipykernel send2trash terminado prometheus_client
   CONDA_TEST_DEPS: nose coverage requests nbval nose-exclude selenium pytest pytest-cov
-  CONDA_CHANNELS: -c conda-forge -c defaults
+  CUSTOM_CHANNELS: -c conda-forge -c defaults
   matrix:
     - CONDA_PY: 38
       CONDA_PY_SPEC: ">=3.8,<3.9.0a0"
@@ -25,8 +25,8 @@ build: off
 install:
   - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
   - cmd: conda config --set show_channel_urls true
-  - cmd: conda update -y %CONDA_CHANNELS% conda
-  - cmd: conda install -y %CONDA_CHANNELS% "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
+  - cmd: conda create -yn notebook-test %CUSTOM_CHANNELS% "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
+  - cmd: call activate notebook-test
   - cmd: python setup.py build
   # basically for nose_warnings_filter at this point
   - cmd: pip install .[test]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,11 @@ matrix:
 environment:
   CONDA_BUILD_DEPS: nodejs pip
   CONDA_RUN_DEPS: jinja2 tornado pyzmq ipython_genutils traitlets jupyter_core jupyter_client nbformat nbconvert ipykernel send2trash terminado prometheus_client
-  CONDA_TEST_DEPS: nose coverage requests nbval nose-exclude selenium pytest pytest-cov firefox=68 geckodriver
+  CONDA_TEST_DEPS: nose nose-cov requests
   CUSTOM_CHANNELS: -c conda-forge -c defaults
   JUPYTER_TEST_BROWSER: firefox
   MOZ_HEADLESS: "1"
+  NOSE_EXCLUDE: selenium
   matrix:
     - CONDA_PY: 38
       CONDA_PY_SPEC: ">=3.8,<3.9.0a0"
@@ -32,4 +33,4 @@ install:
   - cmd: call activate notebook-test && python -m pip install . --no-deps
 
 test_script:
-  - call activate notebook-test && md tst_tmp && cd tst_tmp && python -m nose -v notebook --traverse-namespace
+  - call activate notebook-test && md tst_tmp && cd tst_tmp && nosetests -v notebook --with-cov --cov notebook --traverse-namespace

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,9 @@ install:
   - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
   - cmd: conda config --set show_channel_urls true
   - cmd: conda create -yn notebook-test %CUSTOM_CHANNELS% "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
-  - cmd: call activate notebook-test
-  - cmd: python setup.py build
+  - cmd: call activate notebook-test && python setup.py build
   # basically for nose_warnings_filter at this point
-  - cmd: pip install .[test]
+  - cmd: call activate notebook-test && pip install .[test]
 
 test_script:
-  - nosetests  -v notebook --exclude-dir notebook\tests\selenium
+  - call activate notebook-test && nosetests -v notebook --exclude-dir notebook\tests\selenium

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,21 +2,37 @@ matrix:
   fast_finish: true
 
 environment:
-  CONDA_BUILD_DEPS: nodejs pip
-  CONDA_RUN_DEPS: jinja2 tornado pyzmq ipython_genutils traitlets jupyter_core jupyter_client nbformat nbconvert ipykernel send2trash terminado prometheus_client
-  CONDA_TEST_DEPS: nose nose-cov requests
-  CUSTOM_CHANNELS: -c conda-forge -c defaults
+  CONDA_ACTIVATE: "call C:\\Miniconda36-x64\\Scripts\\activate.bat"
+  CONDA_BUILD_DEPS: >-
+    "babel"
+    "nodejs >=6.0"
+    "pip"
+  CONDA_RUN_DEPS: >-
+    "ipykernel"
+    "ipython_genutils"
+    "jinja2"
+    "jupyter_client >=5.3.4"
+    "jupyter_core >=4.6.0"
+    "nbconvert"
+    "nbformat"
+    "prometheus_client"
+    "pyzmq"
+    "send2trash"
+    "terminado >=0.8.1"
+    "tornado"
+    "traitlets >=4.2.1"
+  CONDA_TEST_DEPS: >
+    "nose"
+    "nose-cov"
+    "requests"
   NOSE_EXCLUDE: selenium
   matrix:
     - CONDA_PY: 38
       CONDA_PY_SPEC: ">=3.8,<3.9.0a0"
-      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
     - CONDA_PY: 37
       CONDA_PY_SPEC: ">=3.7,<3.8.0a0"
-      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
     - CONDA_PY: 36
       CONDA_PY_SPEC: ">=3.6,<3.7.0a0"
-      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
 
 platform:
   - x64
@@ -24,13 +40,35 @@ platform:
 build: off
 
 install:
-  - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-  - cmd: conda config --set show_channel_urls true
-  - cmd: conda config --set always_yes true
   - cmd: conda upgrade conda
-  - cmd: conda create -n notebook-test %CUSTOM_CHANNELS% "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
-  - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat notebook-test && python setup.py build
-  - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat notebook-test && python -m pip install . jupyter_client jupyter_core --no-deps
-
+  - cmd: >-
+      conda create -y
+        -n notebook-test
+        -c conda-forge
+        -c defaults
+        "python %CONDA_PY_SPEC%"
+        %CONDA_BUILD_DEPS%
+        %CONDA_RUN_DEPS%
+        %CONDA_TEST_DEPS%
+      || exit 1
+  - cmd: >-
+      %CONDA_ACTIVATE% notebook-test
+      && npm install
+      && python setup.py build sdist bdist_wheel
+      || exit 1
+  - cmd: >-
+      %CONDA_ACTIVATE% notebook-test
+      && cd build
+      && dir /b /a-d *.whl > whl.txt
+      && set /p WHL=<whl.txt
+      && python -m pip install --no-deps %WHL%
+      || exit 1
 test_script:
-  - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat notebook-test && md tst_tmp && cd tst_tmp && nosetests -v notebook --with-cov --cov notebook --traverse-namespace
+  - >-
+    %CONDA_ACTIVATE% notebook-test
+    && md tst_tmp
+    && cd tst_tmp
+    && nosetests -vv --with-cov --traverse-namespace
+      --cov notebook
+      notebook
+    || exit 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,8 +29,8 @@ install:
   - cmd: conda config --set always_yes true
   - cmd: conda upgrade conda
   - cmd: conda create -n notebook-test %CUSTOM_CHANNELS% "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
-  - cmd: call activate notebook-test && python setup.py build
-  - cmd: call activate notebook-test && python -m pip install . --no-deps
+  - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat notebook-test && python setup.py build
+  - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat notebook-test && python -m pip install . --no-deps
 
 test_script:
-  - call activate notebook-test && md tst_tmp && cd tst_tmp && nosetests -v notebook --with-cov --cov notebook --traverse-namespace
+  - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat notebook-test && md tst_tmp && cd tst_tmp && nosetests -v notebook --with-cov --cov notebook --traverse-namespace

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - cmd: '%CONDA_ACTIVATE% && conda upgrade -y -c conda-forge conda'
   - cmd: '%CONDA_ACTIVATE% && conda create -y -n notebook-test -c conda-forge -c defaults "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1'
   - cmd: '%CONDA_ACTIVATE% notebook-test && npm install && python setup.py build sdist bdist_wheel || exit 1'
-  - cmd: '%CONDA_ACTIVATE% notebook-test && cd dist && for %%whl in (*.whl) do python -m pip install --no-deps %%whl'
+  - cmd: '%CONDA_ACTIVATE% notebook-test && cd dist && for %whl in (*.whl) do python -m pip install --no-deps %whl'
 
 test_script:
   - '%CONDA_ACTIVATE% notebook-test && md tst_tmp && cd tst_tmp && nosetests -vv --with-cov --traverse-namespace --cov notebook notebook || exit 1'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ build: off
 
 install:
   - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+  - cmd: conda upgrade conda
   - cmd: conda config --set show_channel_urls true
   - cmd: conda create -yn notebook-test %CUSTOM_CHANNELS% "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
   - cmd: call activate notebook-test && python setup.py build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,6 @@ install:
   - cmd: '%CONDA_ACTIVATE% && conda upgrade -y -c conda-forge conda'
   - cmd: '%CONDA_ACTIVATE% && conda create -y -n notebook-test -c conda-forge -c defaults "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1'
   - cmd: '%CONDA_ACTIVATE% notebook-test && npm install && python setup.py build sdist bdist_wheel || exit 1'
-  - cmd: '%CONDA_ACTIVATE% notebook-test && cd build && dir && dir /b /a-d *.whl > whl.txt && set /p WHL=<whl.txt && python -m pip install --no-deps %WHL% || exit 1'
+  - cmd: '%CONDA_ACTIVATE% notebook-test && cd dist && dir && dir /b /a-d *.whl > whl.txt && set /p WHL=<whl.txt && python -m pip install --no-deps %WHL% || exit 1'
 test_script:
   - '%CONDA_ACTIVATE% notebook-test && md tst_tmp && cd tst_tmp && nosetests -vv --with-cov --traverse-namespace --cov notebook notebook || exit 1'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,6 @@ environment:
   CONDA_RUN_DEPS: jinja2 tornado pyzmq ipython_genutils traitlets jupyter_core jupyter_client nbformat nbconvert ipykernel send2trash terminado prometheus_client
   CONDA_TEST_DEPS: nose nose-cov requests
   CUSTOM_CHANNELS: -c conda-forge -c defaults
-  JUPYTER_TEST_BROWSER: firefox
-  MOZ_HEADLESS: "1"
   NOSE_EXCLUDE: selenium
   matrix:
     - CONDA_PY: 38

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,12 +30,9 @@ environment:
     "requests"
   NOSE_EXCLUDE: selenium
   matrix:
-    - CONDA_PY: 38
-      CONDA_PY_SPEC: ">=3.8,<3.9.0a0"
-    - CONDA_PY: 37
-      CONDA_PY_SPEC: ">=3.7,<3.8.0a0"
-    - CONDA_PY: 36
-      CONDA_PY_SPEC: ">=3.6,<3.7.0a0"
+    - CONDA_PY: ">=3.8,<3.9.0a0"
+    - CONDA_PY: ">=3.7,<3.8.0a0"
+    - CONDA_PY: ">=3.6,<3.7.0a0"
 
 platform:
   - x64
@@ -44,9 +41,9 @@ build: off
 
 install:
   - cmd: '%CONDA_ACTIVATE% && conda upgrade -y -c conda-forge conda'
-  - cmd: '%CONDA_ACTIVATE% && conda create -y -n notebook-test -c conda-forge -c defaults "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1'
+  - cmd: '%CONDA_ACTIVATE% && conda create -y -n notebook-test -c conda-forge -c defaults "python %CONDA_PY%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1'
   - cmd: '%CONDA_ACTIVATE% notebook-test && npm install && python setup.py sdist bdist_wheel || exit 1'
-  - cmd: '%CONDA_ACTIVATE% notebook-test && cd dist && python -m pip install --no-deps --ignore-installed --find-links=. notebook'
+  - cmd: '%CONDA_ACTIVATE% notebook-test && cd dist && python -m pip install --no-deps --no-index --ignore-installed --find-links=. notebook'
 
 test_script:
   - '%CONDA_ACTIVATE% notebook-test && md tst_tmp && cd tst_tmp && nosetests -vv --with-cov --traverse-namespace --cov notebook notebook || exit 1'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,8 @@ matrix:
   fast_finish: true
 
 environment:
+  CONDA_RUN_DEPS: jinja2 tornado pyzmq ipython_genutils traitlets jupyter_core jupyter_client nbformat nbconvert ipykernel send2trash terminado prometheus_client
+  CONDA_TEST_DEPS: nose coverage requests nbval nose-exclude selenium pytest pytest-cov
   matrix:
     - CONDA_PY: 36
       CONDA_PY_SPEC: ">=3.6,<3.7.0a0"
@@ -24,32 +26,7 @@ install:
   - cmd: conda config --set show_channel_urls true
   - cmd: conda config --add channels conda-forge
   #- cmd: conda update --yes --quiet conda
-  - cmd: >-
-      conda install -y
-        "python %CONDA_PY_SPEC%"
-        coverage
-        ipykernel
-        ipython_genutils
-        jinja2
-        jupyter_client
-        jupyter_core
-        nbconvert
-        nbformat
-        nbval
-        nodejs
-        nose
-        nose-exclude
-        pip
-        prometheus_client
-        pytest
-        pytest-cov
-        pyzmq
-        requests
-        selenium
-        send2trash
-        terminado
-        tornado
-        traitlets
+  - cmd: conda install -y "python %CONDA_PY_SPEC%" %CONDA_RUN_DEPS% %CONDA_TEST_DEPS%
   - cmd: python setup.py build
   # basically for nose_warnings_filter at this point
   - cmd: pip install .[test]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,13 @@ matrix:
 environment:
   matrix:
     - CONDA_PY: 36
+      CONDA_PY_SPEC: ">=3.6,<3.7.0a0"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
     - CONDA_PY: 37
+      CONDA_PY_SPEC: ">=3.7,<3.8.0a0"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
     - CONDA_PY: 38
+      CONDA_PY_SPEC: ">=3.8,<3.9.0a0"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
 
 platform:
@@ -21,11 +24,34 @@ install:
   - cmd: conda config --set show_channel_urls true
   - cmd: conda config --add channels conda-forge
   #- cmd: conda update --yes --quiet conda
-  - cmd: conda install -y pyzmq tornado jupyter_client nbformat ipykernel pip nodejs nose
-  # not using `conda install -y` on nbconvent package because there is
-  # currently a bug with the version that the anaconda installs, so we will just install it with pip
-  - cmd: pip install nbconvert
+  - cmd: >-
+      conda install -y
+        "python %CONDA_PY_SPEC%"
+        coverage
+        ipykernel
+        ipython_genutils
+        jinja2
+        jupyter_client
+        jupyter_core
+        nbconvert
+        nbformat
+        nbval
+        nodejs
+        nose
+        nose-exclude
+        pip
+        prometheus_client
+        pytest
+        pytest-cov
+        pyzmq
+        requests
+        selenium
+        send2trash
+        terminado
+        tornado
+        traitlets
   - cmd: python setup.py build
+  # basically for nose_warnings_filter at this point
   - cmd: pip install .[test]
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,10 @@ build: off
 
 install:
   - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-  - cmd: conda upgrade conda
   - cmd: conda config --set show_channel_urls true
-  - cmd: conda create -yn notebook-test %CUSTOM_CHANNELS% "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
+  - cmd: conda config --set always_yes true
+  - cmd: conda upgrade conda
+  - cmd: conda create -n notebook-test %CUSTOM_CHANNELS% "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
   - cmd: call activate notebook-test && python setup.py build
   - cmd: call activate notebook-test && python -m pip install . --no-deps
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+matrix:
+  fast_finish: true
+
 environment:
   CONDA_BUILD_DEPS: nodejs
   CONDA_RUN_DEPS: jinja2 tornado pyzmq ipython_genutils traitlets jupyter_core jupyter_client nbformat nbconvert ipykernel send2trash terminado prometheus_client

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,9 +40,9 @@ platform:
 build: off
 
 install:
-  - cmd: %CONDA_ACTIVATE% && conda upgrade -y -c conda-forge conda
-  - cmd: %CONDA_ACTIVATE% && conda create -y -n notebook-test -c conda-forge -c defaults "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1
-  - cmd: %CONDA_ACTIVATE% notebook-test && npm install && python setup.py build sdist bdist_wheel || exit 1
-  - cmd: %CONDA_ACTIVATE% notebook-test && cd build && dir /b /a-d *.whl > whl.txt && set /p WHL=<whl.txt && python -m pip install --no-deps %WHL% || exit 1
+  - cmd: '%CONDA_ACTIVATE% && conda upgrade -y -c conda-forge conda'
+  - cmd: '%CONDA_ACTIVATE% && conda create -y -n notebook-test -c conda-forge -c defaults "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1'
+  - cmd: '%CONDA_ACTIVATE% notebook-test && npm install && python setup.py build sdist bdist_wheel || exit 1'
+  - cmd: '%CONDA_ACTIVATE% notebook-test && cd build && dir /b /a-d *.whl > whl.txt && set /p WHL=<whl.txt && python -m pip install --no-deps %WHL% || exit 1'
 test_script:
-  - %CONDA_ACTIVATE% notebook-test && md tst_tmp && cd tst_tmp && nosetests -vv --with-cov --traverse-namespace --cov notebook notebook || exit 1
+  - '%CONDA_ACTIVATE% notebook-test && md tst_tmp && cd tst_tmp && nosetests -vv --with-cov --traverse-namespace --cov notebook notebook || exit 1'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,6 @@ install:
   - cmd: '%CONDA_ACTIVATE% && conda upgrade -y -c conda-forge conda'
   - cmd: '%CONDA_ACTIVATE% && conda create -y -n notebook-test -c conda-forge -c defaults "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1'
   - cmd: '%CONDA_ACTIVATE% notebook-test && npm install && python setup.py build sdist bdist_wheel || exit 1'
-  - cmd: '%CONDA_ACTIVATE% notebook-test && cd build && dir /b /a-d *.whl > whl.txt && set /p WHL=<whl.txt && python -m pip install --no-deps %WHL% || exit 1'
+  - cmd: '%CONDA_ACTIVATE% notebook-test && cd build && dir && dir /b /a-d *.whl > whl.txt && set /p WHL=<whl.txt && python -m pip install --no-deps %WHL% || exit 1'
 test_script:
   - '%CONDA_ACTIVATE% notebook-test && md tst_tmp && cd tst_tmp && nosetests -vv --with-cov --traverse-namespace --cov notebook notebook || exit 1'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,10 @@ matrix:
 environment:
   CONDA_BUILD_DEPS: nodejs pip
   CONDA_RUN_DEPS: jinja2 tornado pyzmq ipython_genutils traitlets jupyter_core jupyter_client nbformat nbconvert ipykernel send2trash terminado prometheus_client
-  CONDA_TEST_DEPS: nose coverage requests nbval nose-exclude selenium pytest pytest-cov firefox geckodriver
+  CONDA_TEST_DEPS: nose coverage requests nbval nose-exclude selenium pytest pytest-cov firefox=68 geckodriver
   CUSTOM_CHANNELS: -c conda-forge -c defaults
+  JUPYTER_TEST_BROWSER: firefox
+  MOZ_HEADLESS: "1"
   matrix:
     - CONDA_PY: 38
       CONDA_PY_SPEC: ">=3.8,<3.9.0a0"
@@ -30,4 +32,4 @@ install:
   - cmd: call activate notebook-test && python -m pip install . --no-deps
 
 test_script:
-  - call activate notebook-test && md tst_tmp && cd tst_tmp && python -m nosetests -v notebook
+  - call activate notebook-test && md tst_tmp && cd tst_tmp && python -m nose -v notebook

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - cmd: '%CONDA_ACTIVATE% && conda upgrade -y -c conda-forge conda'
   - cmd: '%CONDA_ACTIVATE% && conda create -y -n notebook-test -c conda-forge -c defaults "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1'
   - cmd: '%CONDA_ACTIVATE% notebook-test && npm install && python setup.py build sdist bdist_wheel || exit 1'
-  - cmd: '%CONDA_ACTIVATE% notebook-test && cd dist && for %whl in (*.whl) do (python -m pip install --no-deps %whl) || exit 1'
+  - cmd: '%CONDA_ACTIVATE% notebook-test && cd dist && for %%whl in (*.whl) do python -m pip install --no-deps %%whl'
 
 test_script:
   - '%CONDA_ACTIVATE% notebook-test && md tst_tmp && cd tst_tmp && nosetests -vv --with-cov --traverse-namespace --cov notebook notebook || exit 1'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,40 +40,40 @@ platform:
 build: off
 
 install:
-  - cmd: |-
-      %CONDA_ACTIVATE% ^
-      && conda upgrade -y ^
-        -c conda-forge ^
+  - cmd: >-
+      %CONDA_ACTIVATE%
+      && conda upgrade -y
+        -c conda-forge
         conda
-  - cmd: |-
-      %CONDA_ACTIVATE% ^
-      && conda create -y ^
-        -n notebook-test ^
-        -c conda-forge ^
-        -c defaults ^
-        "python %CONDA_PY_SPEC%" ^
-        %CONDA_BUILD_DEPS% ^
-        %CONDA_RUN_DEPS% ^
-        %CONDA_TEST_DEPS% ^
+  - cmd: >-
+      %CONDA_ACTIVATE%
+      && conda create -y
+        -n notebook-test
+        -c conda-forge
+        -c defaults
+        "python %CONDA_PY_SPEC%"
+        %CONDA_BUILD_DEPS%
+        %CONDA_RUN_DEPS%
+        %CONDA_TEST_DEPS%
       || exit 1
-  - cmd: |-
-      %CONDA_ACTIVATE% notebook-test ^
-      && npm install ^
-      && python setup.py build sdist bdist_wheel ^
+  - cmd: >-
+      %CONDA_ACTIVATE% notebook-test
+      && npm install
+      && python setup.py build sdist bdist_wheel
       || exit 1
-  - cmd: |-
-      %CONDA_ACTIVATE% notebook-test ^
-      && cd build ^
-      && dir /b /a-d *.whl > whl.txt ^
-      && set /p WHL=<whl.txt ^
-      && python -m pip install --no-deps %WHL% ^
+  - cmd: >-
+      %CONDA_ACTIVATE% notebook-test
+      && cd build
+      && dir /b /a-d *.whl > whl.txt
+      && set /p WHL=<whl.txt
+      && python -m pip install --no-deps %WHL%
       || exit 1
 test_script:
-  - |-
-    %CONDA_ACTIVATE% notebook-test ^
-    && md tst_tmp ^
-    && cd tst_tmp ^
-    && nosetests -vv --with-cov --traverse-namespace ^
-      --cov notebook ^
-      notebook ^
+  - >-
+    %CONDA_ACTIVATE% notebook-test
+    && md tst_tmp
+    && cd tst_tmp
+    && nosetests -vv --with-cov --traverse-namespace
+      --cov notebook
+      notebook
     || exit 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   - cmd: '%CONDA_ACTIVATE% && conda upgrade -y -c conda-forge conda'
   - cmd: '%CONDA_ACTIVATE% && conda create -y -n notebook-test -c conda-forge -c defaults "python %CONDA_PY_SPEC%" %CONDA_BUILD_DEPS% %CONDA_RUN_DEPS% %CONDA_TEST_DEPS% || exit 1'
   - cmd: '%CONDA_ACTIVATE% notebook-test && npm install && python setup.py build sdist bdist_wheel || exit 1'
-  - cmd: '%CONDA_ACTIVATE% notebook-test && cd dist && for %whl in (*.whl) do python -m pip install --no-deps %whl'
+  - cmd: '%CONDA_ACTIVATE% notebook-test && python -m pip install --no-deps --find-links=dist notebook'
 
 test_script:
   - '%CONDA_ACTIVATE% notebook-test && md tst_tmp && cd tst_tmp && nosetests -vv --with-cov --traverse-namespace --cov notebook notebook || exit 1'

--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -158,9 +158,9 @@ class NotebookTestBase(TestCase):
                     token=cls.token,
                 )
                 if 'asyncio' in sys.modules:
-                          app._init_asyncio_patch()
-                          import asyncio
-                          asyncio.set_event_loop(asyncio.new_event_loop())
+                    app._init_asyncio_patch()
+                    import asyncio
+                    asyncio.set_event_loop(asyncio.new_event_loop())
                 # don't register signal handler during tests
                 app.init_signal = lambda : None
                 # clear log handlers and propagate to root for nose to capture it


### PR DESCRIPTION
Adds python 3.7 and 3.8 to the test matrix.

Anaconda and conda-forge now both have all of our upstreams, I'm pretty sure, but it would be better to catch compatibility issues here.

refs:
- tests #5047