### PR TITLE
Remove utf8 coding cookies

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # Jupyter Notebook documentation build configuration file, created by
 # sphinx-quickstart on Mon Apr 13 09:51:11 2015.

--- a/notebook/_sysinfo.py
+++ b/notebook/_sysinfo.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 """
 Utilities for getting information about Jupyter and the system it's running in.
 """

--- a/notebook/_tz.py
+++ b/notebook/_tz.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 """
 Timezone utilities
 

--- a/notebook/auth/tests/test_security.py
+++ b/notebook/auth/tests/test_security.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from ..security import passwd, passwd_check
 import nose.tools as nt
 

--- a/notebook/base/zmqhandlers.py
+++ b/notebook/base/zmqhandlers.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Tornado handlers for WebSocket <-> ZMQ sockets."""
 
 # Copyright (c) Jupyter Development Team.

--- a/notebook/config_manager.py
+++ b/notebook/config_manager.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Manager to read and modify config data in JSON files."""
 
 # Copyright (c) Jupyter Development Team.

--- a/notebook/edit/handlers.py
+++ b/notebook/edit/handlers.py
@@ -1,4 +1,3 @@
-#encoding: utf-8
 """Tornado handlers for the terminal emulator."""
 
 # Copyright (c) Jupyter Development Team.

--- a/notebook/extensions.py
+++ b/notebook/extensions.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Utilities for installing extensions"""
 
 # Copyright (c) Jupyter Development Team.

--- a/notebook/jstest.py
+++ b/notebook/jstest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Notebook Javascript Test Controller
 
 This module runs one or more subprocesses which will actually run the Javascript

--- a/notebook/nbconvert/tests/test_nbconvert_handlers.py
+++ b/notebook/nbconvert/tests/test_nbconvert_handlers.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import io
 import json
 import os

--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Utilities for installing Javascript extensions for the notebook"""
 
 # Copyright (c) Jupyter Development Team.

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """A tornado based Jupyter notebook server."""
 
 # Copyright (c) Jupyter Development Team.

--- a/notebook/serverextensions.py
+++ b/notebook/serverextensions.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Utilities for installing server extensions for the notebook"""
 
 # Copyright (c) Jupyter Development Team.

--- a/notebook/services/config/tests/test_config_api.py
+++ b/notebook/services/config/tests/test_config_api.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Test the config webservice API."""
 
 import json

--- a/notebook/services/contents/tests/test_contents_api.py
+++ b/notebook/services/contents/tests/test_contents_api.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Test the contents webservice API."""
 
 from contextlib import contextmanager

--- a/notebook/services/contents/tests/test_fileio.py
+++ b/notebook/services/contents/tests/test_fileio.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 """Tests for file IO"""
 
 # Copyright (c) Jupyter Development Team.

--- a/notebook/services/contents/tests/test_manager.py
+++ b/notebook/services/contents/tests/test_manager.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Tests for the notebook manager."""
 from __future__ import print_function
 

--- a/notebook/services/kernelspecs/tests/test_kernelspecs_api.py
+++ b/notebook/services/kernelspecs/tests/test_kernelspecs_api.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Test the kernel specs webservice API."""
 
 import errno

--- a/notebook/terminal/handlers.py
+++ b/notebook/terminal/handlers.py
@@ -1,4 +1,3 @@
-#encoding: utf-8
 """Tornado handlers for the terminal emulator."""
 
 # Copyright (c) Jupyter Development Team.

--- a/notebook/tests/test_files.py
+++ b/notebook/tests/test_files.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Test the /files/ handler."""
 
 import io

--- a/notebook/tests/test_nbextensions.py
+++ b/notebook/tests/test_nbextensions.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Test installation of notebook extensions"""
 
 # Copyright (c) Jupyter Development Team.

--- a/notebook/view/handlers.py
+++ b/notebook/view/handlers.py
@@ -1,4 +1,3 @@
-#encoding: utf-8
 """Tornado handlers for viewing HTML files."""
 
 # Copyright (c) Jupyter Development Team.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Setup script for Jupyter Notebook"""
 
 #-----------------------------------------------------------------------------

--- a/setupbase.py
+++ b/setupbase.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 """
 This module defines the things that are used in setup.py for building the notebook
 


### PR DESCRIPTION
On Python 3, the default source file encoding for Python files is utf-8 and because Python 2 is no longer supported, the utf8 coding cookies can be removed.

The changes were made by manually searching the codebase for `coding:` and removing the cookies discovered. `coding:` should (and does) find all of the coding cookies present in the notebook codebase. Ref https://www.python.org/dev/peps/pep-0263/#defining-the-encoding.