### PR TITLE
Fix exception causes in handlers.py

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -452,7 +452,7 @@ class IPythonHandler(AuthenticatedHandler):
                         msg = "Blocking Cross Origin request from {}.".format(referer)
                     else:
                         msg = "Blocking request from unknown origin"
-                    raise web.HTTPError(403, msg)
+                    raise web.HTTPError(403, msg) from e
             else:
                 raise
 
@@ -542,10 +542,10 @@ class IPythonHandler(AuthenticatedHandler):
         body = self.request.body.strip().decode(u'utf-8')
         try:
             model = json.loads(body)
-        except Exception:
+        except Exception as e:
             self.log.debug("Bad JSON: %r", body)
             self.log.error("Couldn't parse JSON", exc_info=True)
-            raise web.HTTPError(400, u'Invalid JSON in body of request')
+            raise web.HTTPError(400, u'Invalid JSON in body of request') from e
         return model
 
     def write_error(self, status_code, **kwargs):


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 