### PR TITLE
Added section for file editor configuration

### DIFF
--- a/docs/source/frontend_config.rst
+++ b/docs/source/frontend_config.rst
@@ -48,6 +48,18 @@ to reissue the patch on new notebooks.
 <https://codemirror.net/doc/manual.html#option_indentUnit>`_ which are available
 for configuration.
 
+You can similarly change the options of the file editor by entering the following
+snippet in the browser's Javascript console once (from a file editing page).::
+
+   var config = Jupyter.editor.config
+   var patch = {
+         Editor: {
+           codemirror_options: {
+             indentUnit: 2
+           }
+         }
+       }
+   config.update(patch)
 
 Example - Restoring the notebook's default indentation
 ------------------------------------------------------


### PR DESCRIPTION
The doc shows how to update codemirror options for the notebook cell editor, but not for the whole file editor. I have added lines 51-62 to give that information. The information comes from Stack-Overflow (and has been tested), but it has been frustratingly long to find, so I think it is worth sharing ...