### PR TITLE
update codemirror to 5.56.0+components1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "backbone": "components/backbone#~1.2",
     "bootstrap": "bootstrap#~3.4",
     "bootstrap-tour": "0.9.0",
-    "codemirror": "components/codemirror#~5.55.0",
+    "codemirror": "components/codemirror#5.56.0+components1",
     "create-react-class": "https://cdn.jsdelivr.net/npm/create-react-class@15.6.3/create-react-class.min.js",
     "es6-promise": "~1.0",
     "font-awesome": "components/font-awesome#~4.7.0",


### PR DESCRIPTION
This is a fixed re-release of 5.56.0.
Future CM upgrades should go back to the old pattern of e.g. `components/codemirror#~5.57.0`. (Note the 
~tilde) (I can't leave a comment to this effect in the JSON)
To fix #5629 .