### PR TITLE
Change MathJax fonts from STIX-Web to TeX

### DIFF
--- a/notebook/static/base/js/mathjaxutils.js
+++ b/notebook/static/base/js/mathjaxutils.js
@@ -32,7 +32,7 @@ define([
                     availableFonts: [],
                     imageFont: null,
                     preferredFont: null,
-                    webFont: "STIX-Web",
+                    webFont: "TeX",
                     styles: {'.MathJax_Display': {"margin": 0}},
                     linebreaks: { automatic: true }
                 },

--- a/setupbase.py
+++ b/setupbase.py
@@ -187,11 +187,11 @@ def find_package_data():
 
     for tree in trees + [
         mj('localization'), # limit to en?
-        mj('fonts', 'HTML-CSS', 'STIX-Web', 'woff'),
+        mj('fonts', 'HTML-CSS', 'TeX', 'woff'),
         mj('extensions'),
         mj('jax', 'input', 'TeX'),
-        mj('jax', 'output', 'HTML-CSS', 'fonts', 'STIX-Web'),
-        mj('jax', 'output', 'SVG', 'fonts', 'STIX-Web'),
+        mj('jax', 'output', 'HTML-CSS', 'fonts', 'TeX'),
+        mj('jax', 'output', 'SVG', 'fonts', 'TeX'),
         mj('jax', 'element', 'mml'),
     ]:
         for parent, dirs, files in os.walk(tree):


### PR DESCRIPTION
Currently, the fonts used by MathJax don't look great, switching to `TeX` font makes it look much better.

Also, `nbviewer` seems to be using `TeX`, so this way both would be consistent.

See also:

* https://stackoverflow.com/q/28909747/
* #2536

I'm not sure whether this PR uses the right/best way to do this, but it works for me when I try it locally.

In an unrelated, later change, it would of course also be great to upgrade to MathJax version 3, see #5758.