### PR TITLE
Update message about minimum Tornado version

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -53,13 +53,13 @@ ioloop.install()
 try:
     import tornado
 except ImportError:
-    raise ImportError(_("The Jupyter Notebook requires tornado >= 4.0"))
+    raise ImportError(_("The Jupyter Notebook requires tornado >= 5.0"))
 try:
     version_info = tornado.version_info
 except AttributeError:
-    raise ImportError(_("The Jupyter Notebook requires tornado >= 4.0, but you have < 1.1.0"))
-if version_info < (4,0):
-    raise ImportError(_("The Jupyter Notebook requires tornado >= 4.0, but you have %s") % tornado.version)
+    raise ImportError(_("The Jupyter Notebook requires tornado >= 5.0, but you have < 1.1.0"))
+if version_info < (5,0):
+    raise ImportError(_("The Jupyter Notebook requires tornado >= 5.0, but you have %s") % tornado.version)
 
 from tornado import httpserver
 from tornado import web


### PR DESCRIPTION
Hi,

I was reading the code just now and noticed it says it requires notebook >= 4.0, but `setup.py` says >= 5.0 I think?

https://github.com/jupyter/notebook/blob/43df5af2b614088b4b297fae90a70b6505b9bf84/setup.py#L101

Cheers
Bruno