### PR TITLE
Remove unnecessary import of requests_unixsocket

### DIFF
--- a/notebook/utils.py
+++ b/notebook/utils.py
@@ -23,7 +23,6 @@ from urllib.request import pathname2url
 # in tornado >=5 with Python 3
 from tornado.concurrent import Future as TornadoFuture
 from tornado import gen
-import requests_unixsocket
 from ipython_genutils import py3compat
 
 # UF_HIDDEN is a stat flag not defined in the stat module.


### PR DESCRIPTION
Follow up to #4835.   This import gave a hard dependency on `requests_unixsocket`, which was caught by a failing docs build: https://readthedocs.org/projects/jupyter-notebook/builds/11048908/.