### PR TITLE
Add date field to kernel message header

### DIFF
--- a/notebook/static/services/kernels/kernel.js
+++ b/notebook/static/services/kernels/kernel.js
@@ -79,6 +79,7 @@ define([
     Kernel.prototype._get_msg = function (msg_type, content, metadata, buffers) {
         var msg = {
             header : {
+                date: new Date().toISOString(),
                 msg_id : utils.uuid(),
                 username : this.username,
                 session : this.session_id,


### PR DESCRIPTION
This change adds the date field to kernel message headers on par with [jupyter lab's functionality ](https://github.com/jupyterlab/jupyterlab/blob/602b05399b0ca762613c8f560a49b15abdefee39/packages/services/src/kernel/messages.ts#L139-L146)and in line with the [message protocol](https://jupyter-client.readthedocs.io/en/latest/messaging.html#message-header).

Resolves #6257