### PR TITLE
Embed frontend_config toctree in config_overview

### DIFF
--- a/docs/source/config_overview.rst
+++ b/docs/source/config_overview.rst
@@ -54,12 +54,11 @@ front-end Notebook client (i.e. the familiar notebook interface).
 
 Notebook front-end client
 -------------------------
-- :ref:`How front-end configuration works <frontend_config>`
-    * :ref:`Example: Changing the notebook's default indentation setting
-      <frontend_config>`
-    * :ref:`Example: Restoring the notebook's default indentation setting
-      <frontend_config>`
-- :ref:`Persisting configuration settings <frontend_config>`
+
+.. toctree::
+   :maxdepth: 2
+
+   frontend_config
 
 .. _configure_nbextensions:
 


### PR DESCRIPTION
The section `Notebook front-end client` in the config overview
page was essentially a toc tree except the sub-section links
went to the top of the frontend_config page rather than the real
sub-sections in that page because they all used the same reference.

Rather than create a unique reference for each sub-section in the
frontend_config page, this simply embeds the frontend_config toctree
within the config_overview page which essentially has the same effect.

Closes #5740