### PR TITLE
preserve term "Markdown" untranslated

### DIFF
--- a/notebook/i18n/zh_CN/LC_MESSAGES/nbjs.po
+++ b/notebook/i18n/zh_CN/LC_MESSAGES/nbjs.po
@@ -762,7 +762,7 @@ msgstr "代码"
 
 #: notebook/static/notebook/js/maintoolbar.js:77
 msgid "Markdown"
-msgstr "标记"
+msgstr "Markdown"
 
 #: notebook/static/notebook/js/maintoolbar.js:78
 msgid "Raw NBConvert"


### PR DESCRIPTION
Hi guys,

I am Chinese user and have used Markdown for several years,
I've never heard any Chinese say "Markdown" as "标记"(as did by the current translation),
we just keep the term "Markdown" even in our daily communication in Chinese,
so I believe just keep "Markdown" untranslated is more intuitive.