### PR TITLE
Enhancements to the desktop entry

### DIFF
--- a/jupyter-notebook.desktop
+++ b/jupyter-notebook.desktop
@@ -1,10 +1,11 @@
 [Desktop Entry]
 Name=Jupyter Notebook
 Comment=Run Jupyter Notebook
-Exec=jupyter-notebook
+Exec=jupyter-notebook %f
 Terminal=true
 Type=Application
 Icon=notebook
 StartupNotify=true
 MimeType=application/x-ipynb+json;
-Categories=Development;Education
+Categories=Development;Education;
+Keywords=python;


### PR DESCRIPTION
- Add the argument `%f` to the _Exec_ key so that a notebook file can be directly opened from the file manager by right-click → Open With Jupyter Notebook, or by double-clicking (https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s07.html)
- Add the _Keywords_ key so that the Jupyter Notebook application can be searched with a keyword "python", e.g. from GNOME Shell (look for the _Keywords_ key in the table https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html)
- Add a semicolon `;` to the end of the strings in the _Categories_ key (look at the examples here https://specifications.freedesktop.org/menu-spec/latest/ar01s03.html)