### PR TITLE
Remove unnecessary future imports

### DIFF
--- a/notebook/__main__.py
+++ b/notebook/__main__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 if __name__ == '__main__':
     from notebook import notebookapp as app

--- a/notebook/_sysinfo.py
+++ b/notebook/_sysinfo.py
@@ -6,8 +6,6 @@ Utilities for getting information about Jupyter and the system it's running in.
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import absolute_import
-
 import os
 import platform
 import pprint

--- a/notebook/jstest.py
+++ b/notebook/jstest.py
@@ -8,8 +8,6 @@ test suite.
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import absolute_import, print_function
-
 import argparse
 import json
 import multiprocessing.pool

--- a/notebook/nbextensions.py
+++ b/notebook/nbextensions.py
@@ -4,8 +4,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 import os
 import shutil
 import sys

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -4,8 +4,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import absolute_import, print_function
-
 import notebook
 import asyncio
 import binascii

--- a/notebook/serverextensions.py
+++ b/notebook/serverextensions.py
@@ -4,8 +4,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 import importlib
 import sys
 

--- a/notebook/services/contents/tests/test_manager.py
+++ b/notebook/services/contents/tests/test_manager.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 """Tests for the notebook manager."""
-from __future__ import print_function
 
 import os
 import sys

--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -1,7 +1,5 @@
 """Base class for notebook tests."""
 
-from __future__ import print_function
-
 from binascii import hexlify
 from contextlib import contextmanager
 import errno

--- a/notebook/tests/notebook/output.js
+++ b/notebook/tests/notebook/output.js
@@ -44,7 +44,6 @@ casper.notebook_test(function () {
         IPython.notebook.insert_cell_at_index("code", 0);
         var cell = IPython.notebook.get_cell(0);
         cell.set_text([
-            "from __future__ import print_function",
             "import sys",
             "from IPython.display import display, clear_output"
             ].join("\n")

--- a/notebook/utils.py
+++ b/notebook/utils.py
@@ -3,8 +3,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 import asyncio
 import concurrent.futures
 import ctypes

--- a/setupbase.py
+++ b/setupbase.py
@@ -11,8 +11,6 @@ This includes:
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import print_function
-
 import os
 import re
 import pipes


### PR DESCRIPTION
This PR removes unnecessary `__future__` imports specifically `print_function` and `absolute_import` imports which are unnecessary on Python 3.