### PR TITLE
Fix asyncio error when opening notebooks

### DIFF
--- a/notebook/tests/launchnotebook.py
+++ b/notebook/tests/launchnotebook.py
@@ -167,10 +167,16 @@ class NotebookTestBase(TestCase):
                     token=cls.token,
                     **bind_args
                 )
-                if 'asyncio' in sys.modules:
-                          app._init_asyncio_patch()
-                          import asyncio
-                          asyncio.set_event_loop(asyncio.new_event_loop())
+                if "asyncio" in sys.modules:
+                    app._init_asyncio_patch()
+                    import asyncio
+
+                    asyncio.set_event_loop(asyncio.new_event_loop())
+                    # Patch the current loop in order to match production
+                    # behavior
+                    import nest_asyncio
+
+                    nest_asyncio.apply()
                 # don't register signal handler during tests
                 app.init_signal = lambda : None
                 # clear log handlers and propagate to root for nose to capture it

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,7 @@ for more information.
         'jupyter_client>=5.3.4',
         'nbformat',
         'nbconvert',
+        'nest-asyncio>=1.5',
         'ipykernel', # bless IPython kernel for now
         'Send2Trash>=1.8.0',
         'terminado>=0.8.3',


### PR DESCRIPTION
This is a fix for https://github.com/jupyter/notebook/issues/6164

`nest_asyncio` must be applied before any async tasks have been created
otherwise there could be tasks queued that are unpatched, and thus do
not respect nested loops. An example of an unpatched task can be seen in
the original issue:

```
<Task pending coro=<HTTP1ServerConnection._server_request_loop() running at /apps/python3/lib/python3.7/site-packages/tornado/http1connection.py:823>
```
which originates from Tornado.

A similar issue was reported in `nest-asyncio`: https://github.com/erdewit/nest_asyncio/issues/22
where the solution is to call `apply` on import so that unpatched tasks
do not get created.