### PR TITLE
Reliable list_running_servers(runtime_dir) design

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -2322,7 +2322,7 @@ def list_running_servers(runtime_dir=None):
             # active check whether that process is really available via real HTTP request
             # Also remove leftover files from IPython 2.x without a pid field
             response = kernel_request(info, path='/login')
-            if response.code in ('200',) and response.body.find(b'<title>Jupyter Notebook</title>') > 0:
+            if response.code in (200,) and response.body.find(b'<title>Jupyter Notebook</title>') > 0:
                 yield info
             else:
                 # If the process has died, try to delete its info file

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -2322,7 +2322,7 @@ def list_running_servers(runtime_dir=None):
             # active check whether that process is really available via real HTTP request
             # Also remove leftover files from IPython 2.x without a pid field
             response = kernel_request(info, path='/login')
-            if response.code in (200,) and response.body.find(b'<title>Jupyter Notebook</title>') > 0:
+            if response.body.find(b'<title>Jupyter Notebook</title>') > 0:
                 yield info
             else:
                 # If the process has died, try to delete its info file


### PR DESCRIPTION
active check whether that process is really available via real HTTP request;
process pid maybe recycle and reused by host Operating System that i encountered;
and we must use real HTTP request other than the past check_pid(info['pid']).