### PR TITLE
feat: set RLIMIT_AS based on cgroups

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1667,6 +1667,16 @@ class NotebookApp(JupyterApp):
             )
             resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
 
+        if os.path.isfile('/sys/fs/cgroup/memory/memory.limit_in_bytes'):
+            old_soft, old_hard = resource.getrlimit(resource.RLIMIT_AS)
+            with open('/sys/fs/cgroup/memory/memory.limit_in_bytes') as limit:
+                soft = int(limit.read())
+                hard = soft
+                self.log.debug(
+                    'Setting memory limit from cgroups: soft {}->{}; hard {}->{}'.format(old_soft, soft, old_hard, hard)
+                )
+                resource.setrlimit(resource.RLIMIT_AS, (soft, hard))
+
     def init_webapp(self):
         """initialize tornado webapp and httpserver"""
         self.tornado_settings['allow_origin'] = self.allow_origin


### PR DESCRIPTION
This should help avoid having the kernel oomkilled when running in a docker container with memory limits set.

I'm not well-versed on python, please let me know if I didn't follow any good patterns or if there is a better way of doing this.