### PR TITLE
kill notebook its self when server cull idle kernel

### DIFF
--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -141,6 +141,7 @@ define([
         this.register_iopub_handler('status', $.proxy(this._handle_status_message, this));
         this.register_iopub_handler('clear_output', $.proxy(this._handle_clear_output, this));
         this.register_iopub_handler('execute_input', $.proxy(this._handle_input_message, this));
+        this.register_iopub_handler('shutdown_reply', $.proxy(this._handle_shutdown_message, this));
         
         for (var i=0; i < output_msg_types.length; i++) {
             this.register_iopub_handler(output_msg_types[i], $.proxy(this._handle_output_message, this));
@@ -1211,6 +1212,14 @@ define([
             this.events.trigger('received_unsolicited_message.Kernel', msg);
         }
     };
+
+    /**
+     * @function _handle_shutdown_message
+     */
+    Kernel.prototype._handle_shutdown_message = function (msg) {
+        this.events.trigger('kernel_dead.Kernel', {kernel: this});
+        this._kernel_dead();
+    }
 
     /**
      * Dispatch IOPub messages to respective handlers. Each message


### PR DESCRIPTION
As we know, kernelManager will periodic check if kernel is inactivity. When set `MappingKernelManager.cull_connected`=`True`, it will cull idle kernel with connections. Then, when `NotebookApp.shutdown_no_activity_timeout` has exhausted, jupyter will call tornado's `ioloop.stop()` to stop the whole server and release resources. Now we can find jupyter process hanging and will not exit automatic.

Detail info (debug with tcpdump / wireshark / strace / telnet):

When kernel killed by kernel manager, it reply client a msg with `msg_type`=`shutdown_reply`, but client does not handle this msg. Tornado server will wait for websocket connection produced by client, and never exit for a very long time. 

When we telnet tornado's port 8888, its status is listening but not accept new connection.

Debug jupyter process with strace we can find it block in a event: `poll([{fd=280, events=POLLIN}], 1, -1`.
