### PR TITLE
Pin nbconvert <6 for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ for more information.
         'jupyter_core>=4.6.0',
         'jupyter_client>=5.3.4',
         'nbformat',
-        'nbconvert',
+        'nbconvert<6',
         'ipykernel', # bless IPython kernel for now
         'Send2Trash',
         'terminado>=0.8.1',


### PR DESCRIPTION
[Tests are failing](https://travis-ci.org/jupyter/notebook/builds/617652474) with nbconvert 6.0a1. I plan to open an issue about that, but this allows work to continue on unrelated topics until it's fixed.