### PR TITLE
Use default JupyterLab CSS sanitizer options for Markdown

### DIFF
--- a/notebook/static/base/js/markdown.js
+++ b/notebook/static/base/js/markdown.js
@@ -106,7 +106,7 @@ define([
                     html = mathjaxutils.replace_math(html, math);
                 }
                 if(options.sanitize) {
-                    html = $(security.sanitize_html_and_parse(html));
+                    html = $(security.sanitize_html_and_parse(html, true));
                 }
             }
             callback(err, html);


### PR DESCRIPTION
Fixes https://github.com/jupyter-server/jupyter_server/issues/577

6.4.1 removed all CSS styles from HTML inside of Markdown cells after moving to a maintained version of the sanitizer. This PR restores CSS styles in Markdown cells. For a test case of:

```markdown
<span style="color: red; font-size: 30px">test</span>
```
Before:
![Screenshot from 2021-08-28 17-00-57](https://user-images.githubusercontent.com/5832902/131223792-508f99af-7945-4bbb-9b0b-b10215d98d80.png)

After:
![Screenshot from 2021-08-28 16-59-08](https://user-images.githubusercontent.com/5832902/131223736-40141901-9168-4ca0-9446-ffd15cfb7f2a.png)