### PR TITLE
Add support for opening a document with a different factory

### DIFF
--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -46,16 +46,6 @@ import { DisposableDelegate, DisposableSet } from '@lumino/disposable';
 import { Widget } from '@lumino/widgets';
 
 /**
- * The default notebook factory.
- */
-const NOTEBOOK_FACTORY = 'Notebook';
-
-/**
- * The editor factory.
- */
-const EDITOR_FACTORY = 'Editor';
-
-/**
  * A regular expression to match path to notebooks and documents
  */
 const TREE_PATTERN = new RegExp('/(notebooks|edit)/(.*)');
@@ -179,18 +169,12 @@ const opener: JupyterFrontEndPlugin<void> = {
         }
 
         const file = decodeURIComponent(path);
-        const ext = PathExt.extname(file);
+        const urlParams = new URLSearchParams(parsed.search);
+        const factory = urlParams.get('factory') ?? 'default';
         app.restored.then(async () => {
-          // TODO: get factory from file type instead?
-          if (ext === '.ipynb') {
-            docManager.open(file, NOTEBOOK_FACTORY, undefined, {
-              ref: '_noref'
-            });
-          } else {
-            docManager.open(file, EDITOR_FACTORY, undefined, {
-              ref: '_noref'
-            });
-          }
+          docManager.open(file, factory, undefined, {
+            ref: '_noref'
+          });
         });
       }
     });

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -40,8 +40,9 @@ const opener: JupyterFrontEndPlugin<void> = {
         return;
       }
       const ext = PathExt.extname(path);
-      const route = ext === '.ipynb' ? 'notebooks' : 'edit';
-      window.open(`${baseUrl}${route}/${path}`);
+      const route =
+        widgetName !== 'Notebook' || ext !== '.ipynb' ? 'edit' : 'notebooks';
+      window.open(`${baseUrl}${route}/${path}?factory=${widgetName}`);
       return undefined;
     };
   }

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -47,7 +47,12 @@ const opener: JupyterFrontEndPlugin<void> = {
       ) {
         route = 'notebooks';
       }
-      window.open(`${baseUrl}${route}/${path}?factory=${widgetName}`);
+      let url = `${baseUrl}${route}/${path}`;
+      // append ?factory only if it's not the default
+      if (widgetName !== 'default') {
+        url = `${url}?factory=${widgetName}`;
+      }
+      window.open(url);
       return undefined;
     };
   }

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -40,8 +40,13 @@ const opener: JupyterFrontEndPlugin<void> = {
         return;
       }
       const ext = PathExt.extname(path);
-      const route =
-        widgetName !== 'Notebook' || ext !== '.ipynb' ? 'edit' : 'notebooks';
+      let route = 'edit';
+      if (
+        (widgetName === 'default' && ext === '.ipynb') ||
+        widgetName === 'Notebook'
+      ) {
+        route = 'notebooks';
+      }
       window.open(`${baseUrl}${route}/${path}?factory=${widgetName}`);
       return undefined;
     };


### PR DESCRIPTION
First steps towards https://github.com/jupyterlab/retrolab/issues/290.

For example when opening a JSON file with different factories:

https://user-images.githubusercontent.com/591645/159045232-1957a135-16ee-4bde-9e6d-b43fd1b55354.mp4

This is also useful so folks can open notebooks with the text editor too:

https://user-images.githubusercontent.com/591645/159045837-297a5dc1-680a-4868-b1e7-4476e1a9df35.mp4

### TODO

- [x] Basic support for custom factories when opening a document
- [x] ~Should this work for arbitrary widgets, like the settings editor? Decide whether to do this in this PR or as follow-up~ -> deferring to another PR / issue, see this comment for a proof of concept: https://github.com/jupyter/notebook/pull/6315#issuecomment-1072621569
- [x] Should the `?factory=` URL parameter be removed from the URL after the document is opened? -> keeping it when it is not `default`, so the page can be reloaded and the document renders the same