### PR TITLE
Prevent missing IOPub upon restart

### DIFF
--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -156,7 +156,7 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
         
         enabling msg spec adaptation, if necessary
         """
-        idents,msg = self.session.feed_identities(msg)
+        idents, msg = self.session.feed_identities(msg)
         try:
             msg = self.session.deserialize(msg)
         except:


### PR DESCRIPTION
Upon restart, nedge the kernel with info requests until we get something on IOPub, to ensure it is properly connected.

CF https://github.com/jupyter/jupyter_client/issues/593