### PR TITLE
Respect cell.is_editable during find-and-replace

### DIFF
--- a/notebook/static/notebook/js/searchandreplace.js
+++ b/notebook/static/notebook/js/searchandreplace.js
@@ -308,6 +308,10 @@ define([
       var cells = get_cells(env);
       for (var c = 0; c < cells.length; c++) {
         var cell = cells[c];
+        if (!cell.is_editable()) {
+          continue;
+        }
+          
         var oldvalue = cell.code_mirror.getValue();
         var newvalue = oldvalue.replace(reg , replaceValue);
         cell.code_mirror.setValue(newvalue);


### PR DESCRIPTION
Find and replace (searchandreplace.js) will overwrite the contents of cells even if they are marked as non-editable. Add a check against the cell's is_editable() method to ensure this only happens for editable cells.