### PR TITLE
Allow toggling auth for prometheus metrics

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -914,8 +914,10 @@ class PrometheusMetricsHandler(IPythonHandler):
     """
     Return prometheus metrics for this notebook server
     """
-    @web.authenticated
     def get(self):
+        if self.settings['authenticate_prometheus'] and not self.logged_in:
+            raise web.HTTPError(403)
+
         self.set_header('Content-Type', prometheus_client.CONTENT_TYPE_LATEST)
         self.write(prometheus_client.generate_latest(prometheus_client.REGISTRY))
 

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -283,6 +283,7 @@ class NotebookWebApplication(web.Application):
             disable_check_xsrf=jupyter_app.disable_check_xsrf,
             allow_remote_access=jupyter_app.allow_remote_access,
             local_hostnames=jupyter_app.local_hostnames,
+            authenticate_prometheus=jupyter_app.authenticate_prometheus,
 
             # managers
             kernel_manager=kernel_manager,
@@ -1550,6 +1551,13 @@ class NotebookApp(JupyterApp):
          Terminals may also be automatically disabled if the terminado package
          is not available.
          """))
+
+    authenticate_prometheus = Bool(
+        True,
+        help=""""
+        Require authentication to access prometheus metrics.
+        """
+    ).tag(config=True)
 
     # Since use of terminals is also a function of whether the terminado package is
     # available, this variable holds the "final indication" of whether terminal functionality


### PR DESCRIPTION
Equivalent to https://github.com/jupyterhub/jupyterhub/pull/2224

Prometheus metrics can potentially leak information about
the user, so they should be kept behind auth by default.
However, for many JupyterHub deployments, they would need
to be scraped by a centralized Prometheus instance that can not
really authenticate separately to each user notebook without
a lot of work. Admins can use this setting to allow unauthenticated
access to the /metrics endpoint.