### PR TITLE
Add support for JSON formatted logs

### DIFF
--- a/notebook/log.py
+++ b/notebook/log.py
@@ -9,6 +9,10 @@ import json
 from tornado.log import access_log
 from .prometheus.log_functions import prometheus_log_method
 
+from .utils import enable_json_logs
+
+_enable_json_logs = enable_json_logs()
+
 
 def log_request(handler):
     """log a bit more information about each request than tornado's default
@@ -46,5 +50,11 @@ def log_request(handler):
     if status >= 500 and status != 502:
         # log all headers if it caused an error
         log_method(json.dumps(dict(request.headers), indent=2))
-    log_method(msg.format(**ns))
+    if _enable_json_logs:
+        # FIXME: this still logs the msg as a serialized json string,
+        # presumably because it's using tornado's access_log rather than
+        # the logger setup in notebook app with _log_formatter_cls.
+        log_method(ns)
+    else:
+        log_method(msg.format(**ns))
     prometheus_log_method(handler)

--- a/notebook/log.py
+++ b/notebook/log.py
@@ -45,7 +45,10 @@ def log_request(handler, log=access_log, log_json=False):
         msg = msg + ' referer={referer}'
     if status >= 500 and status != 502:
         # log all headers if it caused an error
-        log_method(json.dumps(dict(request.headers), indent=2))
+        if log_json:
+            log_method("", extra=dict(props=dict(request.headers)))
+        else:
+            log_method(json.dumps(dict(request.headers), indent=2))
     if log_json:
         log_method("", extra=dict(props=ns))
     else:

--- a/notebook/log.py
+++ b/notebook/log.py
@@ -46,8 +46,5 @@ def log_request(handler, log=access_log):
     if status >= 500 and status != 502:
         # log all headers if it caused an error
         log_method(json.dumps(dict(request.headers), indent=2))
-    # if _enable_json_logs:
-    #     log_method(ns)
-    # else:
     log_method(msg.format(**ns))
     prometheus_log_method(handler)

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -114,7 +114,6 @@ from notebook._sysinfo import get_sys_info
 from ._tz import utcnow, utcfromtimestamp
 from .utils import (
     check_pid,
-    enable_json_logs,
     pathname2url,
     run_sync,
     unix_socket_in_use,
@@ -720,7 +719,7 @@ class NotebookApp(JupyterApp):
     @default('log_json')
     def _default_log_json(self):
         """Get the log_json value from the environment."""
-        return enable_json_logs()
+        return os.getenv('JUPYTER_ENABLE_JSON_LOGGING', 'false').lower() == 'true'
 
     @validate('log_json')
     def _validate_log_json(self, proposal):

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -730,14 +730,14 @@ class NotebookApp(JupyterApp):
         if value:
             try:
                 import json_logging
-                self.log.info('initializing json logging')
+                self.log.debug('initializing json logging')
                 json_logging.init_non_web(enable_json=True)
                 self._log_formatter_cls = json_logging.JSONLogFormatter
             except ImportError:
                 # If configured for json logs and we can't do it, log a hint.
                 # Only log the error once though.
                 if not self._json_logging_import_error_logged:
-                    logging.getLogger(__name__).warning(
+                    self.log.warning(
                         'Unable to use json logging due to missing packages. '
                         'Run "pip install notebook[json-logging]" to fix.'
                     )

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -113,6 +113,7 @@ from notebook._sysinfo import get_sys_info
 from ._tz import utcnow, utcfromtimestamp
 from .utils import (
     check_pid,
+    enable_json_logs,
     pathname2url,
     run_sync,
     unix_socket_in_use,
@@ -139,17 +140,17 @@ except ImportError:
     terminado_available = False
 
 # Tolerate missing json_logging package.
-enable_json_logs = os.getenv('ENABLE_JSON_LOGGING', 'false').lower() == 'true'
+_enable_json_logs = enable_json_logs()
 try:
     import json_logging
 except ImportError:
     # If configured for json logs and we can't do it, log a hint.
-    if enable_json_logs:
+    if _enable_json_logs:
         logging.getLogger(__name__).exception(
             'Unable to use json logging due to missing packages. '
             'Run "pip install notebook[json-logging]" to fix.'
         )
-    enable_json_logs = False
+    _enable_json_logs = False
 
 #-----------------------------------------------------------------------------
 # Module globals
@@ -717,7 +718,7 @@ class NotebookApp(JupyterApp):
 
     # Unless there is a way to re-initialize the log formatter (like with _log_format_changed?)
     # we need to load the json logging formatter early here otherwise traitlets complains.
-    _log_formatter_cls = json_logging.JSONLogFormatter if enable_json_logs else LogFormatter
+    _log_formatter_cls = json_logging.JSONLogFormatter if _enable_json_logs else LogFormatter
 
     @default('log_level')
     def _default_log_level(self):

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -730,15 +730,14 @@ class NotebookApp(JupyterApp):
         if value:
             try:
                 import json_logging
+                self.log.info('initializing json logging')
+                json_logging.init_non_web(enable_json=True)
                 self._log_formatter_cls = json_logging.JSONLogFormatter
-                # Note that we don't need to trigger _log_format_changed here
-                # because init_logging will set the JSONLogFormatter on all
-                # of the registered loggers.
             except ImportError:
                 # If configured for json logs and we can't do it, log a hint.
                 # Only log the error once though.
                 if not self._json_logging_import_error_logged:
-                    logging.getLogger(__name__).exception(
+                    logging.getLogger(__name__).warning(
                         'Unable to use json logging due to missing packages. '
                         'Run "pip install notebook[json-logging]" to fix.'
                     )
@@ -1632,13 +1631,6 @@ class NotebookApp(JupyterApp):
         )
 
     def init_logging(self):
-        if self.log_json:
-            self.log.debug('initializing json logging')
-            # Note that we don't guard against ImportError here because if the
-            # package is missing then _validate_log_json should have set
-            # log_json=False.
-            import json_logging
-            json_logging.init_non_web(enable_json=True)
         # This prevents double log messages because tornado use a root logger that
         # self.log is a child of. The logging module dispatches log messages to a log
         # and all of its ancenstors until propagate is set to False.

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -11,6 +11,7 @@ import asyncio
 import binascii
 import datetime
 import errno
+import functools
 import gettext
 import hashlib
 import hmac
@@ -251,9 +252,11 @@ class NotebookWebApplication(web.Application):
             # collapse $HOME to ~
             root_dir = '~' + root_dir[len(home):]
 
+        # Use the NotebookApp logger and its formatting for tornado request logging.
+        log_function = functools.partial(log_request, log=log)
         settings = dict(
             # basics
-            log_function=log_request,
+            log_function=log_function,
             base_url=base_url,
             default_url=default_url,
             template_path=template_path,

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -252,7 +252,8 @@ class NotebookWebApplication(web.Application):
             root_dir = '~' + root_dir[len(home):]
 
         # Use the NotebookApp logger and its formatting for tornado request logging.
-        log_function = functools.partial(log_request, log=log)
+        log_function = functools.partial(
+            log_request, log=log, log_json=jupyter_app.log_json)
         settings = dict(
             # basics
             log_function=log_function,

--- a/notebook/tests/test_log.py
+++ b/notebook/tests/test_log.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest import mock
+
+from notebook import log
+
+
+class TestLogRequest(unittest.TestCase):
+
+    @mock.patch('notebook.log.prometheus_log_method')
+    def test_log_request_json(self, mock_prometheus):
+        headers = {'Referer': 'test'}
+        request = mock.Mock(
+            request_time=mock.Mock(return_value=1),
+            headers=headers,
+            method='GET',
+            remote_ip='1.2.3.4',
+            uri='/notebooks/foo/bar'
+        )
+        handler = mock.MagicMock(
+            request=request,
+            get_status=mock.Mock(return_value=500)
+        )
+        logger = mock.MagicMock()
+        log.log_request(handler, log=logger, log_json=True)
+        # Since the status was 500 there should be two calls to log.error,
+        # one with the request headers and another with the other request
+        # parameters.
+        self.assertEqual(2, logger.error.call_count)
+        logger.error.assert_has_calls([
+            mock.call("", extra=dict(props=dict(headers))),
+            mock.call("", extra=dict(props={
+                'status': handler.get_status(),
+                'method': request.method,
+                'ip': request.remote_ip,
+                'uri': request.uri,
+                'request_time': 1000.0,
+                'referer': headers['Referer']
+            }))
+        ])
+        mock_prometheus.assert_called_once_with(handler)

--- a/notebook/tests/test_notebookapp.py
+++ b/notebook/tests/test_notebookapp.py
@@ -227,7 +227,7 @@ class NotebookAppJSONLoggingTests(NotebookTestBase):
         return test_env
 
     def test_log_json_enabled(self):
-        self.assertEqual(self.notebook.log_json, self.json_logging_available)
+        self.assertTrue(self.notebook._default_log_json())
 
     def test_validate_log_json(self):
         self.assertEqual(

--- a/notebook/tests/test_notebookapp.py
+++ b/notebook/tests/test_notebookapp.py
@@ -191,10 +191,10 @@ class NotebookAppTests(NotebookTestBase):
         assert self.port in {info['port'] for info in servers}
 
     def test_log_json_default(self):
-        assert self.notebook.log_json == False
+        self.assertFalse(self.notebook.log_json)
 
     def test_validate_log_json(self):
-        assert self.notebook._validate_log_json(dict(value=False)) == False
+        self.assertFalse(self.notebook._validate_log_json(dict(value=False)))
 
 
 # UNIX sockets aren't available on Windows.
@@ -227,7 +227,9 @@ class NotebookAppJSONLoggingTests(NotebookTestBase):
         return test_env
 
     def test_log_json_enabled(self):
-        assert self.notebook.log_json == self.json_logging_available
+        self.assertEqual(self.notebook.log_json, self.json_logging_available)
 
     def test_validate_log_json(self):
-        assert self.notebook._validate_log_json(dict(value=True)) == self.json_logging_available
+        self.assertEqual(
+            self.notebook._validate_log_json(dict(value=True)),
+            self.json_logging_available)

--- a/notebook/tests/test_notebookapp.py
+++ b/notebook/tests/test_notebookapp.py
@@ -190,6 +190,12 @@ class NotebookAppTests(NotebookTestBase):
         assert len(servers) >= 1
         assert self.port in {info['port'] for info in servers}
 
+    def test_log_json_default(self):
+        assert self.notebook.log_json == False
+
+    def test_validate_log_json(self):
+        assert self.notebook._validate_log_json(dict(value=False)) == False
+
 
 # UNIX sockets aren't available on Windows.
 if not sys.platform.startswith('win'):
@@ -201,3 +207,27 @@ if not sys.platform.startswith('win'):
             servers = list(notebookapp.list_running_servers())
             assert len(servers) >= 1
             assert self.sock in {info['sock'] for info in servers}
+
+
+class NotebookAppJSONLoggingTests(NotebookTestBase):
+    """Tests for when json logging is enabled."""
+    @classmethod
+    def setup_class(cls):
+        super(NotebookAppJSONLoggingTests, cls).setup_class()
+        try:
+            import json_logging
+            cls.json_logging_available = True
+        except ImportError:
+            cls.json_logging_available = False
+
+    @classmethod
+    def get_patch_env(cls):
+        test_env = super(NotebookAppJSONLoggingTests, cls).get_patch_env()
+        test_env.update({'JUPYTER_ENABLE_JSON_LOGGING': 'true'})
+        return test_env
+
+    def test_log_json_enabled(self):
+        assert self.notebook.log_json == self.json_logging_available
+
+    def test_validate_log_json(self):
+        assert self.notebook._validate_log_json(dict(value=True)) == self.json_logging_available

--- a/notebook/utils.py
+++ b/notebook/utils.py
@@ -401,7 +401,3 @@ def unix_socket_in_use(socket_path):
         return True
     finally:
         sock.close()
-
-
-def enable_json_logs():
-    return os.getenv('JUPYTER_ENABLE_JSON_LOGGING', 'false').lower() == 'true'

--- a/notebook/utils.py
+++ b/notebook/utils.py
@@ -401,3 +401,7 @@ def unix_socket_in_use(socket_path):
         return True
     finally:
         sock.close()
+
+
+def enable_json_logs():
+    return os.getenv('ENABLE_JSON_LOGGING', 'false').lower() == 'true'

--- a/notebook/utils.py
+++ b/notebook/utils.py
@@ -404,4 +404,4 @@ def unix_socket_in_use(socket_path):
 
 
 def enable_json_logs():
-    return os.getenv('ENABLE_JSON_LOGGING', 'false').lower() == 'true'
+    return os.getenv('JUPYTER_ENABLE_JSON_LOGGING', 'false').lower() == 'true'

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ for more information.
                  'nbval', 'nose-exclude', 'selenium', 'pytest', 'pytest-cov'],
         'docs': ['sphinx', 'nbsphinx', 'sphinxcontrib_github_alt', 'sphinx_rtd_theme'],
         'test:sys_platform != "win32"': ['requests-unixsocket'],
+        'json-logging': ['json-logging']
     },
     python_requires = '>=3.5',
     entry_points = {


### PR DESCRIPTION
This adds a new extra package dependency on `json-logging`
and an environment variable, which when set to "true" regardless
of case, will try to use the json-logging non-web app log formatter.
A `NotebookApp.log_json` config option is also added which gets
its default value from the `JUPYTER_ENABLE_JSON_LOGGING`
environment variable.

If the `json-logging` package is not installed but `log_json` is True,
something like this will be logged but it will not crash the application:

```
$ JUPYTER_ENABLE_JSON_LOGGING=true jupyter notebook
Unable to use json logging due to missing packages. Run "pip install notebook[json-logging]" to fix.
Traceback (most recent call last):
  File "/home/osboxes/jupyter/notebook/notebook/notebookapp.py", line 144, in <module>
    import json_logging
ModuleNotFoundError: No module named 'json_logging'
```

With this working you get logs like this:

```
{"written_at": "2020-10-07T21:10:51.606Z", "written_ts": 1602105051606265000, "msg": "404 GET /nbextensions/widgets/notebook/js/extension.js (127.0.0.1) 9.26ms referer=http://localhost:8888/notebooks/Untitled.ipynb", "type": "log", "logger": "NotebookApp", "thread": "MainThread", "level": "WARNING", "module": "log", "line_no": 49}
{"written_at": "2020-10-07T21:10:54.443Z", "written_ts": 1602105054443309000, "msg": "Starting buffering for f260ddd7-938c-42d0-ac3b-455bea76694f:49f30b53fc4b4ec6a8f2fb748a171613", "type": "log", "logger": "NotebookApp", "thread": "MainThread", "level": "INFO", "module": "kernelmanager", "line_no": 222}
{"written_at": "2020-10-07T21:10:54.446Z", "written_ts": 1602105054446264000, "msg": "Kernel shutdown: f260ddd7-938c-42d0-ac3b-455bea76694f", "type": "log", "logger": "NotebookApp", "thread": "MainThread", "level": "INFO", "module": "multikernelmanager", "line_no": 201}
```

Web app requests get logged with separate properties like this:

```json
{"written_at": "2020-10-09T20:59:52.044Z", "written_ts": 1602277192044732000, "msg": "", "type": "log", "logger": "NotebookApp", "thread": "MainThread", "level": "WARNING", "module": "log", "line_no": 50, "status": 404, "method": "GET", "ip": "127.0.0.1", "uri": "/api/kernels/a6dd447b-282a-4e1c-ab65-eb340ad12965/channels?session_id=472907c27ed94e2cbfbae86501f7d159", "request_time": 8.63, "referer": "None"}
```

The nice thing about that is you can filter request logs on certain error
status codes or request times that take longer than some threshold to
setup alerts in your logging infrastructure (ELK, LogDNA, etc).

Closes #5798