### PR TITLE
Allow relaxation of XSSI protection

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -446,7 +446,7 @@ class IPythonHandler(AuthenticatedHandler):
         except web.HTTPError as e:
             if self.request.method in {'GET', 'HEAD'}:
                 # Consider Referer a sufficient cross-origin check for GET requests
-                if not self.check_referer():
+                if not self.check_referer() and not self.settings.get('relax_xssi_check', False):
                     referer = self.request.headers.get('Referer')
                     if referer:
                         msg = "Blocking Cross Origin request from {}.".format(referer)

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -247,6 +247,7 @@ class NotebookWebApplication(web.Application):
             password=jupyter_app.password,
             xsrf_cookies=True,
             disable_check_xsrf=jupyter_app.disable_check_xsrf,
+            relax_xssi_check=jupyter_app.relax_xssi_check,
             allow_remote_access=jupyter_app.allow_remote_access,
             local_hostnames=jupyter_app.local_hostnames,
 
@@ -876,6 +877,20 @@ class NotebookApp(JupyterApp):
         completely without authentication.
         These services can disable all authentication and security checks,
         with the full knowledge of what that implies.
+        """
+    )
+
+    relax_xssi_check = Bool(False, config=True,
+        help="""Relax cross-site inclusion (XSSI) protection
+        
+        By default, GET and HEAD requests get a 403 forbidden response if a 
+        xsrf token is absent from the request parameters and the referrer is
+        unknown. This happens for example if you are viewing a HTML document
+        with relative images as these are sandboxed in the browser and the
+        referrer is then dropped.
+        
+        If set to true GET and HEAD requests will not check for a present
+        xsrf token. 
         """
     )
 


### PR DESCRIPTION
By default, GET and HEAD requests get a 403 forbidden response if a
xsrf token is absent from the request parameters and the referrer is
unknown. This happens for example if you are viewing a HTML document
with relative images as these are sandboxed by CSP in the browser and the
referrer is then dropped.

This change makes that behavior configurable.