### PR TITLE
descriptive log for port unavailable and port-retries=0

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1490,10 +1490,13 @@ class NotebookApp(JupyterApp):
                 self.http_server.listen(port, self.ip)
             except socket.error as e:
                 if e.errno == errno.EADDRINUSE:
-                    self.log.info(_('The port %i is already in use, trying another port.') % port)
+                    if self.port_retries:
+                        self.log.info(_('The port %i is already in use, trying another port.') % port)
+                    else:
+                        self.log.info(_('The port %i is already in use.') % port)
                     continue
                 elif e.errno in (errno.EACCES, getattr(errno, 'WSAEACCES', errno.EACCES)):
-                    self.log.warning(_("Permission to listen on port %i denied") % port)
+                    self.log.warning(_("Permission to listen on port %i denied.") % port)
                     continue
                 else:
                     raise

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1502,8 +1502,12 @@ class NotebookApp(JupyterApp):
                 success = True
                 break
         if not success:
-            self.log.critical(_('ERROR: the notebook server could not be started because '
+            if self.port_retries:
+                self.log.critical(_('ERROR: the notebook server could not be started because '
                               'no available port could be found.'))
+            else:
+                self.log.critical(_('ERROR: the notebook server could not be started because '
+                              'port %i is not available.') % port)
             self.exit(1)
     
     @property


### PR DESCRIPTION
when `--port-retries=0` and the launch fails on the port, the error log`ERROR: the notebook server could not be started because no available port could be found.` is not very appropriate. Fixes: #1914