### PR TITLE
Revert change in page alignment

### DIFF
--- a/notebook/static/base/js/page.js
+++ b/notebook/static/base/js/page.js
@@ -27,7 +27,7 @@ define([
         // - header change
         // - page load
         var _handle_resize = $.proxy(this._resize_site, this);
-        
+
         $(window).resize(_handle_resize);
 
         // On document ready, resize codemirror.
@@ -61,8 +61,6 @@ define([
         this._resize_site();
     };
 
-
-
     Page.prototype._resize_site = function(e) {
         /**
          * Update the site's size.
@@ -74,21 +72,7 @@ define([
         if (!(e && e.target && e.target.tagName)) {
             $('div#site').height($(window).height() - $('#header').height());
         }
-        this._align_header_site();
     };
-
-
-
-    Page.prototype._align_header_site = function(e) {
-        /**
-         * Align the site and header divs
-         */
-        var header_div_element_width = this.header_div_element.outerWidth();
-        var header_container_width = $('div#header-container').outerWidth();
-        var margin_left = (header_div_element_width - header_container_width) / 2;
-
-        this.site_div_element.find('.container').css('margin-left', margin_left);
-    }
 
     return {'Page': Page};
 });


### PR DESCRIPTION
This reverts #3173, which introduces some new alignment issues for browsers in on Arch Linux.

The new issues were slightly worse the original issue that #3173 tried to fix, so we're reverting it here.