### PR TITLE
Skip terminal tests on Windows 3.9+ (temporary)

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: [ '3.6' , '3.7', '3.8', '3.9' ] # Windows 3.9 fails due to the pywinpty dependency not working
+        python-version: [ '3.6' , '3.7', '3.8', '3.9' ] # Windows 3.9 fails due to the pywinpty dependency not working (Issue #5967)
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/notebook/conftest.py
+++ b/notebook/conftest.py
@@ -1,0 +1,10 @@
+
+import pytest
+
+import sys
+
+# TODO: Remove this hook once Issue #5967 is resolved.
+def pytest_ignore_collect(path):
+    if str(path).endswith("test_terminals_api.py"):
+        if sys.platform.startswith('win') and sys.version_info >= (3, 9):
+            return True  # do not collect


### PR DESCRIPTION
This change adds a pytest collection hook that ignores the terminals tests when encountered on Windows platforms running Python >= 3.9.  Once issue #5967 has been resolved, this PR should be rolled back.  As a result, each change identifies the issue to assist tracking.