### PR TITLE
Fix packages of exceptions catched by gateway manager

### DIFF
--- a/notebook/tests/test_gateway.py
+++ b/notebook/tests/test_gateway.py
@@ -8,7 +8,8 @@ from unittest.mock import patch
 
 import nose.tools as nt
 from tornado import gen
-from tornado.httpclient import HTTPRequest, HTTPResponse, HTTPError
+from tornado.web import HTTPError
+from tornado.httpclient import HTTPRequest, HTTPResponse
 
 from notebook.gateway.managers import GatewayClient
 from notebook.utils import maybe_future


### PR DESCRIPTION
`gateway_request` in `gateway.manager` raises `tornado.web.HTTPError` exceptions, but the callers, such as `GatewayKernelManager.get_kernel`, catch `tornado.httpclient.HTTPError`, instead of `tornado.web.HTTPError`. Therefore, the callers can not handle exceptions during gateway interactions.

This causes that, for example, when Jupyter Enterprise Gateway culled a kernel by idle timeout, the gateway manager can not handle the kernel's absent appropriately. As a result, notebook users see ambiguous "Kernel Error" and can not restart the kernel or start a new kernel.