### PR TITLE
Add wasm mimetype override

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -2000,6 +2000,8 @@ class NotebookApp(JupyterApp):
         # ensure css, js are correct, which are required for pages to function
         mimetypes.add_type('text/css', '.css')
         mimetypes.add_type('application/javascript', '.js')
+        # for python <3.8
+        mimetypes.add_type('application/wasm', '.wasm')
 
     def shutdown_no_activity(self):
         """Shutdown server on timeout when there are no kernels or terminals."""


### PR DESCRIPTION
Some older pythons' (all 3.6, at least 3.7.0, but not the latest 3.7.8) `mimetypes` don't guess `.wasm` (WebAssembly) files correctly, which causes problems for extensions that wish to use this technology, as browsers will not interpret them if not served with the correct `Content-Type`. Since we're already adding types for other common files, it seems reasonable to do so here.

Ref: https://github.com/jupyter/jupyter_server/pull/328 