### PR TITLE
Fix deprecation warning

### DIFF
--- a/notebook/auth/login.py
+++ b/notebook/auth/login.py
@@ -112,7 +112,7 @@ class LoginHandler(IPythonHandler):
         handler.set_secure_cookie(handler.cookie_name, user_id, **cookie_options)
         return user_id
 
-    auth_header_pat = re.compile('token\s+(.+)', re.IGNORECASE)
+    auth_header_pat = re.compile(r'token\s+(.+)', re.IGNORECASE)
 
     @classmethod
     def get_token(cls, handler):


### PR DESCRIPTION
In sagemath, while doctesting `src/sage/repl/ipython_kernel/install.py`:

> DeprecationWarning: invalid escape sequence '\s'

The solution is to make the regex a raw string.