### PR TITLE
Bump minimum version of jupyter_core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ for more information.
         'pyzmq>=17',
         'ipython_genutils',
         'traitlets>=4.2.1',
-        'jupyter_core>=4.6.0',
+        'jupyter_core>=4.6.1',
         'jupyter_client>=5.3.4',
         'nbformat',
         'nbconvert',


### PR DESCRIPTION
Since there's a 6.0.3 release brewin', I thought we should bump
the minimum version of jupyter_core from 4.6.0 to 4.6.1.  The
latter has an edge case to the slew of secure_write issues that
would be very annoying if NB 6.0.3 didn't upgrade to that version.
The edge case is to tolerate the owner-execute bit on the connection
file, which occurs when RUNTIME_DIR resides on certain filesystem
types (e.g., CIFS).