### PR TITLE
Fix issue #3218

### DIFF
--- a/notebook/static/notebook/less/notificationarea.less
+++ b/notebook/static/notebook/less/notificationarea.less
@@ -30,6 +30,7 @@
     .kernel_indicator_name {
         padding-left: 5px;
         padding-right: 5px;
+        color: #102930
     }
 }
 

--- a/notebook/static/notebook/less/notificationarea.less
+++ b/notebook/static/notebook/less/notificationarea.less
@@ -30,6 +30,7 @@
     .kernel_indicator_name {
         padding-left: 5px;
         padding-right: 5px;
+        // accessibility improvement
         color: #102930
     }
 }

--- a/notebook/static/tree/less/tree.less
+++ b/notebook/static/tree/less/tree.less
@@ -186,7 +186,7 @@ ul.breadcrumb {
     }
     .running-indicator {
         padding-top: @dashboard_tb_pad;
-        color: darken(@brand-success,20%);
+        color: darken(@brand-success,25%);
     }
     .kernel-name {
         padding-top: @dashboard_tb_pad;
@@ -204,6 +204,8 @@ ul.breadcrumb {
     .kernel-name {
         margin-left : @dashboard_lr_pad;
         float : right;
+        color: #489eb8;
+        font-weight: 700;
     }
 }
 
@@ -229,7 +231,7 @@ ul.breadcrumb {
     display: inline-block;
     padding-left: @dashboard_lr_pad;
     margin-left: -2px;
-
+    color: darken(@link-color, 10%);
 
     > .breadcrumb {
         padding: 0px;

--- a/notebook/static/tree/less/tree.less
+++ b/notebook/static/tree/less/tree.less
@@ -186,6 +186,7 @@ ul.breadcrumb {
     }
     .running-indicator {
         padding-top: @dashboard_tb_pad;
+        // accessibility improvement
         color: darken(@brand-success,25%);
     }
     .kernel-name {
@@ -204,6 +205,7 @@ ul.breadcrumb {
     .kernel-name {
         margin-left : @dashboard_lr_pad;
         float : right;
+        // accessibility improvement
         color: #489eb8;
         font-weight: 700;
     }
@@ -231,6 +233,7 @@ ul.breadcrumb {
     display: inline-block;
     padding-left: @dashboard_lr_pad;
     margin-left: -2px;
+    // accessibility improvement
     color: darken(@link-color, 10%);
 
     > .breadcrumb {


### PR DESCRIPTION
**Earlier,  on route `localhost/tree/docs` the word "running" appearing next to the file name of the new notebook was failing the color contrast**.

Before fixing
![Screenshot from 2021-07-21 16-06-26](https://user-images.githubusercontent.com/56908732/126477223-b2495b2d-4e4a-410f-b360-f197192e6ecd.png)

After fixing
![Screenshot from 2021-07-21 16-13-03](https://user-images.githubusercontent.com/56908732/126477314-a7808358-6b59-4728-a2c7-6ccc64f7b418.png)

**On route `localhost/tree#running` (a new notebook is running)  *kernel-name* wasn't too dark.

Before fixing
![Screenshot from 2021-07-21 16-07-03](https://user-images.githubusercontent.com/56908732/126477799-89bc5a21-870d-40d9-a532-db103439ab17.png)

After fixing
![Screenshot from 2021-07-21 16-14-38](https://user-images.githubusercontent.com/56908732/126477847-45faf848-32b8-48a2-8723-93a2dc660b60.png)

**For new notebook, on route `http://localhost/notebooks/docs/Untitled.ipynb` the contrast for *kernel_indicator* was failing.**

Before fixing
![Screenshot from 2021-07-21 16-15-17](https://user-images.githubusercontent.com/56908732/126478060-1f2661c2-dde3-4700-b093-870e56f9c3ef.png)

After fixing
![Screenshot from 2021-07-21 16-15-04](https://user-images.githubusercontent.com/56908732/126478158-5ee909db-29f3-474b-ad76-815c9673c4a0.png)

Fixes #3218