### PR TITLE
Title new buttons with label if action undefined

### DIFF
--- a/notebook/static/notebook/js/toolbar.js
+++ b/notebook/static/notebook/js/toolbar.js
@@ -92,10 +92,14 @@ define(['jquery','base/js/i18n'], function($, i18n) {
                     action = that.actions.get(el.action);
                     action_name = el.action
                 }
+                var title = el.label;
+                if(action && action.help) {
+                    title = i18n.msg._(action.help) || el.label;
+                }
                 var button  = $('<button/>')
                     .addClass('btn btn-default')
                     .attr("aria-label", el.label)
-                    .attr("title", i18n.msg._(action.help)||el.label)
+                    .attr("title", title)
                     .append(
                         $("<i/>").addClass(el.icon||(action||{icon:'fa-exclamation-triangle'}).icon).addClass('fa')
                     );


### PR DESCRIPTION
On a recent release of the notebook js that included https://github.com/jupyter/notebook/pull/5107, some extensions would fail because they either did not have an `action` _or_ their `action.help` was not part of the i18n lookup (most extensions). This provides a fallback to `el.label`. 