### PR TITLE
Add shim to mathjaxutils.js

### DIFF
--- a/notebook/static/notebook/js/mathjaxutils.js
+++ b/notebook/static/notebook/js/mathjaxutils.js
@@ -1,0 +1,8 @@
+
+define([
+    'base/js/mathjaxutils'
+], function(mathjaxutils) {
+    "use strict"
+
+    return mathjaxutils;
+});


### PR DESCRIPTION
This addresses the issues raised here: [jupyter/notebook#5488 (comment)](https://github.com/jupyter/notebook/pull/5488#issuecomment-758864993)

In [#5488](https://github.com/jupyter/notebook/pull/5488), the mathjaxutils.js file was moved. This is unintentionally API breaking and causes issues for extensions like [jupyter_nbextensions_configurator](https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator/issues/125).

This PR adds a simple shim to catch the old path.

cc: @Zsailer 