### PR TITLE
Remove code for unsupported python versions

### DIFF
--- a/notebook/base/zmqhandlers.py
+++ b/notebook/base/zmqhandlers.py
@@ -41,8 +41,6 @@ def serialize_binary_message(msg):
     # don't modify msg or buffer list in-place
     msg = msg.copy()
     buffers = list(msg.pop('buffers'))
-    if sys.version_info < (3, 4):
-        buffers = [x.tobytes() for x in buffers]
     bmsg = json.dumps(msg, default=date_default).encode('utf8')
     buffers.insert(0, bmsg)
     nbufs = len(buffers)

--- a/notebook/services/contents/tests/test_manager.py
+++ b/notebook/services/contents/tests/test_manager.py
@@ -108,7 +108,6 @@ class TestFileContentsManager(TestCase):
         self.assertEqual(cp_dir, os.path.join(root, cpm.checkpoint_dir, cp_name))
         self.assertEqual(cp_subdir, os.path.join(root, subd, cpm.checkpoint_dir, cp_name))
 
-    @dec.skipif(sys.platform == 'win32' and sys.version_info[0] < 3)
     def test_bad_symlink(self):
         with TemporaryDirectory() as td:
             cm = FileContentsManager(root_dir=td)
@@ -149,7 +148,6 @@ class TestFileContentsManager(TestCase):
             # recursive symlinks should not be shown in the contents manager
             self.assertNotIn('recursive', contents)
 
-    @dec.skipif(sys.platform == 'win32' and sys.version_info[0] < 3)
     def test_good_symlink(self):
         with TemporaryDirectory() as td:
             cm = FileContentsManager(root_dir=td)

--- a/notebook/tests/test_serverextensions.py
+++ b/notebook/tests/test_serverextensions.py
@@ -16,11 +16,7 @@ from notebook import nbextensions, serverextensions, extensions
 from notebook.notebookapp import NotebookApp
 from notebook.nbextensions import _get_config_dir
 
-if sys.version_info > (3,):
-    from types import SimpleNamespace
-else:
-    class SimpleNamespace(object):
-        pass
+from types import SimpleNamespace
 
 from collections import OrderedDict
 


### PR DESCRIPTION
This PR removes dead code, specifically code which was handling python 2.x and < 3.4.

Python 3.5 is also past EoL now but I am not sure if the package dropped support for Python 3.5 already so I have made no 3.5 related changes in this PR.