### PR TITLE
do not apply asyncio patch for tornado >=6.1

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -2041,7 +2041,7 @@ class NotebookApp(JupyterApp):
     def _init_asyncio_patch(self):
         """set default asyncio policy to be compatible with tornado
 
-        Tornado 6 (at least) is not compatible with the default
+        Tornado <6.1 is not compatible with the default
         asyncio implementation on Windows
 
         Pick the older SelectorEventLoopPolicy on Windows
@@ -2054,7 +2054,7 @@ class NotebookApp(JupyterApp):
         FIXME: if/when tornado supports the defaults in asyncio,
                remove and bump tornado requirement for py38
         """
-        if sys.platform.startswith("win") and sys.version_info >= (3, 8):
+        if sys.platform.startswith("win") and sys.version_info >= (3, 8) and tornado.version_info < (6, 1):
             import asyncio
             try:
                 from asyncio import (


### PR DESCRIPTION
Tornado 6.1 now no longer requires the asyncio patch on windows for python >=3.8. :tada: 

On https://github.com/jupyter-server/jupyter_server/pull/339, we went with a hard cut to _require_ 6.1, and remove the patch, but this PR applies the lighter touch from https://github.com/ipython/ipykernel/pull/564 of just not applying the patch.

Fixing this is good, as the error manifests itself as unkillable python hang on windows, timing out CI.