### PR TITLE
Add base.handlers.get_current_request()

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        python-version: [ '3.6' ]
+        python-version: [ '3.7' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/.github/workflows/python-nbconvert.yml
+++ b/.github/workflows/python-nbconvert.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.6' , '3.7', '3.8', '3.9' ]
+        python-version: [ '3.7', '3.8', '3.9' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: [ '3.6' , '3.7', '3.8', '3.9' ] # Windows 3.9 fails due to the pywinpty dependency not working (Issue #5967)
+        python-version: [ '3.7', '3.8', '3.9' ] # Windows 3.9 fails due to the pywinpty dependency not working (Issue #5967)
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.7', '3.8', '3.9' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import sys
 
 name = "notebook"
 
-if sys.version_info < (3, 6):
+if sys.version_info < (3, 7):
     pip_message = 'This may be due to an out of date pip. Make sure you have pip >= 9.0.1.'
     try:
         import pip
@@ -31,7 +31,8 @@ if sys.version_info < (3, 6):
 
 
     error = """
-Notebook 6.3+ supports Python 3.6 and above.
+Notebook 6.4+ supports Python 3.7 and above.
+When using Python 3.6, please install Notebook < 6.4.
 When using Python 3.5, please install Notebook <= 6.2.
 When using Python 3.4 or earlier (including 2.7), please install Notebook 5.x.
 
@@ -99,7 +100,6 @@ for more information.
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9'
@@ -131,7 +131,7 @@ for more information.
         'test:sys_platform != "win32"': ['requests-unixsocket'],
         'json-logging': ['json-logging']
     },
-    python_requires = '>=3.6',
+    python_requires = '>=3.7',
     entry_points = {
         'console_scripts': [
             'jupyter-notebook = notebook.notebookapp:main',


### PR DESCRIPTION
This function allows to retrieve the current web request in async
contexts.

Retrieving the current context can be useful for example when
customizing Enterprise Gateway RemoteProcessProxy, to retrieve
authentication headers.

The implementation makes uses of Python 3.7's new contextvars module.
There are backports efforts for 3.6:

- https://pypi.org/project/aiocontextvars/ - does not have automatic
  asyncio support

- https://pypi.org/project/contextvars/ - which doesn't have it either.
  The tracking issue on this matter has been stale for 3 years now, and
  the conclusion of the discussion is "upgrade to a newer version of
  Python": https://github.com/MagicStack/contextvars/issues/2

Since notebook has no control on the event loop it is running into, I
preferred to drop Python 3.6 support.