### PR TITLE
geteuid -> getuid

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -2284,7 +2284,7 @@ class NotebookApp(JupyterApp):
         if not self.allow_root:
             # check if we are running as root, and abort if it's not allowed
             try:
-                uid = os.geteuid()
+                uid = os.getuid()
             except AttributeError:
                 uid = -1 # anything nonzero here, since we can't check UID assume non-root
             if uid == 0:


### PR DESCRIPTION
While I [personally disagree](https://github.com/great-expectations/great_expectations/issues/3548) that this `if not self.allow_root` should exist at all, I noticed that the current behavior might be different from the one that was intended when this was written:

> getuid() will return ID of user who runs program, while os.geteuid() will return ID of user who owns the executable
https://stackoverflow.com/questions/14950378/what-is-difference-between-os-getuid-and-os-geteuid