### PR TITLE
Added functionality to allow filter kernels by Jupyter Enterprise Gat…

### DIFF
--- a/notebook/gateway/managers.py
+++ b/notebook/gateway/managers.py
@@ -519,6 +519,12 @@ class GatewayKernelSpecManager(KernelSpecManager):
 
         return self.base_endpoint
 
+    def _get_endpoint_for_user_filter(self, default_endpoint):
+        kernel_user = os.environ.get('KERNEL_USERNAME')
+        if kernel_user:
+            return '?user='.join([default_endpoint, kernel_user])
+        return default_endpoint
+
     @gen.coroutine
     def get_all_specs(self):
         fetched_kspecs = yield self.list_kernel_specs()
@@ -543,6 +549,9 @@ class GatewayKernelSpecManager(KernelSpecManager):
     def list_kernel_specs(self):
         """Get a list of kernel specs."""
         kernel_spec_url = self._get_kernelspecs_endpoint_url()
+
+        kernel_spec_url = self._get_endpoint_for_user_filter(kernel_spec_url)
+
         self.log.debug("Request list kernel specs at: %s", kernel_spec_url)
         response = yield gateway_request(kernel_spec_url, method='GET')
         kernel_specs = json_decode(response.body)
@@ -558,6 +567,9 @@ class GatewayKernelSpecManager(KernelSpecManager):
             The name of the kernel.
         """
         kernel_spec_url = self._get_kernelspecs_endpoint_url(kernel_name=str(kernel_name))
+
+        kernel_spec_url = self._get_endpoint_for_user_filter(kernel_spec_url)
+
         self.log.debug("Request kernel spec at: %s" % kernel_spec_url)
         try:
             response = yield gateway_request(kernel_spec_url, method='GET')
@@ -586,6 +598,7 @@ class GatewayKernelSpecManager(KernelSpecManager):
             The name of the desired resource
         """
         kernel_spec_resource_url = url_path_join(self.base_resource_endpoint, str(kernel_name), str(path))
+        kernel_spec_resource_url = self._get_endpoint_for_user_filter(kernel_spec_resource_url)
         self.log.debug("Request kernel spec resource '{}' at: {}".format(path, kernel_spec_resource_url))
         try:
             response = yield gateway_request(kernel_spec_resource_url, method='GET')


### PR DESCRIPTION
We come from [here](https://github.com/jupyter/enterprise_gateway/pull/800)

We have allowed Jupyter Enterprise Gateway to filter kernels by a query param.
This query param is env var KERNEL_USERNAME 

@kevin-bates 