### PR TITLE
Fix send2trash tests failing on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ for more information.
         'nbformat',
         'nbconvert',
         'ipykernel', # bless IPython kernel for now
-        'Send2Trash>=1.5.0',
+        'Send2Trash>=1.8.0',
         'terminado>=0.8.3',
         'prometheus_client'
     ],


### PR DESCRIPTION
Hi.

I've faced an issue with failing tests on Windows:
https://github.com/jupyter/notebook/actions/runs/1104955127

This was caused by send2trash package issue while using it not in the main thread:
https://github.com/arsenetar/send2trash/pull/59

Not it is fixed, and tests have been passed successfully:
https://github.com/dolfinus/notebook/actions/runs/1112095303

Let's upgrade the dependency.