### PR TITLE
Ensure that cell ids persist after save

### DIFF
--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -490,6 +490,9 @@ define([
         var data = {};
         // deepcopy the metadata so copied cells don't share the same object
         data.metadata = JSON.parse(JSON.stringify(this.metadata));
+        if (this.id !== undefined) {
+            data.id = this.id;
+        }
         if (data.metadata.deletable) {
             delete data.metadata.deletable;
         }
@@ -510,6 +513,9 @@ define([
     Cell.prototype.fromJSON = function (data) {
         if (data.metadata !== undefined) {
             this.metadata = data.metadata;
+        }
+        if (data.id !== undefined) {
+            this.id = data.id;
         }
     };
 

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -1648,6 +1648,9 @@ define([
             if (cell_json.metadata.deletable !== undefined) {
                 delete cell_json.metadata.deletable;
             }
+            if (cell_json.id !== undefined) {
+                delete cell_json.id;
+            }
             this.clipboard.push(cell_json);
         }
         this.enable_paste();


### PR DESCRIPTION
### Summary
This PR ensures that if an `'id'` field exists for a cell when the notebook is loaded, the same `'id'` value is saved for the given cell when the notebook is saved.

The previous behaviour was that a new random `'id'` value was generated every time for each cell. 

### Details

As of nbformat schema 4.5, cells now have a mandatory `'id'` field for each cell:
   - https://nbformat.readthedocs.io/en/latest/format_description.html#cell-ids
   - https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md
   - https://github.com/jupyter/nbformat/pull/189

If this field does not exist for a given cell, nbformat will generate a new value for that field. 

When a cell is loaded by notebook using the `fromJson` function, this `'id'` field is ignored and when the cell is saved, nbformat sees there is no `'id'` and randomly generates a new one.

With this PR, the `'id'` field is saved to the cell data and then sent back to nbformat when the cell is saved so the cell id remains consistent between saves.

This PR also ensures that when cells are copied, the cell `'id'` is removed, meaning that nbformat will generate a new id for it when it is saved. This is required because cell ids must be unique within a notebook.

### Why this is important

Tools, plugins, etc. that use cell ids will expect the cell ids to remain consistent between saves. Use of ids in plugins is one of the main reasons for adding the id field in the first place:

- https://github.com/jupyter/enhancement-proposals/blob/master/62-cell-id/cell-id.md#recommended-application--usage-of-id-field