### PR TITLE
Prevent inclusion of requests_unixsocket on Windows

### DIFF
--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -16,7 +16,8 @@ pjoin = os.path.join
 from unittest.mock import patch
 
 import requests
-import requests_unixsocket
+if not sys.platform.startswith('win'):
+    import requests_unixsocket
 from tornado.ioloop import IOLoop
 import zmq
 

--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -16,8 +16,6 @@ pjoin = os.path.join
 from unittest.mock import patch
 
 import requests
-if not sys.platform.startswith('win'):
-    import requests_unixsocket
 from tornado.ioloop import IOLoop
 import zmq
 
@@ -232,6 +230,9 @@ class UNIXSocketNotebookTestBase(NotebookTestBase):
 
     @staticmethod
     def fetch_url(url):
+        # Lazily import so it is not required at the module level
+        if os.name != 'nt':
+            import requests_unixsocket
         with requests_unixsocket.monkeypatch():
             return requests.get(url)
 

--- a/setup.py
+++ b/setup.py
@@ -117,10 +117,9 @@ for more information.
     ],
     extras_require = {
         'test': ['nose', 'coverage', 'requests', 'nose_warnings_filters',
-                 'nbval', 'nose-exclude', 'selenium', 'pytest', 'pytest-cov',
-                 'requests-unixsocket'],
+                 'nbval', 'nose-exclude', 'selenium', 'pytest', 'pytest-cov'],
         'docs': ['sphinx', 'nbsphinx', 'sphinxcontrib_github_alt'],
-        'test:sys_platform == "win32"': ['nose-exclude'],
+        'test:sys_platform != "win32"': ['requests-unixsocket'],
     },
     python_requires = '>=3.5',
     entry_points = {


### PR DESCRIPTION
Prevent the need to install `requests_unixsocket` on Windows so that downstream projects that rely on notebook's test framework are not side-affected by a package that is not used.

Fixes #5644