### PR TITLE
Fully revert the pinning of nbsphinx to 0.8.6

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 - terminado
 - myst-parser
 - pip:
-  - nbsphinx==0.8.6
+  - nbsphinx
   - Send2Trash
   - prometheus_client
   - sphinxcontrib_github_alt


### PR DESCRIPTION
Remove the last vestige of pinning nbsphinx to 0.8.6.  (Sorry, I should have caught this when reviewing #6200).