### PR TITLE
Added support for JUPYTER_TOKEN_FILE

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -931,6 +931,9 @@ class NotebookApp(JupyterApp):
     token = Unicode('<generated>',
         help=_("""Token used for authenticating first-time connections to the server.
 
+        The token can be read from the file referenced by JUPYTER_TOKEN_FILE or set directly
+        with the JUPYTER_TOKEN environment variable.
+
         When no password is enabled,
         the default is to generate a new, random token.
 

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -947,7 +947,7 @@ class NotebookApp(JupyterApp):
             return os.getenv('JUPYTER_TOKEN')
         if os.getenv('JUPYTER_TOKEN_FILE'):
             self._token_generated = False
-            with io.open(os.getenv('JUPYTER_TOKEN_FILE'), "r") as token_file
+            with io.open(os.getenv('JUPYTER_TOKEN_FILE'), "r") as token_file:
                 return token_file.read()
         if self.password:
             # no token if password is enabled

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -945,6 +945,10 @@ class NotebookApp(JupyterApp):
         if os.getenv('JUPYTER_TOKEN'):
             self._token_generated = False
             return os.getenv('JUPYTER_TOKEN')
+        if os.getenv('JUPYTER_TOKEN_FILE'):
+            self._token_generated = False
+            with io.open(os.getenv('JUPYTER_TOKEN_FILE'), "r") as token_file
+                return token_file.read()
         if self.password:
             # no token if password is enabled
             self._token_generated = False


### PR DESCRIPTION
## Motivation

Currently, we use `JUPYTER_TOKEN` as an environment variable to pass a token to the jupyter notebook with which we can authenticate us later. This is a good practice, for a local environment, but in a docker environment the best practice is to use `docker secrets`. Docker secrets uses instead of a string directly in the env variable, a file location where the string is stored. This file is stored in memory and only accessible by the container that has the correct access right. 

## Changes

Added an env variable `JUPYTER_TOKEN_FILE`, if it is available it will read the token from the given location and return it. Priority has `JUPYTER_TOKEN`. 

## Further information

Docker-compose with docker secret, best practices: https://docs.docker.com/engine/swarm/secrets/#build-support-for-docker-secrets-into-your-images
