### PR TITLE
Inject session identifier into environment variable.

### DIFF
--- a/notebook/services/sessions/sessionmanager.py
+++ b/notebook/services/sessions/sessionmanager.py
@@ -14,7 +14,6 @@ except ImportError:
 from tornado import gen, web
 
 from traitlets.config.configurable import LoggingConfigurable
-from ipython_genutils.py3compat import unicode_type
 from traitlets import Instance
 
 from notebook.utils import maybe_future
@@ -86,7 +85,7 @@ class SessionManager(LoggingConfigurable):
 
     def new_session_id(self):
         "Create a uuid for a new session"
-        return unicode_type(uuid.uuid4())
+        return str(uuid.uuid4())
 
     @gen.coroutine
     def create_session(self, path=None, name=None, type=None, kernel_name=None, kernel_id=None):
@@ -107,8 +106,13 @@ class SessionManager(LoggingConfigurable):
         """Start a new kernel for a given session."""
         # allow contents manager to specify kernels cwd
         kernel_path = self.contents_manager.get_kernel_path(path=path)
+
         kernel_id = yield maybe_future(
-            self.kernel_manager.start_kernel(path=kernel_path, kernel_name=kernel_name)
+            self.kernel_manager.start_kernel(
+                path=kernel_path,
+                kernel_name=kernel_name,
+                env={"JPY_SESSION_NAME": path},
+            )
         )
         # py2-compat
         raise gen.Return(kernel_id)


### PR DESCRIPTION
There are many use case where users want to know the current notebook
name/path. This help by adding a session identifier (to not really say
this is the current notebook name), and by default make it the full path
to the notebook document that created the session.

This will of course not work if the notebook get renamed, but we can
tackle this later.

See also https://github.com/jupyter/jupyter_client/pull/656,
https://github.com/jupyter/notebook/pull/6180. It will need to be ported
to jupyter_server as well.

I used the opportunity to clean an unused python2 compat layer. 