### PR TITLE
Ensure jupyter config dir exist

### DIFF
--- a/notebook/auth/security.py
+++ b/notebook/auth/security.py
@@ -118,6 +118,7 @@ def persist_config(config_file=None, mode=0o600):
     """
 
     if config_file is None:
+        os.makedirs(jupyter_config_dir(), exist_ok=True)
         config_file = os.path.join(jupyter_config_dir(), 'jupyter_notebook_config.json')
 
     loader = JSONFileConfigLoader(os.path.basename(config_file), os.path.dirname(config_file))

--- a/notebook/auth/security.py
+++ b/notebook/auth/security.py
@@ -118,8 +118,9 @@ def persist_config(config_file=None, mode=0o600):
     """
 
     if config_file is None:
-        os.makedirs(jupyter_config_dir(), exist_ok=True)
         config_file = os.path.join(jupyter_config_dir(), 'jupyter_notebook_config.json')
+
+    os.makedirs(os.path.dirname(config_file), exist_ok=True)
 
     loader = JSONFileConfigLoader(os.path.basename(config_file), os.path.dirname(config_file))
     try:


### PR DESCRIPTION
The bug: when
 - the user login for the first file with a token and want to change his/her password
 - and if the folder `~/.jupyter` (`jupyter_config_dir()`) does not exist

then the jupyter server will raise a `FileNotFoundError` exception and return a 500 error.

This change tries to fix this bug by ensuring the folder exists so that the `config_file` can be opened.