### PR TITLE
Add python 3.8, begin testing 3.9-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
 python:
     - 3.6
 
-
 env:
   global:
     - PATH=$TRAVIS_BUILD_DIR/pandoc:$PATH
@@ -95,6 +94,10 @@ matrix:
           env: GROUP=python
         - python: 3.7
           dist: xenial
+          env: GROUP=python
+        - python: 3.8
+          env: GROUP=python
+        - python: 3.9-dev
           env: GROUP=python
         - python: 3.6
           env: GROUP=docs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,11 @@ matrix:
 environment:
   matrix:
     - CONDA_PY: 36
+      CONDA_PY_SPEC: 3.6
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
+    - CONDA_PY: 38
+      CONDA_PY_SPEC: 3.8
+      CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
 
 platform:
   - x64
@@ -17,7 +21,7 @@ install:
   - cmd: conda config --set show_channel_urls true
   - cmd: conda config --add channels conda-forge
   #- cmd: conda update --yes --quiet conda
-  - cmd: conda install -y pyzmq tornado jupyter_client nbformat ipykernel pip nodejs nose
+  - cmd: conda install -y python=%CONDA_PY_SPEC% pyzmq tornado jupyter_client nbformat ipykernel pip nodejs nose
   # not using `conda install -y` on nbconvent package because there is
   # currently a bug with the version that the anaconda installs, so we will just install it with pip
   - cmd: pip install nbconvert

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ for more information.
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.8'
     ],
     zip_safe = False,
     install_requires = [


### PR DESCRIPTION
- Add Python 3.8 to the supported list of python versions.
- Include Python 3.8 and 3.9-dev in the set of Travis builds and 3.8 to the appveyor build. 

Note: I didn't include 3.7 or 3.9-dev in appveyor because they're sequentially run and it would add about 5 minutes for each to the overall run length which, given the 2 sets being run now are already 5 minutes longer than the complete Travis run (13 vs. 8 min), seemed too long.
