### PR TITLE
Prevent redirect loop if query params are present in url

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -856,9 +856,13 @@ class TrailingSlashHandler(web.RequestHandler):
     
     This should be the first, highest priority handler.
     """
-    
+
     def get(self):
-        self.redirect(self.request.uri.rstrip('/'))
+        uri = self.request.uri
+        new_uri = uri.rstrip('/')
+        if new_uri == uri and '/?' in new_uri:
+            new_uri = '?'.join(new_uri.rsplit('/?'))
+        self.redirect(new_uri)
     
     post = put = get
 


### PR DESCRIPTION
TrailingSlashHandler can cause redirect loop if the URL contains query params. This can happen in Firefox, it appends a redirects=1 after the URL.