### PR TITLE
Fix: send2trash on darwin

### DIFF
--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -14,7 +14,6 @@ import warnings
 import mimetypes
 import nbformat
 
-from send2trash import send2trash
 from tornado import web
 
 from .filecheckpoints import FileCheckpoints
@@ -514,7 +513,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
         def _check_trash(os_path):
             if sys.platform in {'win32', 'darwin'}:
-                return True
+                return False
 
             # It's a bit more nuanced than this, but until we can better
             # distinguish errors from send2trash, assume that we can only trash
@@ -544,7 +543,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
                 # raises let us distinguish permission errors from other errors in
                 # code. So for now, just let them all get logged as server errors.
                 send2trash(os_path)
-                return
+                return False
             else:
                 self.log.warning("Skipping trash for %s, on different device "
                                  "to home directory", os_path)


### PR DESCRIPTION
This issue related to https://github.com/arsenetar/send2trash/issues/51.

issue output
```
MacOS Big Sur "dlsym(RTLD_DEFAULT, GetMacOSStatusCommentString): symbol not found" 
```
Until this time, the upstream of send2trash has not been released the new implementation to fix that. So I did a smart change which I set the "check_trash" to false. This patch makes sure darwin users can run the Jupiter-lab with notebook-6.1x.

Passing Info:
```
jupyter --version
jupyter core     : 4.7.1
jupyter-notebook : 6.2.0
qtconsole        : not installed
ipython          : 7.21.0
ipykernel        : 5.5.0
jupyter client   : 6
1.11
jupyter lab      : 2.2.9
nbconvert        : 6.0.7
ipywidgets       : not installed
nbformat         : 5.1.2
traitlets        : 5.0.5
```