### PR TITLE
Restore ctrl-enter shortcut behavior for macOS users

### DIFF
--- a/notebook/static/notebook/js/keyboardmanager.js
+++ b/notebook/static/notebook/js/keyboardmanager.js
@@ -105,6 +105,7 @@ define([
             'shift'       : 'jupyter-notebook:ignore',
             'shift-enter' : 'jupyter-notebook:run-cell-and-select-next',
             'alt-enter'   : 'jupyter-notebook:run-cell-and-insert-below',
+            'ctrl-enter'  : 'jupyter-notebook:run-cell',
             // cmd on mac, ctrl otherwise
             'cmdtrl-enter'  : 'jupyter-notebook:run-cell',
             'cmdtrl-s'    : 'jupyter-notebook:save-notebook'


### PR DESCRIPTION
This change restores the `ctrl-enter` shortcut for executing a cell that was side-effected by #5120.  With this change, macOS users will have two shortcuts to perform cell execution: 1) `cmd-enter`, added in #5120 for a better mac UX, and 2) `ctrl-enter` the "standard" shortcut previously in use for years who's behavior was inadvertently removed.

Resolves #5794