### PR TITLE
Toolbar buttons tooltip: show help instead of label

### DIFF
--- a/notebook/static/notebook/js/toolbar.js
+++ b/notebook/static/notebook/js/toolbar.js
@@ -94,7 +94,8 @@ define(['jquery','base/js/i18n'], function($, i18n) {
                 }
                 var button  = $('<button/>')
                     .addClass('btn btn-default')
-                    .attr("title", i18n.msg._(action.help))
+                    .attr("aria-label", el.label)
+                    .attr("title", i18n.msg._(action.help)||el.label)
                     .append(
                         $("<i/>").addClass(el.icon||(action||{icon:'fa-exclamation-triangle'}).icon).addClass('fa')
                     );

--- a/notebook/static/notebook/js/toolbar.js
+++ b/notebook/static/notebook/js/toolbar.js
@@ -94,7 +94,7 @@ define(['jquery','base/js/i18n'], function($, i18n) {
                 }
                 var button  = $('<button/>')
                     .addClass('btn btn-default')
-                    .attr("title", el.label||i18n.msg._(action.help))
+                    .attr("title", i18n.msg._(action.help))
                     .append(
                         $("<i/>").addClass(el.icon||(action||{icon:'fa-exclamation-triangle'}).icon).addClass('fa')
                     );


### PR DESCRIPTION
Currently the tooltip for a toolbar button with just an icon is the help text for the action/command.
If a toolbar button has a label the label text is shown alongside the button icon as expected, but it also replaces the tooltip help.

With this PR the help text is always shown as the tooltip.

## Old behaviour:
![44-10](https://user-images.githubusercontent.com/1644105/70376543-cd679200-1901-11ea-9b48-7ed221432157.png)
![44-20](https://user-images.githubusercontent.com/1644105/70376546-cfc9ec00-1901-11ea-931f-4d6c6cf3a744.png)

## New behaviour:
![45-17](https://user-images.githubusercontent.com/1644105/70376547-d193af80-1901-11ea-95d8-fec31b508509.png)

![45-26](https://user-images.githubusercontent.com/1644105/70376549-d7899080-1901-11ea-96de-d6ad46d01ef9.png)

