### PR TITLE
Fix broken links for contributor

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -201,4 +201,4 @@ Windows users can find ``make.bat`` in the ``docs`` folder.
 
 You should also have a look at the `Project Jupyter Documentation Guide`__.
 
-__ https://jupyter.readthedocs.io/en/latest/contributing/content-contributor.html
+__ https://jupyter.readthedocs.io/en/latest/contributing/docs-contributions/index.html

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -14,7 +14,7 @@ General Guidelines
 For general documentation about contributing to Jupyter projects, see the
 `Project Jupyter Contributor Documentation`__.
 
-__ https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html
+__ https://jupyter.readthedocs.io/en/latest/contributing/content-contributor.html
 
 
 Setting Up a Development Environment
@@ -201,4 +201,4 @@ Windows users can find ``make.bat`` in the ``docs`` folder.
 
 You should also have a look at the `Project Jupyter Documentation Guide`__.
 
-__ https://jupyter.readthedocs.io/en/latest/contrib_docs/index.html
+__ https://jupyter.readthedocs.io/en/latest/contributing/content-contributor.html


### PR DESCRIPTION
Fix #5599 
The links to the `Project Jupyter Contributor Documentation` and `Project Jupyter Documentation Guide` is broken.
Fixed them.