### PR TITLE
replace check_pid and variants with psutil library

### DIFF
--- a/notebook/utils.py
+++ b/notebook/utils.py
@@ -284,34 +284,6 @@ def check_version(v, check):
         return True
 
 
-# Copy of IPython.utils.process.check_pid:
-
-def _check_pid_win32(pid):
-    import ctypes
-    # OpenProcess returns 0 if no such process (of ours) exists
-    # positive int otherwise
-    return bool(ctypes.windll.kernel32.OpenProcess(1,0,pid))
-
-def _check_pid_posix(pid):
-    """Copy of IPython.utils.process.check_pid"""
-    try:
-        os.kill(pid, 0)
-    except OSError as err:
-        if err.errno == errno.ESRCH:
-            return False
-        elif err.errno == errno.EPERM:
-            # Don't have permission to signal the process - probably means it exists
-            return True
-        raise
-    else:
-        return True
-
-if sys.platform == 'win32':
-    check_pid = _check_pid_win32
-else:
-    check_pid = _check_pid_posix
-
-
 def maybe_future(obj):
     """Like tornado's deprecated gen.maybe_future
 

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ for more information.
         'ipykernel', # bless IPython kernel for now
         'Send2Trash',
         'terminado>=0.8.3',
+        'psutil~=5.7.2',
         'prometheus_client'
     ],
     extras_require = {


### PR DESCRIPTION
Improvements:

* a lot more tested and resilient (e.g. _check_pid_win32 has bugs)
* ensures not just that nbserver has the same PID but also was created at the same time (PID may be reused)

Drawback:

* adds a new dependency