### PR TITLE
Move requests_unixsocket import outside of UNIXSocketNotebookTestBase.fetch_url()

### DIFF
--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -53,6 +53,9 @@ class NotebookTestBase(TestCase):
         for _ in range(int(MAX_WAITTIME/POLL_INTERVAL)):
             try:
                 cls.fetch_url(url)
+            except ModuleNotFoundError as error:
+                # Errors that should be immediately thrown back to caller
+                raise error
             except Exception as e:
                 if not cls.notebook_thread.is_alive():
                     raise RuntimeError("The notebook server failed to start") from e


### PR DESCRIPTION
Some tests were failing on Fedora due to missing import of `requests_unixsocket`. Because of bare exception in `wait_until_alive()` function, it was difficult to understand where the problem lies. 
 
I would suggest moving the import to the beginning of the test file, so in case of missing module ImportError exception will be raised even before the tests are collected. 
 
Another solution would be to replace exception in the `wait_until_alive()` function with more specific ones (eg. `HTTPError`, `ConnectionError`...) so it will wait only if an exception is related to currently starting notebook and nothing else (like ImportError in this case).