### PR TITLE
Fix broken links

### DIFF
--- a/docs/source/examples/Notebook/What is the Jupyter Notebook.ipynb
+++ b/docs/source/examples/Notebook/What is the Jupyter Notebook.ipynb
@@ -135,7 +135,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When you run the notebook web application on your computer, notebook documents are just **files on your local filesystem with a `.ipynb` extension**. This allows you to use familiar workflows for organizing your notebooks into folders and sharing them with others."
+    "When you run the notebook web application on your computer, notebook documents are just **files on your local filesystem with a** `.ipynb` **extension**. This allows you to use familiar workflows for organizing your notebooks into folders and sharing them with others."
    ]
   },
   {
@@ -148,7 +148,7 @@
     "* **Markdown cells:** Narrative text with embedded LaTeX equations\n",
     "* **Raw cells:** Unformatted text that is included, without modification, when notebooks are converted to different formats using nbconvert\n",
     "\n",
-    "Internally, notebook documents are **[JSON](https://en.wikipedia.org/wiki/JSON) data** with **binary values [base64](https://en.wikipedia.org/wiki/Base64)** encoded. This allows them to be **read and manipulated programmatically** by any programming language. Because JSON is a text format, notebook documents are version control friendly.\n",
+    "Internally, notebook documents are [JSON](https://en.wikipedia.org/wiki/JSON) **data** with **binary values** [base64](https://en.wikipedia.org/wiki/Base64) encoded. This allows them to be **read and manipulated programmatically** by any programming language. Because JSON is a text format, notebook documents are version control friendly.\n",
     "\n",
     "**Notebooks can be exported** to different static formats including HTML, reStructeredText, LaTeX, PDF, and slide shows ([reveal.js](https://revealjs.com)) using Jupyter's `nbconvert` utility.\n",
     "\n",


### PR DESCRIPTION
The documentation linked below contains 3 rendering errors:
https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/What%20is%20the%20Jupyter%20Notebook.html

![image](https://user-images.githubusercontent.com/6622588/95911956-0bdba200-0d9a-11eb-9631-066f809c7e15.png)

These are caused by limitations in the Sphinx tool used to render the page:
https://docutils.sourceforge.io/FAQ.html#is-nested-inline-markup-possible

This PR fixes them with the least amount of changes.