### PR TITLE
Fixed unexpected emphasis-strong markdown rendering

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "jquery": "components/jquery#~3.5.0",
     "jquery-typeahead": "~2.10.6",
     "jquery-ui": "components/jqueryui#~1.12",
-    "marked": "~0.7",
+    "marked": "~2.0.0",
     "MathJax": "^2.7.4",
     "moment": "~2.19.3",
     "react": "~16.0.0",


### PR DESCRIPTION
Fix #6126
With the release of v2.0.0 *marked* did a total rework of emphasis/strong which fixed its bug of unexpected rendering.

#### Screenshots
Before:
![before_fix](https://user-images.githubusercontent.com/22915654/131405557-403d1d4b-f627-4de1-a2fa-6519080e7829.png)

After:
![fix](https://user-images.githubusercontent.com/22915654/131404248-bd391e37-e8de-431e-9b69-11d18f2b9a4f.png)
