### PR TITLE
Increase minimum tornado version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ for more information.
     zip_safe = False,
     install_requires = [
         'jinja2',
-        'tornado>=5.0',
+        'tornado>=6.1',
         # pyzmq>=17 is not technically necessary,
         # but hopefully avoids incompatibilities with Tornado 5. April 2018
         'pyzmq>=17',


### PR DESCRIPTION
As noted in #5920, the fix for #5908 introduces a requirement on tornado 6.0.  Since #5907 also _prefers_ tornado 6.1 (although doesn't require it), we might as well bump things to 6.1.

Fixes #5920