### PR TITLE
Replace deprecated date_default with json_default

### DIFF
--- a/notebook/services/contents/handlers.py
+++ b/notebook/services/contents/handlers.py
@@ -11,7 +11,7 @@ import json
 from tornado import gen, web
 
 from notebook.utils import maybe_future, url_path_join, url_escape
-from jupyter_client.jsonutil import date_default
+from jupyter_client.jsonutil import json_default
 
 from notebook.base.handlers import (
     IPythonHandler, APIHandler, path_regex,
@@ -85,7 +85,7 @@ class ContentsHandler(APIHandler):
             self.set_header('Location', location)
         self.set_header('Last-Modified', model['last_modified'])
         self.set_header('Content-Type', 'application/json')
-        self.finish(json.dumps(model, default=date_default))
+        self.finish(json.dumps(model, default=json_default))
 
     @web.authenticated
     @gen.coroutine
@@ -247,7 +247,7 @@ class CheckpointsHandler(APIHandler):
         """get lists checkpoints for a file"""
         cm = self.contents_manager
         checkpoints = yield maybe_future(cm.list_checkpoints(path))
-        data = json.dumps(checkpoints, default=date_default)
+        data = json.dumps(checkpoints, default=json_default)
         self.finish(data)
 
     @web.authenticated
@@ -256,7 +256,7 @@ class CheckpointsHandler(APIHandler):
         """post creates a new checkpoint"""
         cm = self.contents_manager
         checkpoint = yield maybe_future(cm.create_checkpoint(path))
-        data = json.dumps(checkpoint, default=date_default)
+        data = json.dumps(checkpoint, default=json_default)
         location = url_path_join(self.base_url, 'api/contents',
             url_escape(path), 'checkpoints', url_escape(checkpoint['id']))
         self.set_header('Location', location)


### PR DESCRIPTION
With `notebook` installed in a conda environment, opening a new notebook throws the warning: `~/miniforge3/envs/myenv/lib/python3.8/json/encoder.py:257: UserWarning: date_default is deprecated since jupyter_client 7.0.0. Use jupyter_client.jsonutil.json_default.` This PR switches from the obsolete date_default to json_default as recommended.