### PR TITLE
Add an issue template and issue landing page.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ If you're having issues installing Jupyter Notebook, or you're having another is
 
 1. scan the "What to do when things go wrong" (https://jupyter-notebook.readthedocs.io/en/stable/troubleshooting.html#what-to-do-when-things-go-wrong) page in our documentation to see if your question has already been answered
 
-2. post your question on the Jupyter Notebook discourse channel (https://discourse.jupyter.org/c/notebook/31). There are many more people in the Jupyter community that engage on this channel.
+2. post your question on the Jupyter Notebook discourse channel (https://discourse.jupyter.org/c/notebook/31). There are many more people in the Jupyter community that engage on that channel.
 -->
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Is this a bug in Notebook? Open an issue.
+about: If you're not sure, feel free to post your question on Jupyter's Discourse channel.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+BEFORE YOU OPEN AN ISSUE, PLEASE READ THIS
+
+Hello! Thank you for using Jupyter Notebook. We're glad you're here.
+
+Right now, you're opening an issue. Before you do, let's make sure this is the right place to post your question/issue.
+
+First, it's important to know that Jupyter Notebook development has moved into a phase of maintenance-only. There are very few people with limited time maintaining this repository. This means, we won't likely accept new features here. Instead, we recommend that you check out JupyterLab (https://github.com/jupyterlab/jupyterlab)—Jupyter's next generation Notebook interface.
+
+Here, we're looking for specific bugs in the Jupyter Notebook codebase. If you think you've identified such a bug, you can continue opening your issue here. We'd appreciate if you include as much detail as possible, i.e. links to the offending code, snapshots of the UI issue, code-blocks with your console logs, etc.
+
+If you're having issues installing Jupyter Notebook, or you're having another issue and don't know how to proceed, try the following:
+
+1. scan the "What to do when things go wrong" (https://jupyter-notebook.readthedocs.io/en/stable/troubleshooting.html#what-to-do-when-things-go-wrong) page in our documentation to see if your question has already been answered
+
+2. post your question on the Jupyter Notebook discourse channel (https://discourse.jupyter.org/c/notebook/31). There are many more people in the Jupyter community that engage on this channel.
+-->
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Is this a common issue? See our Docs.
+    url: https://jupyter-notebook.readthedocs.io/en/stable/troubleshooting.html#what-to-do-when-things-go-wrong
+    about: Before posting an issue here, make sure your issue hasn't already been addressed here.
+  - name: Do you need support or a question answered? See Jupyter Discourse.
+    url: https://discourse.jupyter.org/c/notebook/31
+    about: If you have a question or you're having issues installing Jupyter Notebook, try posting on Discourse. There are lots of friendly Joyvans there to help!
+  - name: Do you have a feature request? See JupyterLab.
+    url: https://github.com/jupyterlab/jupyterlab
+    about: Jupyter Notebook is in a maintenance-only phase. We won't likely accept new features; instead, we recommend you check out JupyterLab for new features and support.


### PR DESCRIPTION
Here's a snapshot of the landing page.

![Screen Shot 2020-12-02 at 11 19 16 AM](https://user-images.githubusercontent.com/2791223/100922514-d6e2f600-3492-11eb-8923-df954cfe2924.png)

The goal is to redirect user questions to discourse, feature requests to jupyterlab, and slow down issues posted here that aren't thorough bug reports.