### PR TITLE
Add keyboard shortcuts to menu dropdowns

### DIFF
--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -24,6 +24,7 @@ define([
          *  options: dictionary
          *      Dictionary of keyword arguments.
          *          notebook: Notebook instance
+         *          render keyboard shortcuts from KeyboardManager
          *          contents: ContentManager instance
          *          events: $(Events) instance
          *          save_widget: SaveWidget instance
@@ -37,7 +38,8 @@ define([
         this.base_url = options.base_url || utils.get_body_data("baseUrl");
         this.selector = selector;
         this.notebook = options.notebook;
-        this.actions = this.notebook.keyboard_manager.actions;
+        this.keyboard_manager = this.notebook.keyboard_manager;
+        this.actions = this.keyboard_manager.actions;
         this.contents = options.contents;
         this.events = options.events;
         this.save_widget = options.save_widget;
@@ -276,9 +278,21 @@ define([
             }
             // Immediately-Invoked Function Expression cause JS.
             (function(that, id_act, idx){
-                that.element.find(idx).click(function(event){
+                var el = that.element.find(idx);
+                el.click(function(event){
                     that.actions.call(id_act, event);
                 });
+                
+                var keybinding = that.keyboard_manager.command_shortcuts.get_action_shortcut(id_act);
+                
+                if(keybinding === undefined) {
+            		    keybinding = that.keyboard_manager.edit_shortcuts.get_action_shortcut(id_act);
+                }
+                
+                if(keybinding !== undefined) {
+                    var binding = '<span class="kb">'+keybinding+'</span>';
+                    el.children().append(binding);
+                }
             })(that, id_act, idx);
         }
 

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -295,7 +295,7 @@ define([
                     var link_element = el.children('a');
                     var text = link_element.text();
                     link_element.text('');
-                    link_element.attr('style', 'display: flex; flex-direction: row; justify-content: space-between; align-items: flex-end;');
+                    link_element.addClass('menu-shortcut-container');
                     link_element.append('<span class="action">' + text + '</span>');
                     link_element.append('<span class="kb">' + shortcut + '</span>');
                 }

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -235,6 +235,9 @@ define([
             '#int_kernel': 'interrupt-kernel',
             '#cut_cell': 'cut-cell',
             '#copy_cell': 'copy-cell',
+            '#paste_cell_above': 'paste-cell-above',
+            '#paste_cell_below': 'paste-cell-below',
+            '#paste_cell_replace': 'paste-cell-replace',
             '#delete_cell': 'delete-cell',
             '#undelete_cell': 'undo-cell-deletion',
             '#split_cell': 'split-cell-at-cursor',
@@ -266,6 +269,7 @@ define([
             '#copy_cell_attachments': 'copy-cell-attachments',
             '#paste_cell_attachments': 'paste-cell-attachments',
             '#insert_image': 'insert-image',
+            '#keyboard_shortcuts' : 'show-keyboard-shortcuts',
             '#edit_keyboard_shortcuts' : 'edit-command-mode-keyboard-shortcuts',
         };
 
@@ -311,9 +315,6 @@ define([
         } else {
             this.element.find('#notebook_tour').addClass("disabled");
         }
-        this.element.find('#keyboard_shortcuts').click(function () {
-            that.quick_help.show_keyboard_shortcuts();
-        });
         
         this.update_restore_checkpoint(null);
         

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -283,15 +283,15 @@ define([
                     that.actions.call(id_act, event);
                 });
                 
-                var keybinding = that.keyboard_manager.command_shortcuts.get_action_shortcut(id_act);
+                var keybinding = that.keyboard_manager.command_shortcuts.get_action_shortcut(id_act) || that.keyboard_manager.edit_shortcuts.get_action_shortcut(id_act);
                 
-                if(keybinding === undefined) {
-            		    keybinding = that.keyboard_manager.edit_shortcuts.get_action_shortcut(id_act);
-                }
-                
-                if(keybinding !== undefined) {
-                    var binding = '<span class="kb">'+keybinding+'</span>';
-                    el.children().append(binding);
+                if (keybinding) {
+                    var link_element = el.children('a');
+                    var text = link_element.text();
+                    link_element.text('');
+                    link_element.attr('style', 'display: flex; flex-direction: row; justify-content: space-between; align-items: flex-end;');
+                    link_element.append('<span class="action">' + text + '</span>');
+                    link_element.append('<span class="kb">' + keybinding + '</span>');
                 }
             })(that, id_act, idx);
         }

--- a/notebook/static/notebook/js/menubar.js
+++ b/notebook/static/notebook/js/menubar.js
@@ -7,10 +7,11 @@ define([
     'base/js/dialog',
     'base/js/utils',
     'base/js/i18n',
+    'notebook/js/quickhelp',
     './celltoolbar',
     './tour',
     'moment',
-], function($, IPython, dialog, utils, i18n, celltoolbar, tour, moment) {
+], function($, IPython, dialog, utils, i18n, quickhelp, celltoolbar, tour, moment) {
     "use strict";
 
     var MenuBar = function (selector, options) {
@@ -286,12 +287,13 @@ define([
                 var keybinding = that.keyboard_manager.command_shortcuts.get_action_shortcut(id_act) || that.keyboard_manager.edit_shortcuts.get_action_shortcut(id_act);
                 
                 if (keybinding) {
+                    var shortcut = quickhelp.humanize_sequence(keybinding);
                     var link_element = el.children('a');
                     var text = link_element.text();
                     link_element.text('');
                     link_element.attr('style', 'display: flex; flex-direction: row; justify-content: space-between; align-items: flex-end;');
                     link_element.append('<span class="action">' + text + '</span>');
-                    link_element.append('<span class="kb">' + keybinding + '</span>');
+                    link_element.append('<span class="kb">' + shortcut + '</span>');
                 }
             })(that, id_act, idx);
         }

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1619,17 +1619,11 @@ define([
         var that = this;
         if (!this.paste_enabled) {
             $('#paste_cell_replace').removeClass('disabled')
-                .on('click', function () {that.keyboard_manager.actions.call(
-                    'jupyter-notebook:paste-cell-replace');});
-            $('#paste_cell_replace > a').attr('aria-disabled', 'false'); 
+            $('#paste_cell_replace > a').attr('aria-disabled', 'false');
             $('#paste_cell_above').removeClass('disabled')
-                .on('click', function () {that.keyboard_manager.actions.call(
-                    'jupyter-notebook:paste-cell-above');});
-            $('#paste_cell_above > a').attr('aria-disabled', 'false'); 
+            $('#paste_cell_above > a').attr('aria-disabled', 'false');
             $('#paste_cell_below').removeClass('disabled')
-                .on('click', function () {that.keyboard_manager.actions.call(
-                    'jupyter-notebook:paste-cell-below');});
-            $('#paste_cell_below > a').attr('aria-disabled', 'false');         
+            $('#paste_cell_below > a').attr('aria-disabled', 'false');
             this.paste_enabled = true;
         }
     };
@@ -1639,12 +1633,12 @@ define([
      */
     Notebook.prototype.disable_paste = function () {
         if (this.paste_enabled) {
-            $('#paste_cell_replace').addClass('disabled').off('click');
-            $('#paste_cell_replace > a').attr('aria-disabled', 'true'); 
-            $('#paste_cell_above').addClass('disabled').off('click');
-            $('#paste_cell_above > a').attr('aria-disabled', 'true'); 
-            $('#paste_cell_below').addClass('disabled').off('click');
-            $('#paste_cell_below > a').attr('aria-disabled', 'true'); 
+            $('#paste_cell_replace').addClass('disabled');
+            $('#paste_cell_replace > a').attr('aria-disabled', 'true');
+            $('#paste_cell_above').addClass('disabled');
+            $('#paste_cell_above > a').attr('aria-disabled', 'true');
+            $('#paste_cell_below').addClass('disabled');
+            $('#paste_cell_below > a').attr('aria-disabled', 'true');
             this.paste_enabled = false;
         }
     };

--- a/notebook/static/notebook/less/menubar.less
+++ b/notebook/static/notebook/less/menubar.less
@@ -161,6 +161,9 @@ ul#help_menu li a{
     color: darkgray;
     margin-left: 10px;
     text-transform: capitalize;
+    kbd {
+        white-space: nowrap;
+    }
 }
 
 //end submenu

--- a/notebook/static/notebook/less/menubar.less
+++ b/notebook/static/notebook/less/menubar.less
@@ -146,4 +146,8 @@ ul#help_menu li a{
     margin-left: 10px;
 }
 
+.kb {
+    float: right;
+}
+
 //end submenu

--- a/notebook/static/notebook/less/menubar.less
+++ b/notebook/static/notebook/less/menubar.less
@@ -146,8 +146,14 @@ ul#help_menu li a{
     margin-left: 10px;
 }
 
+.action {
+    
+}
+
 .kb {
-    float: right;
+    color: darkgray;
+    margin-left: 10px;
+    text-transform: capitalize;
 }
 
 //end submenu

--- a/notebook/static/notebook/less/menubar.less
+++ b/notebook/static/notebook/less/menubar.less
@@ -71,6 +71,13 @@ i.menu-icon {
     .pull-left();
 }
 
+ul.dropdown-menu li a.menu-shortcut-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
 ul#help_menu li a{
     overflow: hidden;
     padding-right: 2.2em;


### PR DESCRIPTION
Following up on the work of @aaronmyatt in #2968, this PR fixes #2759.

Fix was all about adding a missing CSS rule regarding word wrapping specifically for `kbd` tag.

![Windows fix OK](https://user-images.githubusercontent.com/24898521/84309794-eaa34480-ab60-11ea-97fc-607ad7df520b.png)


We (see below) tested the fix on many OS & browsers:
- ✅ Mac OS: Safari & Firefox
- ✅ Linux: Brave & Firefox
- ✅ Windows 10: Edge & Chrome & Firefox


As a side note, this PR is a contribution from mob-programming involving : @cadichris, @garaud, @klock, @limdhuul, @lmazardo, @mikaelletang, @murlock, @nelyus, @pgrange

![mob](https://user-images.githubusercontent.com/24898521/84309854-0575b900-ab61-11ea-9f0a-7887b1c60a92.png)
