### PR TITLE
Check for invalid characters prior to rename

### DIFF
--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -600,12 +600,13 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
             # be created and confusion will reign! (See https://github.com/jupyter/notebook/issues/5190)
             # Go ahead and add other invalid (and non-path-separator) characters here as well so there's
             # consistent behavior - although all others will result in '[Errno 22]Invalid Argument' errors.
-            invalid_chars = (':', '>', '<', '*', '?', '|', '"')
+            invalid_chars = '?:><*"|'
         else:
             # On non-windows systems, allow the underlying file creation to perform enforcement when appropriate
-            invalid_chars = ()
+            invalid_chars = ''
 
         for char in invalid_chars:
             if char in path:
-                raise web.HTTPError(400, u"Path '{}' contains invalid characters {} relative to its platform.  "
-                                         u"Please edit the path and re-submit the request.".format(path, invalid_chars))
+                raise web.HTTPError(400, "Path '{}' contains characters that are invalid for the filesystem. "
+                                         "Path names on this filesystem cannot contain any of the following "
+                                         "characters: {}".format(path, invalid_chars))

--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -558,6 +558,10 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         if new_path == old_path:
             return
 
+        # Perform path validation prior to converting to os-specific value since this
+        # is still relative to root_dir.
+        self._validate_path(new_path)
+
         new_os_path = self._get_os_path(new_path)
         old_os_path = self._get_os_path(old_path)
 
@@ -586,3 +590,22 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         else:
             parent_dir = ''
         return parent_dir
+
+    @staticmethod
+    def _validate_path(path):
+        """Checks if the path contains invalid characters relative to the current platform"""
+
+        if sys.platform == 'win32':
+            # On Windows systems, we MUST disallow colons otherwise an Alternative Data Stream will
+            # be created and confusion will reign! (See https://github.com/jupyter/notebook/issues/5190)
+            # Go ahead and add other invalid (and non-path-separator) characters here as well so there's
+            # consistent behavior - although all others will result in '[Errno 22]Invalid Argument' errors.
+            invalid_chars = (':', '>', '<', '*', '?', '|', '"')
+        else:
+            # On non-windows systems, allow the underlying file creation to perform enforcement when appropriate
+            invalid_chars = ()
+
+        for char in invalid_chars:
+            if char in path:
+                raise web.HTTPError(400, u"Path '{}' contains invalid characters {} relative to its platform.  "
+                                         u"Please edit the path and re-submit the request.".format(path, invalid_chars))

--- a/notebook/services/contents/tests/test_manager.py
+++ b/notebook/services/contents/tests/test_manager.py
@@ -522,6 +522,11 @@ class TestContentsManager(TestCase):
         # Fetching the notebook under the new name is successful
         assert isinstance(cm.get("changed_path"), dict)
 
+        # Test validation.  Currently, only Windows has a non-empty set of invalid characters
+        if sys.platform == 'win32' and isinstance(cm, FileContentsManager):
+            with self.assertRaisesHTTPError(400):
+                cm.rename("changed_path", "prevent: in name")
+
         # Ported tests on nested directory renaming from pgcontents
         all_dirs = ['foo', 'bar', 'foo/bar', 'foo/bar/foo', 'foo/bar/foo/bar']
         unchanged_dirs = all_dirs[:2]


### PR DESCRIPTION
On Windows platforms, rename operations containing ':' are problematic
since the operation succeeds, but creates an unintended "alternate data
stream" that gives the user the impression their file contents have been
deleted.  This change performs cursory validation of the destination
name on platforms in which issues can occur.  Currently, non-Windows
systems don't require this level of validation.

When an invalid character is encountered during the rename operation, a message similar to the following will occur:
![Screen Shot 2020-01-28 at 1 55 50 PM](https://user-images.githubusercontent.com/22599560/73309090-73cf6580-41d6-11ea-87ce-ef0d8c585dd1.png)

Fixes #5190