### PR TITLE
Improve login shell heuristics

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1160,7 +1160,10 @@ class NotebookApp(JupyterApp):
         """)
     )
     terminado_settings = Dict(config=True,
-            help=_('Supply overrides for terminado. Currently only supports "shell_command".'))
+            help=_('Supply overrides for terminado. Currently only supports "shell_command". '
+                 'On Unix, if "shell_command" is not provided, a non-login shell is launched '
+                 "by default when the notebook server is connected to a terminal, a login "
+                 "shell otherwise."))
 
     cookie_options = Dict(config=True,
         help=_("Extra keyword arguments to pass to `set_secure_cookie`."


### PR DESCRIPTION
A follow-up on #5565, with better heuristics and respecting overrides via `NotebookApp.terminado_settings`. Cf. https://github.com/jupyter/notebook/pull/5565#issuecomment-653544660 for details.

I'm wondering whether to also update the documentation for `NotebookApp.terminado_settings`, so that it makes it clearer what the shell defaults are and how they can be overridden. Something like:

> Supply overrides for terminado. Currently only supports "shell_command". On Unix systems, a non-login shell is run by default when the notebook server is launched from a terminal, a login shell otherwise.

But AFAICS, this would also require updating translations, so I'm not sure it's worth the trouble.