### PR TITLE
Run next input handler

### DIFF
--- a/notebook/static/notebook/js/codecell.js
+++ b/notebook/static/notebook/js/codecell.js
@@ -389,6 +389,7 @@ define([
             shell : {
                 reply : $.proxy(this._handle_execute_reply, this),
                 payload : {
+                    run_next_input : $.proxy(this._handle_run_next_input, this),
                     set_next_input : $.proxy(this._handle_set_next_input, this),
                     page : $.proxy(this._open_with_pager, this)
                 }
@@ -420,6 +421,20 @@ define([
         this.element.removeClass("running");
         this.events.trigger('set_dirty.Notebook', {value: true});
     };
+
+    /**
+     * @method _handle_run_next_input
+     * @private
+     */
+    CodeCell.prototype._handle_run_next_input = function (payload) {
+        var data = {
+            cell: this,
+            text: payload.text,
+            replace: payload.replace,
+            clear_output: payload.clear_output,
+        };
+        this.events.trigger('run_next_input.Notebook', data);
+    }
 
     /**
      * @method _handle_set_next_input

--- a/notebook/static/notebook/js/notebook.js
+++ b/notebook/static/notebook/js/notebook.js
@@ -257,6 +257,21 @@ define([
     Notebook.prototype.bind_events = function () {
         var that = this;
 
+        this.events.on('run_next_input.Notebook', function (event, data) {
+            if (data.replace) {
+                data.cell.set_text(data.text);
+                if (data.clear_output !== false) {
+                  // default (undefined) is true to preserve prior behavior
+                  data.cell.clear_output();
+                }
+            } else {
+                var index = that.find_cell_index(data.cell);
+                var new_cell = that.insert_cell_below('code',index);
+                new_cell.set_text(data.text);
+            }
+
+	    new_cell.execute()
+        });
 
         this.events.on('set_next_input.Notebook', function (event, data) {
             if (data.replace) {


### PR DESCRIPTION
Hey all,

Many Jupyter users have difficulty running cells programmatically, and they resort to embedding JavaScript into their widgets to do so.  This isn't portable across Jupyter versions.

I think since `set_next_input` is handled, it would make sense to have `run_next_input`.

Here is the corresponding ipython kernel PR.

https://github.com/ipython/ipykernel/pull/583