### PR TITLE
"#element".tooltip is not a function on home page fixed.

### DIFF
--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -73,7 +73,7 @@ define(function(){
     // tree
     jglobal('SessionList','tree/js/sessionlist');
 
-    Jupyter.version = "6.4.0";
+    Jupyter.version = "6.5.0.dev0";
     Jupyter._target = '_blank';
 
     return Jupyter;

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -73,7 +73,7 @@ define(function(){
     // tree
     jglobal('SessionList','tree/js/sessionlist');
 
-    Jupyter.version = "6.5.0.dev0";
+    Jupyter.version = "6.4";
     Jupyter._target = '_blank';
 
     return Jupyter;

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -73,7 +73,7 @@ define(function(){
     // tree
     jglobal('SessionList','tree/js/sessionlist');
 
-    Jupyter.version = "6.4";
+    Jupyter.version = "6.4.0";
     Jupyter._target = '_blank';
 
     return Jupyter;

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -215,10 +215,11 @@ data-server-root="{{server_root}}"
 
 {% block script %}
     {{super()}}
+    <script src="{{ static_url("tree/js/main.min.js") }}" type="text/javascript" charset="utf-8"></script>
+
     <script type="text/javascript">
-      ('#element').tooltip('enable')
+      $('#element').tooltip('enable')
     </script>
 
-<script src="{{ static_url("tree/js/main.min.js") }}" type="text/javascript" charset="utf-8"></script>
 
 {% endblock %}

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -220,6 +220,4 @@ data-server-root="{{server_root}}"
     <script type="text/javascript">
       $('#element').tooltip('enable')
     </script>
-
-
 {% endblock %}


### PR DESCRIPTION
Closes #6062

Hello, this is my first time contributing to Github.
In the notebook/templates/tree.html file was there a $ character missing which resulted in an `"#element".tooltip is not a function` error in the console, I fixed this issue by adding the $ character. Then I also found out that this line: `$('#element').tooltip('enable')` that uses jquery was ran first, only then jquery was imported (`<script src="{{ static_url("tree/js/main.min.js") }}" type="text/javascript" charset="utf-8"></script>`), this also resulted in an error, I swapped them and now it works.
I hope I did not miss anything.

Kind regards, Ilay Hamer.