### PR TITLE
Add Issue Lock and Answered Bots

### DIFF
--- a/.github/answered.yml
+++ b/.github/answered.yml
@@ -1,0 +1,20 @@
+# This action automatically schedules issues to be closed that have been
+# labeled as answered if there is no activity on them for 30 days. This takes
+# care of the common usecase of an issue being answered to the best of our
+# ability and no other follow-up from the submitter.
+name: 'Close answered issues'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          skip-stale-issue-message: true
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-label: 'status:Closing as Answered'
+          only-issue-labels: 'status:Answered'

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,17 @@
+name: 'Lock Closed Threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: '180'
+          issue-lock-labels: 'status:resolved-locked'
+          pr-lock-inactive-days: '180'
+          pr-lock-labels: 'status:resolved-locked'


### PR DESCRIPTION
The answer bot enables us to explicitly indicate we have answered the question by giving the issue the `status:Answered` label, and then after 30 days of inactivity, the issue is scheduled to be closed after one more week, presumably answered.

cf https://github.com/jupyterlab/jupyterlab/pull/9920

The lock bot locks issues and PRs that have been closed for six months, preventing zombie thread discussions.

cf https://github.com/jupyterlab/jupyterlab/pull/9754