### PR TITLE
Add support for creating terminals via GET

### DIFF
--- a/notebook/terminal/__init__.py
+++ b/notebook/terminal/__init__.py
@@ -10,7 +10,7 @@ if not check_version(terminado.__version__, '0.8.3'):
 from ipython_genutils.py3compat import which
 from notebook.utils import url_path_join as ujoin
 from .terminalmanager import TerminalManager
-from .handlers import TerminalHandler, TermSocket
+from .handlers import TerminalHandler, TermSocket, NewTerminalHandler
 from . import api_handlers
 
 
@@ -45,6 +45,7 @@ def initialize(nb_app):
         (ujoin(base_url, r"/terminals/(\w+)"), TerminalHandler),
         (ujoin(base_url, r"/terminals/websocket/(\w+)"), TermSocket,
              {'term_manager': terminal_manager}),
+        (ujoin(base_url, r"/terminals/new/(\w+)"), NewTerminalHandler),
         (ujoin(base_url, r"/api/terminals"), api_handlers.TerminalRootHandler),
         (ujoin(base_url, r"/api/terminals/(\w+)"), api_handlers.TerminalHandler),
     ]

--- a/notebook/terminal/__init__.py
+++ b/notebook/terminal/__init__.py
@@ -10,7 +10,7 @@ if not check_version(terminado.__version__, '0.8.3'):
 from ipython_genutils.py3compat import which
 from notebook.utils import url_path_join as ujoin
 from .terminalmanager import TerminalManager
-from .handlers import TerminalHandler, TermSocket, NewTerminalHandler
+from .handlers import TerminalHandler, TermSocket, NewTerminalHandler, NamedTerminalHandler
 from . import api_handlers
 
 
@@ -42,10 +42,11 @@ def initialize(nb_app):
     terminal_manager.log = nb_app.log
     base_url = nb_app.web_app.settings['base_url']
     handlers = [
+        (ujoin(base_url, r"/terminals/new"), NamedTerminalHandler),
+        (ujoin(base_url, r"/terminals/new/(\w+)"), NewTerminalHandler),
         (ujoin(base_url, r"/terminals/(\w+)"), TerminalHandler),
         (ujoin(base_url, r"/terminals/websocket/(\w+)"), TermSocket,
              {'term_manager': terminal_manager}),
-        (ujoin(base_url, r"/terminals/new/(\w+)"), NewTerminalHandler),
         (ujoin(base_url, r"/api/terminals"), api_handlers.TerminalRootHandler),
         (ujoin(base_url, r"/api/terminals/(\w+)"), api_handlers.TerminalHandler),
     ]

--- a/notebook/terminal/handlers.py
+++ b/notebook/terminal/handlers.py
@@ -18,6 +18,15 @@ class TerminalHandler(IPythonHandler):
                    ws_path="terminals/websocket/%s" % term_name))
 
 
+class NewTerminalHandler(IPythonHandler):
+    """Render the terminal interface."""
+    @web.authenticated
+    def get(self, term_name):
+        self.terminal_manager.create_with_name(term_name)
+        new_path = self.request.path.replace("new/{}".format(term_name), term_name)
+        self.redirect(new_path)
+
+
 class TermSocket(WebSocketMixin, IPythonHandler, terminado.TermSocket):
 
     def origin_check(self):

--- a/notebook/terminal/handlers.py
+++ b/notebook/terminal/handlers.py
@@ -3,6 +3,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import json
 from tornado import web
 import terminado
 from notebook._tz import utcnow
@@ -19,11 +20,17 @@ class TerminalHandler(IPythonHandler):
 
 
 class NewTerminalHandler(IPythonHandler):
-    """Render the terminal interface."""
+    """Renders a new terminal interface using the named argument."""
     @web.authenticated
     def get(self, term_name):
-        self.terminal_manager.create_with_name(term_name)
         new_path = self.request.path.replace("new/{}".format(term_name), term_name)
+        if term_name in self.terminal_manager.terminals:
+            self.set_header('Location', new_path)
+            self.set_status(302)
+            self.finish(json.dumps(self.terminal_manager.get_terminal_model(term_name)))
+            return
+
+        self.terminal_manager.create_with_name(term_name)
         self.redirect(new_path)
 
 

--- a/notebook/terminal/handlers.py
+++ b/notebook/terminal/handlers.py
@@ -15,18 +15,22 @@ class TerminalHandler(IPythonHandler):
     """Render the terminal interface."""
     @web.authenticated
     def get(self, term_name):
-        if term_name == 'new':
-            model = self.terminal_manager.create()
-            term_name = model['name']
-            new_path = self.request.path.replace("terminals/new", "terminals/" + term_name)
-            self.redirect(new_path)
-        else:
-            self.write(self.render_template('terminal.html',
+        self.write(self.render_template('terminal.html',
                        ws_path="terminals/websocket/%s" % term_name))
 
 
+class NamedTerminalHandler(IPythonHandler):
+    """Creates and renders a named terminal interface."""
+    @web.authenticated
+    def get(self):
+        model = self.terminal_manager.create()
+        term_name = model['name']
+        new_path = self.request.path.replace("terminals/new", "terminals/" + term_name)
+        self.redirect(new_path)
+
+
 class NewTerminalHandler(IPythonHandler):
-    """Renders a new terminal interface using the named argument."""
+    """Creates and renders a terminal interface using the named argument."""
     @web.authenticated
     def get(self, term_name):
         if term_name == 'new':

--- a/notebook/terminal/handlers.py
+++ b/notebook/terminal/handlers.py
@@ -15,14 +15,22 @@ class TerminalHandler(IPythonHandler):
     """Render the terminal interface."""
     @web.authenticated
     def get(self, term_name):
-        self.write(self.render_template('terminal.html',
-                   ws_path="terminals/websocket/%s" % term_name))
+        if term_name == 'new':
+            model = self.terminal_manager.create()
+            term_name = model['name']
+            new_path = self.request.path.replace("terminals/new", "terminals/" + term_name)
+            self.redirect(new_path)
+        else:
+            self.write(self.render_template('terminal.html',
+                       ws_path="terminals/websocket/%s" % term_name))
 
 
 class NewTerminalHandler(IPythonHandler):
     """Renders a new terminal interface using the named argument."""
     @web.authenticated
     def get(self, term_name):
+        if term_name == 'new':
+            raise web.HTTPError(400, "Terminal name 'new' is reserved.")
         new_path = self.request.path.replace("new/{}".format(term_name), term_name)
         if term_name in self.terminal_manager.terminals:
             self.set_header('Location', new_path)

--- a/notebook/terminal/terminalmanager.py
+++ b/notebook/terminal/terminalmanager.py
@@ -44,6 +44,16 @@ class TerminalManager(LoggingConfigurable, NamedTermManager):
     def create(self):
         """Create a new terminal."""
         name, term = self.new_named_terminal()
+        return self._finish_create(name, term)
+
+    def create_with_name(self, name):
+        """Create a new terminal."""
+        if name in self.terminals:
+            raise web.HTTPError(409, "A terminal with name '{}' already exists.".format(name))
+        term = self.get_terminal(name)
+        return self._finish_create(name, term)
+
+    def _finish_create(self, name, term):
         # Monkey-patch last-activity, similar to kernels.  Should we need
         # more functionality per terminal, we can look into possible sub-
         # classing or containment then.

--- a/notebook/terminal/tests/test_terminals_api.py
+++ b/notebook/terminal/tests/test_terminals_api.py
@@ -76,8 +76,16 @@ class TerminalAPITest(NotebookTestBase):
         self.assertIsInstance(foo_term, dict)
         self.assertEqual(foo_term['name'], 'foo')
 
-        with assert_http_error(409):
-            self.term_api._req('GET', 'terminals/new/foo')
+        # hit the same endpoint a second time and ensure 302 with Location is returned
+        r = self.term_api._req('GET', 'terminals/new/foo')
+        # Access the "interesting" response from the history
+        self.assertEqual(len(r.history), 1)
+        r = r.history[0]
+        foo_term = r.json()
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(r.headers['Location'], self.url_prefix + "terminals/foo")
+        self.assertIsInstance(foo_term, dict)
+        self.assertEqual(foo_term['name'], 'foo')
 
         r = self.term_api.shutdown('foo')
         self.assertEqual(r.status_code, 204)

--- a/notebook/terminal/tests/test_terminals_api.py
+++ b/notebook/terminal/tests/test_terminals_api.py
@@ -54,7 +54,7 @@ class TerminalAPITest(NotebookTestBase):
             self.term_api.shutdown(k['name'])
 
     def test_no_terminals(self):
-        # Make sure there are no terminals running at the start
+        # Make sure there are no terminals are running at the start
         terminals = self.term_api.list().json()
         self.assertEqual(terminals, [])
 
@@ -64,6 +64,27 @@ class TerminalAPITest(NotebookTestBase):
         term1 = r.json()
         self.assertEqual(r.status_code, 200)
         self.assertIsInstance(term1, dict)
+
+    def test_create_terminal_via_get(self):
+        # Test creation of terminal via GET against terminals/new/<name>
+        r = self.term_api._req('GET', 'terminals/new/foo')
+        self.assertEqual(r.status_code, 200)
+
+        r = self.term_api.get('foo')
+        foo_term = r.json()
+        self.assertEqual(r.status_code, 200)
+        self.assertIsInstance(foo_term, dict)
+        self.assertEqual(foo_term['name'], 'foo')
+
+        with assert_http_error(409):
+            self.term_api._req('GET', 'terminals/new/foo')
+
+        r = self.term_api.shutdown('foo')
+        self.assertEqual(r.status_code, 204)
+
+        # Make sure there are no terminals are running
+        terminals = self.term_api.list().json()
+        self.assertEqual(terminals, [])
 
     def test_terminal_root_handler(self):
         # POST request


### PR DESCRIPTION
This pull request adds back support for creating new terminal sessions via an HTTP `GET` request against `/terminals/new/<name>`.  Upon its creation, the user is redirected to `/terminals/<name>`.  Attempts to issue a `GET` request to `/terminals/new/<name>` when terminal `<name>` is already created will result in a `409` (Conflict) status code.

I based these changes on the comments provided by @rgbkrk and @blink1073 on #4180.

Although this feature was previously "hidden", it sounds like it was quite useful and I believe this should be considered somewhat of a regression issue.  That said, this "fix" results in a change in user behavior, but I'd prefer we allow for that since the feature was not explicit previously.

This seems to address the issue, but this is relatively unfamiliar territory for me, so I'm hoping others can take it for a spin and/or let me know what else should be done.

Resolves #5790