### PR TITLE
Enable check_origin on gateway websocket communication

### DIFF
--- a/notebook/gateway/handlers.py
+++ b/notebook/gateway/handlers.py
@@ -32,6 +32,9 @@ class WebSocketChannelsHandler(WebSocketHandler, IPythonHandler):
     kernel_id = None
     ping_callback = None
 
+    def check_origin(self, origin=None):
+        return IPythonHandler.check_origin(self, origin)
+
     def set_default_headers(self):
         """Undo the set_default_headers in IPythonHandler which doesn't make sense for websockets"""
         pass


### PR DESCRIPTION
This is a port of the same change in [NB2KG (PR 22)](https://github.com/jupyter/nb2kg/pull/22).

Fixes #5460