### PR TITLE
handle allow_origin='*' in check_referer

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -404,6 +404,10 @@ class IPythonHandler(AuthenticatedHandler):
         Used on GET for api endpoints and /files/
         to block cross-site inclusion (XSSI).
         """
+
+        if self.allow_origin == "*" or self.skip_check_origin():
+            return True
+
         host = self.request.headers.get("Host")
         referer = self.request.headers.get("Referer")
 


### PR DESCRIPTION
allow_origin can be the wildcard '*' to allow any host

applies logic already in check_origin to check_referer
