### PR TITLE
Fix version of jupyter-packaging in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires=["jupyter_packaging~=0.9,<2"]
+requires=["jupyter_packaging~=0.9"]
 build-backend = "setuptools.build_meta"
 
 [tool.check-manifest]


### PR DESCRIPTION
The specifier `~=0.9` is equivalent to `>= 0.9, == 0.*` so there is no need to specify `<2`.

See PEP 440 for more details: https://www.python.org/dev/peps/pep-0440/#compatible-release