### PR TITLE
Require a file name in the "Save As" dialog

### DIFF
--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -2920,6 +2920,14 @@ define([
                     click: function() {
                         var nb_path = d.find('input').val();
                         var nb_name = nb_path.split('/').slice(-1).pop();
+                        if (!nb_name) {
+                            $(".save-message").html(
+                                    $("<span>")
+                                        .attr("style", "color:red;")
+                                        .text($(".save-message").text())
+                                );
+                            return false;
+                        }
                         // If notebook name does not contain extension '.ipynb' add it
                         var ext = utils.splitext(nb_name)[1];
                         if (ext === '') {


### PR DESCRIPTION
This PR fixes  #5732 by checking for empty file names in the "Save As" dialog and refusing to save the file. It also helpfully highlights the instructions to the user in red.

It would be better if the error message were clearer, or even better if the save button were disabled until a file name was entered, but that would require a much larger and more complex change to the code. (Maintainers, feel free to take this patch and run with it!)