### PR TITLE
Allow /metrics by default if auth is off

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1584,6 +1584,21 @@ class NotebookApp(JupyterApp):
         """
     ).tag(config=True)
 
+    @default('authenticate_prometheus')
+    def _default_authenticate_prometheus(self):
+        """ Authenticate Prometheus by default, unless auth is disabled. """
+        auth = bool(self.password) or bool(self.token)
+        if auth is False:
+            self.log.info(_("Authentication of /metrics is OFF, since other authentication is disabled."))
+        return auth
+
+    @observe('authenticate_prometheus')
+    def _update_authenticate_prometheus(self, change):
+        newauth = change['new']
+        if self.authenticate_prometheus is True and newauth is False:
+            self.log.info(_("Authentication of /metrics is being turned OFF."))
+        self.authenticate_prometheus = newauth
+
     # Since use of terminals is also a function of whether the terminado package is
     # available, this variable holds the "final indication" of whether terminal functionality
     # should be considered (particularly during shutdown/cleanup).  It is enabled only


### PR DESCRIPTION
Resolves #5973 

How to test:

Use this dockerfile to compare

```Dockerfile
FROM jupyter/minimal-notebook:5cb007f03275  
RUN pip3 install -U git+git://github.com/blairdrummond/notebook.git@prometheus-auth-default
```

And run `docker build . -t jupyter-prom-test`

# Using the old image, `/metrics` is blocked even if auth is off

```bash
# Auth is ENABLED
docker run -p 8888:8888 \
    -e JUPYTER_ENABLE_LAB=yes  \
     jupyter/minimal-notebook:5cb007f03275 jupyter notebook \
    --no-browser --ip=0.0.0.0  --ServerApp.allow_origin='*'

# Doesn't work, which is GOOD
curl http://0.0.0.0:8888/metrics

# Works
TOKEN=XXXXXXXXX
curl "http://0.0.0.0:8888/metrics?token=$TOKEN"

# Auth is OFF
docker run -p 8888:8888 \
    -e JUPYTER_ENABLE_LAB=yes  \
     jupyter/minimal-notebook:5cb007f03275 jupyter notebook \
    --no-browser --ip=0.0.0.0  --ServerApp.allow_origin='*' \
    --NotebookApp.token='' --ServerApp.password=''

##############################
# Doesn't work, which is BAD!!!!!!!!!!!!
curl http://0.0.0.0:8888/metrics
```

# Using the new image

```bash
# Auth is ENABLED
docker run -p 8888:8888 \
    -e JUPYTER_ENABLE_LAB=yes  \
    jupyter-prom-test jupyter notebook \
    --no-browser --ip=0.0.0.0  --ServerApp.allow_origin='*'

# Doesn't work, which is GOOD
curl http://0.0.0.0:8888/metrics

# Works
TOKEN=XXXXXXXXX
curl "http://0.0.0.0:8888/metrics?token=$TOKEN"

# Auth is OFF
docker run -p 8888:8888 \
    -e JUPYTER_ENABLE_LAB=yes  \
    jupyter-prom-test jupyter notebook \
    --no-browser --ip=0.0.0.0  --ServerApp.allow_origin='*' \
    --NotebookApp.token='' --ServerApp.password=''

##############################
# Works!!! Which is GOOD!!!!!!!!!!!!
curl http://0.0.0.0:8888/metrics
```




