### PR TITLE
Update marked package version to 0.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "jquery": "components/jquery#~3.5.0",
     "jquery-typeahead": "~2.10.6",
     "jquery-ui": "components/jqueryui#~1.12",
-    "marked": "~0.5",
+    "marked": "~0.7",
     "MathJax": "^2.7.4",
     "moment": "~2.19.3",
     "react": "~16.0.0",


### PR DESCRIPTION
To address security scanning callouts, the minimum version of marked is being updated from 0.5 to 0.7.

Resolves #5611 