### PR TITLE
Rename the default branch to `main`

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,7 +1,7 @@
 name: Check Release
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
     branches: ["*"]
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -56,7 +56,7 @@ steps::
 If you are using a system-wide Python installation and you only want to install the notebook for you,
 you can add ``--user`` to the install commands.
 
-Once you have done this, you can launch the master branch of Jupyter notebook
+Once you have done this, you can launch the main branch of Jupyter notebook
 from any directory in your system with::
 
     jupyter notebook
@@ -95,7 +95,7 @@ this command whenever there are changes to JavaScript or LESS sources::
 
 **IMPORTANT:** Don't forget to run ``npm run build`` after switching branches.
 When switching between branches of different versions (e.g. ``4.x`` and
-``master``), run ``pip install -e .``. If you have tried the above and still
+``main``), run ``pip install -e .``. If you have tried the above and still
 find that the notebook is not reflecting the current source code, try cleaning
 the repo with ``git clean -xfd`` and reinstalling with ``pip install -e .``.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Jupyter Notebook
 
 [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/jupyter)
-[![Build Status](https://travis-ci.org/jupyter/notebook.svg?branch=master)](https://travis-ci.org/jupyter/notebook)
+[![Build Status](https://travis-ci.org/jupyter/notebook.svg?branch=main)](https://travis-ci.org/jupyter/notebook)
 [![Documentation Status](https://readthedocs.org/projects/jupyter-notebook/badge/?version=latest)](https://jupyter-notebook.readthedocs.io/en/latest/?badge=latest)
-[![codecov](https://codecov.io/gh/jupyter/notebook/branch/master/graph/badge.svg)](https://codecov.io/gh/jupyter/notebook)
+[![codecov](https://codecov.io/gh/jupyter/notebook/branch/main/graph/badge.svg)](https://codecov.io/gh/jupyter/notebook)
 
 The Jupyter notebook is a web-based notebook environment for interactive
 computing.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ The recommended way to make a release is to use [`jupyter_releaser`](https://git
 #### Set the release branch
 
 ```bash
-export release_branch=master
+export release_branch=main
 ```
 
 #### Create the git checkout

--- a/docs-translations/hi-IN/README.md
+++ b/docs-translations/hi-IN/README.md
@@ -1,9 +1,9 @@
 # Jupyter Notebook
 
 [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/jupyter)
-[![Build Status](https://travis-ci.org/jupyter/notebook.svg?branch=master)](https://travis-ci.org/jupyter/notebook)
+[![Build Status](https://travis-ci.org/jupyter/notebook.svg?branch=main)](https://travis-ci.org/jupyter/notebook)
 [![Documentation Status](https://readthedocs.org/projects/jupyter-notebook/badge/?version=latest)](https://jupyter-notebook.readthedocs.io/en/latest/?badge=latest)
-                
+
 
 
 Jupyter नोटबुक इंटरैक्टिव के लिए एक वेब-आधारित नोटबुक वातावरण है
@@ -74,4 +74,4 @@ IPython कोडबेस का बिग स्प्लिट ™। IPython
 - [Korean Version of Installation](https://github.com/ChungJooHo/Jupyter_Kor_doc/)
 - [Documentation for Project Jupyter](https://jupyter.readthedocs.io/en/latest/index.html) [[PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)]
 - [Issues](https://github.com/jupyter/notebook/issues)
-- [Technical support - Jupyter Google Group](https://groups.google.com/forum/#!forum/jupyter) 
+- [Technical support - Jupyter Google Group](https://groups.google.com/forum/#!forum/jupyter)

--- a/docs-translations/ja-JP/README.md
+++ b/docs-translations/ja-JP/README.md
@@ -1,9 +1,9 @@
 # Jupyter Notebook
 
 [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/jupyter)
-[![Build Status](https://travis-ci.org/jupyter/notebook.svg?branch=master)](https://travis-ci.org/jupyter/notebook)
+[![Build Status](https://travis-ci.org/jupyter/notebook.svg?branch=main)](https://travis-ci.org/jupyter/notebook)
 [![Documentation Status](https://readthedocs.org/projects/jupyter-notebook/badge/?version=latest)](https://jupyter-notebook.readthedocs.io/en/latest/?badge=latest)
-                
+
 英語版のリンク : [[English Version](http://github.com/jupyter/notebook/)]
 
 Jupyter Notebookは、インタラクティブなWebベースのノートブック形式の環境です。
@@ -41,11 +41,11 @@ Jupyter Notebookをリモートで起動する前に、いくつかの構成が�
 
 ## 開発用インストール
 
-開発用インストールのセットアップ方法については、[`CONTRIBUTING.rst`](https://github.com/jupyter/notebook/blob/master/CONTRIBUTING.rst)を参照してください。
+開発用インストールのセットアップ方法については、[`CONTRIBUTING.rst`](https://github.com/jupyter/notebook/blob/main/CONTRIBUTING.rst)を参照してください。
 
 ## 貢献
 
-プロジェクトへの貢献に興味がある場合は、[`CONTRIBUTING.rst`](https://github.com/jupyter/notebook/blob/master/CONTRIBUTING.rst)をご覧ください。
+プロジェクトへの貢献に興味がある場合は、[`CONTRIBUTING.rst`](https://github.com/jupyter/notebook/blob/main/CONTRIBUTING.rst)をご覧ください。
 
 ## 参考
 

--- a/docs-translations/ko-KR/README.md
+++ b/docs-translations/ko-KR/README.md
@@ -1,9 +1,9 @@
 # Jupyter Notebook
 
 [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/jupyter)
-[![Build Status](https://travis-ci.org/jupyter/notebook.svg?branch=master)](https://travis-ci.org/jupyter/notebook)
+[![Build Status](https://travis-ci.org/jupyter/notebook.svg?branch=main)](https://travis-ci.org/jupyter/notebook)
 [![Documentation Status](https://readthedocs.org/projects/jupyter-notebook/badge/?version=latest)](http://jupyter-notebook.readthedocs.io/en/latest/?badge=latest)
-                
+
 English 버전 링크 : [[English Version](http://github.com/jupyter/notebook/)]
 
 Jupyter notebook 은 상호 교환을 위한 웹 기반 환경입니다.
@@ -25,7 +25,7 @@ You can find the installation documentation for the
 조금 더 심화된 Jupyter notebook의 사용은 다음 주소에서 볼 수 있습니다.
 [here](https://jupyter-notebook.readthedocs.io/en/latest/).
 
-설치를 위해서는 
+설치를 위해서는
 [pip installed](https://pip.readthedocs.io/en/stable/installing/) 가 있는지 확인한 후 다음을 실행해주세요:
 
     $ pip install notebook

--- a/docs-translations/zh-CN/README.md
+++ b/docs-translations/zh-CN/README.md
@@ -1,9 +1,9 @@
 # Jupyter Notebook
 
 [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/jupyter)
-[![Build Status](https://travis-ci.org/jupyter/notebook.svg?branch=master)](https://travis-ci.org/jupyter/notebook)
+[![Build Status](https://travis-ci.org/jupyter/notebook.svg?branch=main)](https://travis-ci.org/jupyter/notebook)
 [![Documentation Status](https://readthedocs.org/projects/jupyter-notebook/badge/?version=latest)](https://jupyter-notebook.readthedocs.io/en/latest/?badge=latest)
-                
+
 
 
 Jupyter Notebook是用于交互的基于Web的笔记本环境
@@ -74,4 +74,4 @@ IPython代码库的Big Split™。 IPython 3是最后一个主要的整体
 - [Korean Version of Installation](https://github.com/ChungJooHo/Jupyter_Kor_doc/)
 - [Documentation for Project Jupyter](https://jupyter.readthedocs.io/en/latest/index.html) [[PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)]
 - [Issues](https://github.com/jupyter/notebook/issues)
-- [Technical support - Jupyter Google Group](https://groups.google.com/forum/#!forum/jupyter) 
+- [Technical support - Jupyter Google Group](https://groups.google.com/forum/#!forum/jupyter)

--- a/docs/source/examples/Notebook/examples_index.rst
+++ b/docs/source/examples/Notebook/examples_index.rst
@@ -5,7 +5,7 @@ Notebook Examples
 The pages in this section are all converted notebook files. You can also
 `view these notebooks on nbviewer`__.
 
-__ https://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/
+__ https://nbviewer.jupyter.org/github/jupyter/notebook/blob/main/
    docs/source/examples/Notebook/
 
 .. toctree::

--- a/docs/source/extending/handlers.rst
+++ b/docs/source/extending/handlers.rst
@@ -3,7 +3,7 @@ Custom request handlers
 
 The notebook webserver can be interacted with using a well `defined
 RESTful
-API <http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml>`__.
+API <http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/main/notebook/services/api/api.yaml>`__.
 You can define custom RESTful API handlers in addition to the ones
 provided by the notebook. As described below, to define a custom handler
 you need to first write a notebook server extension. Then, in the

--- a/docs/source/links.txt
+++ b/docs/source/links.txt
@@ -19,10 +19,10 @@
 .. Main Jupyter notebook links
 
 .. _Notebook Basics: notebook_p2_
-.. _notebook_p2: https://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Notebook%20Basics.ipynb
+.. _notebook_p2: https://nbviewer.jupyter.org/github/jupyter/notebook/blob/main/docs/source/examples/Notebook/Notebook%20Basics.ipynb
 
 .. _Running Code in the Jupyter Notebook: notebook_p1_
-.. _notebook_p1: https://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Running%20Code.ipynb
+.. _notebook_p1: https://nbviewer.jupyter.org/github/jupyter/notebook/blob/main/docs/source/examples/Notebook/Running%20Code.ipynb
 
 .. Other python projects
 .. _matplotlib: https://matplotlib.org
@@ -33,9 +33,9 @@
 .. _Markdown: https://daringfireball.net/projects/markdown/syntax
 
 .. _Rich Output: notebook_p5_
-.. _notebook_p5: https://nbviewer.jupyter.org/github/ipython/ipython/blob/master/examples/IPython%20Kernel/Rich%20Output.ipynb
+.. _notebook_p5: https://nbviewer.jupyter.org/github/ipython/ipython/blob/main/examples/IPython%20Kernel/Rich%20Output.ipynb
 
 .. _Plotting with Matplotlib: notebook_p3_
-.. _notebook_p3: https://nbviewer.jupyter.org/github/ipython/ipython/blob/master/examples/IPython%20Kernel/Plotting%20in%20the%20Notebook.ipynb
+.. _notebook_p3: https://nbviewer.jupyter.org/github/ipython/ipython/blob/main/examples/IPython%20Kernel/Plotting%20in%20the%20Notebook.ipynb
 
-.. _Working with Markdown Cells: https://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Working%20With%20Markdown%20Cells.ipynb
+.. _Working with Markdown Cells: https://nbviewer.jupyter.org/github/jupyter/notebook/blob/main/docs/source/examples/Notebook/Working%20With%20Markdown%20Cells.ipynb

--- a/docs/source/notebook.rst
+++ b/docs/source/notebook.rst
@@ -234,7 +234,7 @@ drop-down on the toolbar (which will be "Code", initially), or via
 
 For more information on the different things you can do in a notebook,
 see the `collection of examples
-<https://nbviewer.jupyter.org/github/jupyter/notebook/tree/master/docs/source/examples/Notebook/>`_.
+<https://nbviewer.jupyter.org/github/jupyter/notebook/tree/main/docs/source/examples/Notebook/>`_.
 
 Code cells
 ~~~~~~~~~~

--- a/docs/source/template.tpl
+++ b/docs/source/template.tpl
@@ -2,7 +2,7 @@
 
 {% macro notebooklink() -%}
 
-`View the original notebook on nbviewer <https://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/{{ resources['metadata']['path'] }}/{{ resources['metadata']['name'] | replace(' ', '%20') }}.ipynb>`__
+`View the original notebook on nbviewer <https://nbviewer.jupyter.org/github/jupyter/notebook/blob/main/docs/{{ resources['metadata']['path'] }}/{{ resources['metadata']['name'] | replace(' ', '%20') }}.ipynb>`__
 
 
 {%- endmacro %}

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -227,7 +227,7 @@ class NotebookWebApplication(web.Application):
             log.info(DEV_NOTE_NPM)
 
         if sys_info['commit_source'] == 'repository':
-            # don't cache (rely on 304) when working from master
+            # don't cache (rely on 304) when working from main
             version_hash = ''
         else:
             # reset the cache on server restart


### PR DESCRIPTION
The default branch has been renamed to `main`.

This updates the references to `master` accordingly.

Fixes https://github.com/jupyter/notebook-team-compass/issues/6