### PR TITLE
handle KeyError when get session

### DIFF
--- a/notebook/services/sessions/sessionmanager.py
+++ b/notebook/services/sessions/sessionmanager.py
@@ -189,7 +189,10 @@ class SessionManager(LoggingConfigurable):
 
             raise web.HTTPError(404, u'Session not found: %s' % (', '.join(q)))
 
-        model = yield maybe_future(self.row_to_model(row))
+        try:
+            model = yield maybe_future(self.row_to_model(row))
+        except KeyError as e:
+            raise web.HTTPError(404, u'Session not found: %s' % str(e))
         raise gen.Return(model)
 
     @gen.coroutine

--- a/notebook/services/sessions/tests/test_sessionmanager.py
+++ b/notebook/services/sessions/tests/test_sessionmanager.py
@@ -94,7 +94,7 @@ class TestSessionManager(TestCase):
         session = self.create_session(path='/path/to/1/test1.ipynb', kernel_name='python')
         # kill the kernel
         sm.kernel_manager.shutdown_kernel(session['kernel']['id'])
-        with self.assertRaises(KeyError):
+        with self.assertRaises(web.HTTPError):
             self.loop.run_sync(lambda: sm.get_session(session_id=session['id']))
         # no sessions left
         listed = self.loop.run_sync(lambda: sm.list_sessions())


### PR DESCRIPTION
If gateway is enabled, `row_to_model` can delete session row when kernel culled or died on gateway. Then it raises a `KeyError` unhadled in `get_session`.