### PR TITLE
Add Workflow Permissions for Lock Bot

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  issues:
+    write
+  pull-requests:
+    write
+
 jobs:
   lock:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes failing lock bot [runs](https://github.com/jupyter/notebook/runs/2415471932?check_suite_focus=true#step:2:10).

cf https://github.com/jupyterlab/team-compass/issues/125
