### PR TITLE
Fix to remove potential memory leak on Jupyter Notebooks ZMQChannelHandler code

### DIFF
--- a/notebook/services/kernels/handlers.py
+++ b/notebook/services/kernels/handlers.py
@@ -251,7 +251,8 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
         if stale_handler:
             self.log.warning("Replacing stale connection: %s", self.session_key)
             yield stale_handler.close()
-        self._open_sessions[self.session_key] = self
+        if self.kernel_id in self.kernel_manager:  # only update open sessions if kernel is actively managed
+            self._open_sessions[self.session_key] = self
 
     def open(self, kernel_id):
         super(ZMQChannelsHandler, self).open()


### PR DESCRIPTION
Adding a session to the _open_sessions list only after validating kernel. This will prevent memory wastage if any requests are made with an incorrect kernel ID.