### PR TITLE
Handle TrashPermissionError, now that it exists

### DIFF
--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -15,6 +15,7 @@ import mimetypes
 import nbformat
 
 from send2trash import send2trash
+from send2trash.exceptions import TrashPermissionError
 from tornado import web
 
 from .filecheckpoints import FileCheckpoints
@@ -512,17 +513,6 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         if not os.path.exists(os_path):
             raise web.HTTPError(404, u'File or directory does not exist: %s' % os_path)
 
-        def _check_trash(os_path):
-            if sys.platform in {'win32', 'darwin'}:
-                return True
-
-            # It's a bit more nuanced than this, but until we can better
-            # distinguish errors from send2trash, assume that we can only trash
-            # files on the same partition as the home directory.
-            file_dev = os.stat(os_path).st_dev
-            home_dev = os.stat(os.path.expanduser('~')).st_dev
-            return file_dev == home_dev
-
         def is_non_empty_dir(os_path):
             if os.path.isdir(os_path):
                 # A directory containing only leftover checkpoints is
@@ -538,16 +528,12 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
                 # send2trash can really delete files on Windows, so disallow
                 # deleting non-empty files. See Github issue 3631.
                 raise web.HTTPError(400, u'Directory %s not empty' % os_path)
-            if _check_trash(os_path):
+            try:
                 self.log.debug("Sending %s to trash", os_path)
-                # Looking at the code in send2trash, I don't think the errors it
-                # raises let us distinguish permission errors from other errors in
-                # code. So for now, just let them all get logged as server errors.
                 send2trash(os_path)
                 return
-            else:
-                self.log.warning("Skipping trash for %s, on different device "
-                                 "to home directory", os_path)
+            except TrashPermissionError as e:
+                self.log.warning("Skipping trash for %s, %s", os_path, e)
 
         if os.path.isdir(os_path):
             # Don't permanently delete non-empty directories.

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ for more information.
         'nbformat',
         'nbconvert',
         'ipykernel', # bless IPython kernel for now
-        'Send2Trash',
+        'Send2Trash>=1.5.0',
         'terminado>=0.8.3',
         'prometheus_client'
     ],


### PR DESCRIPTION
In Ubuntu's automated test environment [full log example](https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-hirsute/hirsute/amd64/j/jupyter-notebook/20201110_184225_68a35@/log.gz), both HOME and the temporary directories are likely to be on a tmpfs. That will cause
`gi.repository.GLib.GError: g-io-error-quark: Trashing on system internal mounts is not supported (15)` which will raise a `TrashPermissionError`.

As the comments in the code indicate, `_check_trash()` was added (in #3304) because `TrashPermissionError` didn't
exist, yet. We asked send2trash to implement such an exception, so that we wouldn't have to guess whether a file was trash-able or not, and they did. So, let's take advantage of it.

Because we don't permanently delete, recursively, `test_delete_non_empty_dir` will now fail in environments where the test data isn't trash-able. So, handle that, and skip the test gracefully.

Closes: #3374