### PR TITLE
Spelling correction

### DIFF
--- a/docs/source/examples/Notebook/Working With Markdown Cells.ipynb
+++ b/docs/source/examples/Notebook/Working With Markdown Cells.ipynb
@@ -340,7 +340,7 @@
     "    \n",
     "Keep in mind that attached files will increase the size of your notebook. \n",
     "\n",
-    "You can manually edit the attachement by using the `View > Cell Toolbar > Attachment` menu, but you should not need to. "
+    "You can manually edit the attachment by using the `View > Cell Toolbar > Attachment` menu, but you should not need to. "
    ]
   }
  ],


### PR DESCRIPTION
An instance of 'attachment' was misspelled 'attachement'.