### PR TITLE
Configuration alias for open_browser

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -563,6 +563,7 @@ aliases.update({
     'certfile': 'NotebookApp.certfile',
     'client-ca': 'NotebookApp.client_ca',
     'notebook-dir': 'NotebookApp.notebook_dir',
+    'open_browser': 'NotebookApp.open_browser',
     'browser': 'NotebookApp.browser',
     'pylab': 'NotebookApp.pylab',
     'gateway-url': 'GatewayClient.url',


### PR DESCRIPTION
JupyterHub creates a class called SingleUserNotebookApp that configure
NotebookApp. This commit is meant to remove the commonly seen warning
from configuring open_browser through that class.

```
[W 2020-05-12 14:34:25.041 SingleUserNotebookApp configurable:168] Config option `open_browser` not recognized by `SingleUserNotebookApp`.  Did you mean `browser`?
```

I've suggested a change here but I'm not confident about it as I don't fully understand the configuration setup, haven't test it, or knows if this is the way to go about it.

## My understanding

- We use traitlets, and traitlets are typically configure like `c.ClassNameWithTraitlets.configuration_name = "some value"`.
- NotebookApp is a class derived from JupyterApp which both has traitlet configurations
- SingleUserNotebookApp is a NotebookApp derived class that wants to change the default values of traitlets in NotebookApp. It is done [here](https://github.com/jupyterhub/jupyterhub/blob/5dee864afd86e9dfdc4c12814683412194b363d9/jupyterhub/singleuser.py#L329-L338).
- Aliases are maintained, allowing for example `browser` on SingleUserNotebookApp to refer to the configuration of NotebookApp.
  - [Applications aliases](https://github.com/ipython/traitlets/blob/32ced29b0ab06914ff92e9bdcd8806536633d701/traitlets/config/application.py#L239-L242)
  - [JupyterApp's appended aliases](https://github.com/jupyter/jupyter_core/blob/ac712354ec2c9377a290acca03a91712f991c889/jupyter_core/application.py#L45-L68)
  - [NotebookApp's appended aliases](https://github.com/jupyter/notebook/blob/0090315f6e61e469bb3a353787504ea6407c4c2e/notebook/notebookapp.py#L557-L569)
  - [SingleUserNotebookApp appended aliases](https://github.com/jupyterhub/jupyterhub/blob/5dee864afd86e9dfdc4c12814683412194b363d9/jupyterhub/singleuser.py#L133-L145)

#### Conclusion
So, perhaps open_browser is added as a configuration in NotebookApp, but isn't added to the aliases dictionary, which makes derivative classes unable to configure it on them, because it becomes for example `c.SingleUserNotebookApp.open_browser` instead of `c.NotebookApp.open_browser` due to a missing alias, somehow.

This PR adds this alias, does it make sense? Perhaps we should add more aliases as well to fix multiple issues?