### PR TITLE
Fix small mistake in save_hooks documentation

### DIFF
--- a/docs/source/extending/savehooks.rst
+++ b/docs/source/extending/savehooks.rst
@@ -38,7 +38,7 @@ A pre-save hook for stripping output::
             cell['outputs'] = []
             cell['execution_count'] = None
 
-    c.FileContentsManager.pre_save_hook = scrub_output_pre_save
+    c.ContentsManager.pre_save_hook = scrub_output_pre_save
 
 A post-save hook to make a script equivalent whenever the notebook is saved
 (replacing the ``--script`` option in older versions of the notebook):


### PR DESCRIPTION
There is a mistake in the example code for the `pre_save_hook`, where the method is given as a method of the `FileContentsManager` class. The `pre_save_hook` is actually a method of the `ContentsManager` class. 

This correction should make it easier for users copying and pasting from this template.