### PR TITLE
Fix crypto handling

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,11 @@
 const path = require('path');
+const crypto = require('crypto');
+
+// Workaround for loaders using "md4" by default, which is not supported in FIPS-compliant OpenSSL
+// See https://github.com/jupyterlab/jupyterlab/issues/11248
+const cryptoOrigCreateHash = crypto.createHash;
+crypto.createHash = (algorithm) =>
+  cryptoOrigCreateHash(algorithm == 'md4' ? 'sha256' : algorithm);
 
 module.exports = {
   entry: '@jupyterlab/apputils/lib/sanitizer',


### PR DESCRIPTION
Workaround for https://github.com/jupyterlab/jupyterlab/issues/11248

Enforce a FIPS-compliant hashing algorithm when using Webpack