### PR TITLE
Install terminado for docs build

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,6 @@
 name: notebook_docs
 dependencies:
-- python=3.5
+- python=3.8
 - sphinx_rtd_theme
 - jinja2
 - tornado
@@ -8,6 +8,7 @@ dependencies:
 - jupyter_client
 - ipykernel
 - sphinx
+- terminado
 - pip:
   - nbsphinx
   - Send2Trash


### PR DESCRIPTION
RTD is currently failing with an ImportError (e.g. https://readthedocs.org/projects/jupyter-notebook/builds/11068903/ )

Also move to a recent Python, because I don't know how long 3.5 will be available on conda.