### PR TITLE
Re-enable support for answer_yes flag

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1906,6 +1906,13 @@ class NotebookApp(JupyterApp):
         """
         info = self.log.info
         info(_('interrupted'))
+        # Check if answer_yes is set
+        if self.answer_yes:
+            self.log.critical(_("Shutting down..."))
+            # schedule stop on the main thread,
+            # since this might be called from a signal handler
+            self.io_loop.add_callback_from_signal(self.io_loop.stop)
+            return
         print(self.notebook_info())
         yes = _('y')
         no = _('n')


### PR DESCRIPTION
This fixes a bug. When user want's to shutdown the notebook server without confirmation, they should be able to call:

```
jupyter notebook -y
```