### PR TITLE
Own context menu added for items in jupyter notebook

### DIFF
--- a/notebook/static/tree/less/tree.less
+++ b/notebook/static/tree/less/tree.less
@@ -447,3 +447,26 @@ ul#new-menu {
         font-size:10px;
     }
 }
+
+/*
+* Styling for context menu
+*/
+
+div#contextMenu {
+    border:1px solid #eeeeee;
+    padding:10px;
+    width:100px;
+    position:absolute;
+    z-index:1000;
+    background:white;
+    display:none;
+    }
+    div#contextMenu a{
+        text-decoration:none;
+    }
+    div#contextMenu>*{
+        padding:5px;
+    }
+    div#contextMenu>*:hover{
+        background:#eeeeee;
+    }

--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -25,7 +25,12 @@ data-server-root="{{server_root}}"
 {% endblock %}
 
 {% block site %}
-
+  <div id="contextMenu">
+      <div class="options"><a id="open-item" href="javascript:void(0)">Open</a></div>
+      <div class="options"><a id="rename-item" href="javascript:void(0)">Rename</a></div>
+      <div class="options"><a id="move-item" href="javascript:void(0)">Move</a></div>
+      <div class="options"><a id="delete-item" href="javascript:void(0)">Delete</a></div>
+  </div>
   <div id="ipython-main-app" class="container">
     <div id="tab_content" class="tabbable" role="main">
       <ul id="tabs" class="nav nav-tabs">


### PR DESCRIPTION
This pull request adds Notebook own context menu, when a right click is performed on a directory/file name [Refer to issue #6140 please] .
This adds currently 4 items in context menu "Open", "Rename", "Move" and "Delete" . Please suggest for any enhancement or something that I can improve more. Below is the attached recorded video.
https://www.loom.com/share/b2eabe2c7b884b1dba509393f6c3cd87
