### PR TITLE
[Gateway] Track only this server's kernels

### DIFF
--- a/notebook/gateway/managers.py
+++ b/notebook/gateway/managers.py
@@ -435,8 +435,13 @@ class GatewayKernelManager(AsyncMappingKernelManager):
                 raise
         else:
             kernel = json_decode(response.body)
-            self._kernels[kernel_id] = kernel
-        self.log.debug("Kernel retrieved: %s" % kernel)
+            # Only update our models if we already know about this kernel
+            if kernel_id in self._kernels:
+                self._kernels[kernel_id] = kernel
+                self.log.debug("Kernel retrieved: %s", kernel)
+            else:
+                self.log.warning("Kernel '%s' is not managed by this instance.", kernel_id)
+                kernel = None
         return kernel
 
     async def kernel_model(self, kernel_id):
@@ -458,8 +463,9 @@ class GatewayKernelManager(AsyncMappingKernelManager):
         self.log.debug("Request list kernels: %s", kernel_url)
         response = await gateway_request(kernel_url, method='GET')
         kernels = json_decode(response.body)
-        self._kernels = {x['id']: x for x in kernels}
-        return kernels
+        # Only update our models if we already know about the kernels
+        self._kernels = {x['id']: x for x in kernels if x['id'] in self._kernels}
+        return list(self._kernels.values())
 
     async def shutdown_kernel(self, kernel_id, now=False, restart=False):
         """Shutdown a kernel by its kernel uuid.
@@ -512,7 +518,7 @@ class GatewayKernelManager(AsyncMappingKernelManager):
         kwargs = {'method': 'DELETE'}
         kwargs = GatewayClient.instance().load_connection_args(**kwargs)
         client = HTTPClient()
-        for kernel_id in self._kernels.keys():
+        for kernel_id in self._kernels:
             kernel_url = self._get_kernel_endpoint_url(kernel_id)
             self.log.debug("Request delete kernel at: %s", kernel_url)
             try:

--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -54,9 +54,10 @@ class MainKernelHandler(APIHandler):
 class KernelHandler(APIHandler):
 
     @web.authenticated
+    @gen.coroutine
     def get(self, kernel_id):
         km = self.kernel_manager
-        model = km.kernel_model(kernel_id)
+        model = yield maybe_future(km.kernel_model(kernel_id))
         self.finish(json.dumps(model, default=date_default))
 
     @web.authenticated


### PR DESCRIPTION
While working on Enterprise Gateway, I found that if a gateway server is hosting kernels from multiple lab servers (via either jupyter_server or notebook), all kernels managed by the gateway server could be shut down when terminating _one_ of the lab servers.  This change ensures that kernel-based operations of a given lab/notebook server only operate against its own kernels.

Also:
- Fixed some faulty log statements.
- Found the KernelHandlers `get` method hadn't transitioned to a coroutine so I made that change.

Analogous changes have been made in https://github.com/jupyter-server/jupyter_server/pull/407.