### PR TITLE
Remove the custom run keyboard shortcut

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -263,28 +263,6 @@ const menuPlugin: JupyterFrontEndPlugin<void> = {
 };
 
 /**
- * A plugin to add an extra shortcut to execute a cell in place via Cmd-Enter on Mac.
- * TODO: switch to settings define menus when fixed upstream: https://github.com/jupyterlab/jupyterlab/issues/11754
- */
-const runShortcut: JupyterFrontEndPlugin<void> = {
-  id: '@jupyter-notebook/notebook-extension:run-shortcut',
-  autoStart: true,
-  activate: (app: JupyterFrontEnd) => {
-    app.commands.addKeyBinding({
-      command: 'notebook:run-cell',
-      keys: ['Accel Enter'],
-      selector: '.jp-Notebook:focus'
-    });
-
-    app.commands.addKeyBinding({
-      command: 'notebook:run-cell',
-      keys: ['Accel Enter'],
-      selector: '.jp-Notebook.jp-mod-editMode'
-    });
-  }
-};
-
-/**
  * A plugin to enable scrolling for outputs by default.
  * Mimic the logic from the classic notebook, as found here:
  * https://github.com/jupyter/notebook/blob/a9a31c096eeffe1bff4e9164c6a0442e0e13cdb3/notebook/static/notebook/js/outputarea.js#L96-L120
@@ -381,7 +359,6 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   kernelLogo,
   kernelStatus,
   menuPlugin,
-  runShortcut,
   scrollOutput
 ];
 


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/retrolab/issues/332

Since Notebook v7 now depends on the latest JupyterLab 4.0 pre-release which includes this shortcut by default.