### PR TITLE
Fix: split_cell doesn't always split cell

### DIFF
--- a/notebook/static/notebook/js/cell.js
+++ b/notebook/static/notebook/js/cell.js
@@ -619,7 +619,7 @@ define([
         for (var i = 0; i < ranges.length; i++) {
             // append both to handle selections
             // ranges[i].head.sticky is null if ctrl-a select
-            if ((ranges[i].head.sticky ?? 'before') == 'before') {
+            if ((ranges[i].head.sticky == 'before') || (ranges[i].head.sticky === null )) {
                 cursors.push(ranges[i].anchor);
                 cursors.push(ranges[i].head);
                 if (is_single_cursor(ranges[i].anchor, start) &&


### PR DESCRIPTION
This PR resolve [issues](https://github.com/jupyter/notebook/issues/5929).
Summary issues: not work **_split cell at cursor(s)_** hotkey (Ctrl-Shift--) after [this PR ](https://github.com/jupyter/notebook/pull/4824)
Also add duplicate cell if full cell is selected.