### PR TITLE
Windows Installation Helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ geckodriver.log
 docs/source/changelog.md
 
 .jupyter_releaser_checkout
+
+*venv*
+*Untitled*

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -46,7 +46,7 @@ Installing the Jupyter Notebook
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once you have installed the dependencies mentioned above download and run the following 
-`installer <https://github.com/JaskaranSinghUofT/windows-jupyter-notebook-development-installation/blob/main/Windows_Jupyter_Notebook_Development_Installation.bat?raw=true>`_ 
+`installer <https://downgit.github.io/#/home?url=https://github.com/JaskaranSinghUofT/windows-jupyter-notebook-development-installation/blob/main/Windows_Jupyter_Notebook_Development_Installation.bat>`_.
 
 
 Alternatively if you want to manually install, use the following

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -45,7 +45,12 @@ You can also use the installer from the `Node.js website <https://nodejs.org>`_.
 Installing the Jupyter Notebook
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Once you have installed the dependencies mentioned above, use the following
+Once you have installed the dependencies mentioned above
+Download and run the following `installer <https://github.com/JaskaranSinghUofT/windows-jupyter-notebook-development-installation/blob/main/Windows_Jupyter_Notebook_Development_Installation.bat?raw=true>` 
+or if you prefer, the manual installation is below
+
+
+Alternatively if you want to manually install, use the following
 steps::
 
     pip install --upgrade setuptools pip

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -46,7 +46,7 @@ Installing the Jupyter Notebook
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once you have installed the dependencies mentioned above
-Download and run the following `installer <https://github.com/JaskaranSinghUofT/windows-jupyter-notebook-development-installation/blob/main/Windows_Jupyter_Notebook_Development_Installation.bat?raw=true>` 
+Download and run the following `installer <https://github.com/JaskaranSinghUofT/windows-jupyter-notebook-development-installation/blob/main/Windows_Jupyter_Notebook_Development_Installation.bat?raw=true>`_ 
 or if you prefer, the manual installation is below
 
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -45,9 +45,8 @@ You can also use the installer from the `Node.js website <https://nodejs.org>`_.
 Installing the Jupyter Notebook
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Once you have installed the dependencies mentioned above
-Download and run the following `installer <https://github.com/JaskaranSinghUofT/windows-jupyter-notebook-development-installation/blob/main/Windows_Jupyter_Notebook_Development_Installation.bat?raw=true>`_ 
-or if you prefer, the manual installation is below
+Once you have installed the dependencies mentioned above download and run the following 
+`installer <https://github.com/JaskaranSinghUofT/windows-jupyter-notebook-development-installation/blob/main/Windows_Jupyter_Notebook_Development_Installation.bat?raw=true>`_ 
 
 
 Alternatively if you want to manually install, use the following

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -46,7 +46,7 @@ Installing the Jupyter Notebook
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once you have installed the dependencies mentioned above download and run the following 
-`installer <https://downgit.github.io/#/home?url=https://github.com/JaskaranSinghUofT/windows-jupyter-notebook-development-installation/blob/main/Windows_Jupyter_Notebook_Development_Installation.bat>`_.
+`installer <https://jaskaransinghuoft.github.io/windows-jupyter-notebook-development-installation/Windows_Jupyter_Notebook_Development_Installation.bat>`_.
 
 
 Alternatively if you want to manually install, use the following

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -45,7 +45,7 @@ You can also use the installer from the `Node.js website <https://nodejs.org>`_.
 Installing the Jupyter Notebook
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Once you have installed the dependencies mentioned above download and run the following 
+Once you have installed the dependencies mentioned above download and run the d
 `installer <https://jaskaransinghuoft.github.io/windows-jupyter-notebook-development-installation/Windows_Jupyter_Notebook_Development_Installation.bat>`_.
 
 


### PR DESCRIPTION
Adds an easier way to install the development-build of Jupyter Notebook to the CONTRIBUTING.rst file.

Essentially, for Windows, a batch script was written to automate the installation process; the script can be downloaded from CONTRIBUTING.rst under the "Installing the Jupyter Notebook" section.