### PR TITLE
Make sure notebook is pip installed when building docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -176,7 +176,8 @@ containing all the necessary packages (except pandoc), use::
 
     conda env create -f docs/environment.yml
     conda activate notebook_docs  # Linux and OS X
-    activate notebook_docs         # Windows
+    activate notebook_docs        # Windows
+    pip install .
 
 .. _conda environment:
     https://conda.io/docs/user-guide/tasks/manage-environments.html#creating-an-environment-from-an-environment-yml-file

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -174,17 +174,17 @@ To build the documentation you'll need `Sphinx <http://www.sphinx-doc.org/>`_,
 To install (and activate) a `conda environment`_ named ``notebook_docs``
 containing all the necessary packages (except pandoc), use::
 
-    conda env create -f docs/environment.yml
+    conda create -n notebook_docs pip
     conda activate notebook_docs  # Linux and OS X
     activate notebook_docs        # Windows
-    pip install .
+    pip install .[docs]
 
 .. _conda environment:
     https://conda.io/docs/user-guide/tasks/manage-environments.html#creating-an-environment-from-an-environment-yml-file
 
 If you want to install the necessary packages with ``pip``, use the following instead::
 
-    pip install . -r docs/doc-requirements.txt
+    pip install .[docs]
 
 Once you have installed the required packages, you can build the docs with::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -171,16 +171,13 @@ Building the Documentation
 To build the documentation you'll need `Sphinx <http://www.sphinx-doc.org/>`_,
 `pandoc <http://pandoc.org/>`_ and a few other packages.
 
-To install (and activate) a `conda environment`_ named ``notebook_docs``
+To install (and activate) a conda environment named ``notebook_docs``
 containing all the necessary packages (except pandoc), use::
 
     conda create -n notebook_docs pip
     conda activate notebook_docs  # Linux and OS X
     activate notebook_docs        # Windows
     pip install .[docs]
-
-.. _conda environment:
-    https://conda.io/docs/user-guide/tasks/manage-environments.html#creating-an-environment-from-an-environment-yml-file
 
 If you want to install the necessary packages with ``pip``, use the following instead::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -183,7 +183,7 @@ containing all the necessary packages (except pandoc), use::
 
 If you want to install the necessary packages with ``pip``, use the following instead::
 
-    pip install -r docs/doc-requirements.txt
+    pip install . -r docs/doc-requirements.txt
 
 Once you have installed the required packages, you can build the docs with::
 

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,8 @@ for more information.
     extras_require = {
         'test': ['nose', 'coverage', 'requests', 'nose_warnings_filters',
                  'nbval', 'nose-exclude', 'selenium', 'pytest', 'pytest-cov'],
-        'docs': ['sphinx', 'nbsphinx', 'sphinxcontrib_github_alt'],
+        'docs': ['sphinx', 'nbsphinx', 'sphinxcontrib_github_alt',
+                 'sphinx-rtd-theme'],
         'test:sys_platform != "win32"': ['requests-unixsocket'],
     },
     python_requires = '>=3.5',


### PR DESCRIPTION
The instructions on building the docs fail to mention that
the notebook package itself needs to be installed.

This updates the instructions to pip install the local notebook
package include the `docs` dependencies using the `docs` extra
install package list.

Closes #5741