### PR TITLE
Add maths checks in CSS reference test

### DIFF
--- a/tools/tests/CSS Reference.ipynb
+++ b/tools/tests/CSS Reference.ipynb
@@ -8160,13 +8160,26 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": []
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Maths elements\n",
+    "$number = 1$\n",
+    "\n",
+    "$$numbercenter = 5$$\n",
+    "\n",
+    "$$fraction = \\frac{1}{3}$$\n",
+    "\n",
+    "$$root = \\sqrt{4}$$\n",
+    "\n",
+    "$$logfunction = \\log(10)$$\n",
+    "\n",
+    "$$binomial =  \\binom{5}{2}$$\n",
+    "\n",
+    "$$CircleArea = \\pi  \\times r ^2$$\n",
+    "\n",
+    "$$\\bar x = \\frac{1}{n} (\\sum_{i=1}^n x_i) =  \\frac{x_1 + x_2 + ... +x_n}{n}$$"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
![changes](https://user-images.githubusercontent.com/44138542/114101057-dc7f9b00-98cd-11eb-832a-cd7458668810.png)
The changes are not visible in github but only when you download the notebook CSS Reference.ipynb