### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/notebook/_version.py
+++ b/notebook/_version.py
@@ -9,5 +9,5 @@ store the current version info of the notebook.
 
 # Next beta/alpha/rc release: The version number for beta is X.Y.ZbN **without dots**.
 
-version_info = (7, 0, 0, '.dev0')
+version_info = (6, 3, 0, '.dev0')
 __version__ = '.'.join(map(str, version_info[:3])) + ''.join(version_info[3:])

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1611,9 +1611,6 @@ class NotebookApp(JupyterApp):
         )
         #  Ensure the appropriate version of Python and jupyter_client is available.
         if isinstance(self.kernel_manager, AsyncMappingKernelManager):
-            if sys.version_info < (3, 6):  # Can be removed once 3.5 is dropped.
-                raise ValueError("You are using `AsyncMappingKernelManager` in Python 3.5 (or lower) "
-                                 "which is not supported. Please upgrade Python to 3.6+ or change kernel managers.")
             if not async_kernel_mgmt_available:  # Can be removed once jupyter_client >= 6.1 is required.
                 raise ValueError("You are using `AsyncMappingKernelManager` without an appropriate "
                                  "jupyter_client installed!  Please upgrade jupyter_client or change kernel managers.")

--- a/notebook/services/kernels/tests/test_kernels_api.py
+++ b/notebook/services/kernels/tests/test_kernels_api.py
@@ -204,8 +204,6 @@ class AsyncKernelAPITest(KernelAPITest):
     def setup_class(cls):
         if not async_testing_enabled:  # Can be removed once jupyter_client >= 6.1 is required.
             raise SkipTest("AsyncKernelAPITest tests skipped due to down-level jupyter_client!")
-        if sys.version_info < (3, 6):  # Can be removed once 3.5 is dropped.
-            raise SkipTest("AsyncKernelAPITest tests skipped due to Python < 3.6!")
         super(AsyncKernelAPITest, cls).setup_class()
 
     @classmethod

--- a/notebook/services/sessions/tests/test_sessions_api.py
+++ b/notebook/services/sessions/tests/test_sessions_api.py
@@ -273,8 +273,6 @@ class AsyncSessionAPITest(SessionAPITest):
     def setup_class(cls):
         if not async_testing_enabled:  # Can be removed once jupyter_client >= 6.1 is required.
             raise SkipTest("AsyncSessionAPITest tests skipped due to down-level jupyter_client!")
-        if sys.version_info < (3, 6):  # Can be removed once 3.5 is dropped.
-            raise SkipTest("AsyncSessionAPITest tests skipped due to Python < 3.6!")
         super(AsyncSessionAPITest, cls).setup_class()
 
     @classmethod

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -73,7 +73,7 @@ define(function(){
     // tree
     jglobal('SessionList','tree/js/sessionlist');
 
-    Jupyter.version = "7.0.0.dev0";
+    Jupyter.version = "6.3.0.dev0";
     Jupyter._target = '_blank';
 
     return Jupyter;

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import sys
 
 name = "notebook"
 
-if sys.version_info < (3, 5):
+if sys.version_info < (3, 6):
     pip_message = 'This may be due to an out of date pip. Make sure you have pip >= 9.0.1.'
     try:
         import pip
@@ -31,7 +31,8 @@ if sys.version_info < (3, 5):
 
 
     error = """
-Notebook 6.0+ supports Python 3.5 and above.
+Notebook 6.3+ supports Python 3.6 and above.
+When using Python 3.5, please install Notebook <= 6.2.
 When using Python 3.4 or earlier (including 2.7), please install Notebook 5.x.
 
 Python {py} detected.
@@ -90,10 +91,10 @@ for more information.
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8'
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9'
     ],
     zip_safe = False,
     install_requires = [
@@ -121,7 +122,7 @@ for more information.
         'test:sys_platform != "win32"': ['requests-unixsocket'],
         'json-logging': ['json-logging']
     },
-    python_requires = '>=3.5',
+    python_requires = '>=3.6',
     entry_points = {
         'console_scripts': [
             'jupyter-notebook = notebook.notebookapp:main',


### PR DESCRIPTION
This change drops support for Python 3.5 (preferably in the next minor release: 6.3).  Python 3.5 was EOL last September and hasn't been included in the CI runs since moving to GH actions.  Since Python 3.9 has been included in recent CI runs, I've gone ahead and added it to the set of supported Python releases.

I've also updated the _dev version_ to be based on the next _minor_ release rather than the next major release.

