### PR TITLE
Add a metadata tag to override notebook direction (ltr/rtl)

### DIFF
--- a/notebook/static/base/js/dialog.js
+++ b/notebook/static/base/js/dialog.js
@@ -230,6 +230,7 @@ define(['jquery',
                             return false;
                         }
                         options.callback(new_md);
+                        options.notebook.apply_directionality();
                     }
                 }
             },

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -65,11 +65,27 @@ define([
      *
      **/
     var _actions = {
+        'toggle-cell-rtl-layout': {
+            cmd: i18n.msg._('toggle current cell ltr/rtl direction'),
+            help: i18n.msg._('Toggle current cell directionality between left-to-right and right-to-left'),
+            handler: function (env) {
+              var notebook_direction = document.body.getAttribute('dir') == 'rtl' ? 'rtl' : 'ltr';
+              var current_cell_default_direction = env.notebook.get_selected_cell().cell_type == 'code' ? 'ltr' : notebook_direction;
+              var current_cell_direction = env.notebook.get_selected_cell().metadata.direction || current_cell_default_direction;
+              var new_direction = current_cell_direction == 'rtl' ? 'ltr' : 'rtl';
+              env.notebook.get_selected_cells().forEach(cell => cell.metadata.direction = new_direction);
+              env.notebook.set_dirty(true);
+              env.notebook.apply_directionality();
+            }
+        },
         'toggle-rtl-layout': {
-            cmd: i18n.msg._('toggle rtl layout'),
-            help: i18n.msg._('Toggle the screen directionality between left-to-right and right-to-left'),
-            handler: function () {
-              (document.body.getAttribute('dir')=='rtl') ? document.body.setAttribute('dir','ltr') : document.body.setAttribute('dir','rtl');
+            cmd: i18n.msg._('toggle notebook ltr/rtl direction'),
+            help: i18n.msg._('Toggle notebook directionality between left-to-right and right-to-left'),
+            handler: function (env) {
+              var new_direction = document.body.getAttribute('dir') == 'rtl' ? 'ltr' : 'rtl';
+              env.notebook.metadata.direction = new_direction;
+              env.notebook.set_dirty(true);
+              env.notebook.apply_directionality();
             }
         },
         'edit-command-mode-keyboard-shortcuts': {

--- a/notebook/static/notebook/js/actions.js
+++ b/notebook/static/notebook/js/actions.js
@@ -73,7 +73,9 @@ define([
               var current_cell_default_direction = env.notebook.get_selected_cell().cell_type == 'code' ? 'ltr' : notebook_direction;
               var current_cell_direction = env.notebook.get_selected_cell().metadata.direction || current_cell_default_direction;
               var new_direction = current_cell_direction == 'rtl' ? 'ltr' : 'rtl';
-              env.notebook.get_selected_cells().forEach(cell => cell.metadata.direction = new_direction);
+              env.notebook.get_selected_cells().forEach(
+                  function(cell) { cell.metadata.direction = new_direction; }
+              );
               env.notebook.set_dirty(true);
               env.notebook.apply_directionality();
             }

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -699,7 +699,7 @@ define([
         // html
         document.body.setAttribute('dir', notebook_direction);
         // existing cells
-        this.get_cells().forEach(cell => {
+        this.get_cells().forEach( function(cell) {
             if (cell.cell_type == 'markdown') {
                 cell.code_mirror.setOption('direction', cell.metadata.direction || notebook_direction);
                 cell.element.find('.rendered_html').attr('dir', cell.metadata.direction || notebook_direction);

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -691,6 +691,27 @@ define([
     };
 
     /**
+     * Reads direction settings (LTR/RTL) from notebook/cells metadata
+     * and applies them to display elements.
+     */
+    Notebook.prototype.apply_directionality = function () {
+        var notebook_direction = this.metadata.direction || 'ltr';
+        // html
+        document.body.setAttribute('dir', notebook_direction);
+        // existing cells
+        this.get_cells().forEach(cell => {
+            if (cell.cell_type == 'markdown') {
+                cell.code_mirror.setOption('direction', cell.metadata.direction || notebook_direction);
+                cell.element.find('.rendered_html').attr('dir', cell.metadata.direction || notebook_direction);
+            } else if (cell.cell_type == 'code') {
+                cell.element.find('.output_text').attr('dir', cell.metadata.direction || 'auto');
+            }
+        });
+        // new cells
+        textcell.MarkdownCell.options_default.cm_config.direction = notebook_direction;
+    };
+
+    /**
      * Get the cell above a given cell.
      * 
      * @param {Cell} cell
@@ -2662,6 +2683,9 @@ define([
             this.trusted = trusted;
             this.events.trigger("trust_changed.Notebook", trusted);
         }
+
+        this.apply_directionality();
+
     };
 
     /**

--- a/notebook/static/notebook/js/textcell.js
+++ b/notebook/static/notebook/js/textcell.js
@@ -303,7 +303,6 @@ define([
     MarkdownCell.options_default = {
         cm_config: {
             mode: 'ipythongfm',
-            direction: bidi.isMirroringEnabled() ? 'rtl' : 'ltr'
         },
         placeholder: "Type *Markdown* and LaTeX: $\\alpha^2$"
     };

--- a/notebook/static/notebook/less/outputarea.less
+++ b/notebook/static/notebook/less/outputarea.less
@@ -211,3 +211,7 @@ div.output_unrecognized {
       }
   }
 }
+
+div.output_text[dir="rtl"] {
+  text-align: right;
+}

--- a/notebook/static/notebook/less/renderedhtml.less
+++ b/notebook/static/notebook/less/renderedhtml.less
@@ -131,7 +131,11 @@
     * + .alert {margin-top: 1em;}
 }
 
-[dir="rtl"] .rendered_html {
+// Right align text iff:
+// (a) notebook is rtl and it's not overriden in cell metadata (i.e. rtl or none)
+// (b) notebook is whatever but cell metadata specifies rtl
+// note that cell metadata is used to set 'dir' attribute of rendered_html element.
+[dir="rtl"] .rendered_html:not([dir="ltr"]), .rendered_html[dir="rtl"] {
     p {
         text-align : right;
     }


### PR DESCRIPTION
Currently, the direction of text flow in a notebook (left-to-right / right-to-left) is determined by browser language settings. If the browser is set to use a language with right-to-left script, all notebooks are displayed in RTL direction and vice versa.

This behavior could be improved, IMHO (I'm a student from the middle east). I write my homework in my mother language, but I also download stuff from the internet which are mostly in English. This means that I have to change my browser language settings frequently, which is not user friendly.

This PR makes it possible to override this default behavior *per notebook* using a metadata tag. Here's how to use this tag in order to make a notebook RTL:

`"direction": "rtl"`

or to force notebook to use LTR:

`"direction": "ltr"`

The end user could either manually set this tag or use the `toggle rtl layout` command from the command palette to change the direction of a notebook permanently, without needing to change the browser settings.

That's it from the end user point of view.