### PR TITLE
Fix typo for Check in zh_CN

### DIFF
--- a/notebook/i18n/zh_CN/LC_MESSAGES/nbjs.po
+++ b/notebook/i18n/zh_CN/LC_MESSAGES/nbjs.po
@@ -1076,7 +1076,7 @@ msgstr "没有到服务的连接"
 
 #: notebook/static/notebook/js/notificationarea.js:160
 msgid "A connection to the notebook server could not be established. The notebook will continue trying to reconnect. Check your network connection or notebook server configuration."
-msgstr "到后台服务的连接没能建立, 我们会继续尝试重连, 请检查网络连接...还有服务配置."
+msgstr "到后台服务的连接没能建立, 我们会继续尝试重连, 请检查网络连接还有服务配置."
 
 #: notebook/static/notebook/js/notificationarea.js:165
 msgid "Connection failed"

--- a/notebook/i18n/zh_CN/LC_MESSAGES/nbjs.po
+++ b/notebook/i18n/zh_CN/LC_MESSAGES/nbjs.po
@@ -1076,7 +1076,7 @@ msgstr "没有到服务的连接"
 
 #: notebook/static/notebook/js/notificationarea.js:160
 msgid "A connection to the notebook server could not be established. The notebook will continue trying to reconnect. Check your network connection or notebook server configuration."
-msgstr "到后台服务的连接没能建立, 我们会继续尝试重连, 请检出网络连接...还有服务配置."
+msgstr "到后台服务的连接没能建立, 我们会继续尝试重连, 请检查网络连接...还有服务配置."
 
 #: notebook/static/notebook/js/notificationarea.js:165
 msgid "Connection failed"

--- a/notebook/i18n/zh_CN/LC_MESSAGES/nbjs.po
+++ b/notebook/i18n/zh_CN/LC_MESSAGES/nbjs.po
@@ -1831,7 +1831,7 @@ msgstr "文件大小为 %d MB, 还想上传么?"
 
 #: notebook/static/tree/js/notebooklist.js:286
 msgid "Large file size warning"
-msgstr "请注意文件大小..."
+msgstr "请注意文件大小"
 
 
 #: notebook/static/tree/js/notebooklist.js:355
@@ -1960,7 +1960,7 @@ msgstr "无效的文件名"
 
 #: notebook/static/tree/js/notebooklist.js:1335
 msgid "File names must be at least one character and not start with a period"
-msgstr "文件名不能为空...并且不能以句号开始,除下划线以外的符号都不能开头..."
+msgstr "文件名不能为空，并且不能以句号开始，除下划线以外的符号都不能开头"
 
 #: notebook/static/tree/js/notebooklist.js:1364
 msgid "Cannot upload invalid Notebook"


### PR DESCRIPTION
`检查`(check) and `检出`(check out) sound similar, but their meaning is different. In this context, it should be `检查`.