### PR TITLE
Add missing "import inspect"

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -13,6 +13,7 @@ import gettext
 import hashlib
 import hmac
 import importlib
+import inspect
 import io
 import ipaddress
 import json


### PR DESCRIPTION
I got an error when running the `master` branch of `notebook`:

```
[W 15:12:59.786 NotebookApp] Error loading config file: jupyter_notebook_config
    Traceback (most recent call last):
...
      File "/home/[...]/notebook/notebookapp.py", line 1402, in _observe_contents_manager_class
        if inspect.isclass(new):
    NameError: name 'inspect' is not defined
```

I don't know why the `import` is missing how this hasn't been detected by CI, but adding the `import` statement seems to fix the error/warning.