### PR TITLE
Use place-hold.it instead of plaecehold.it to create image placeholders

### DIFF
--- a/tools/tests/Confined Output.ipynb
+++ b/tools/tests/Confined Output.ipynb
@@ -13,11 +13,11 @@
    "source": [
     "markdown image:\n",
     "\n",
-    "<img src=\"http://placehold.it/800x200.png\">\n",
+    "<img src=\"http://place-hold.it/800x200.png\">\n",
     "\n",
     "unconfined markdown image:\n",
     "\n",
-    "<img src=\"http://placehold.it/800x200.png\" class=\"unconfined\">"
+    "<img src=\"http://place-hold.it/800x200.png\" class=\"unconfined\">"
    ]
   },
   {
@@ -48,7 +48,7 @@
     {
      "data": {
       "text/html": [
-       "<img src=\"http://placehold.it/800x200.png\"   />"
+       "<img src=\"http://place-hold.it/800x200.png\"   />"
       ],
       "text/plain": [
        "<IPython.core.display.Image object>"
@@ -60,7 +60,7 @@
     }
    ],
    "source": [
-    "Image(url=\"http://placehold.it/800x200.png\", embed=False)"
+    "Image(url=\"http://place-hold.it/800x200.png\", embed=False)"
    ]
   },
   {
@@ -90,7 +90,7 @@
     }
    ],
    "source": [
-    "Image(url=\"http://placehold.it/800x200.png\", embed=True)"
+    "Image(url=\"http://place-hold.it/800x200.png\", embed=True)"
    ]
   },
   {
@@ -124,7 +124,7 @@
     }
    ],
    "source": [
-    "Image(url=\"http://placehold.it/800x200.png\", embed=True, unconfined=True)"
+    "Image(url=\"http://place-hold.it/800x200.png\", embed=True, unconfined=True)"
    ]
   },
   {
@@ -159,7 +159,7 @@
     }
    ],
    "source": [
-    "Image(url=\"http://placehold.it/1800x200.jpg\", embed=True, retina=True)"
+    "Image(url=\"http://place-hold.it/1800x200.jpg\", embed=True, retina=True)"
    ]
   },
   {


### PR DESCRIPTION
Contributes to https://github.com/jupyter/notebook/issues/6319

Use place-hold.it instead of plaecehold.it to create image placeholders

This fixes the following command run during the `check_release (link_check)` CI step.

```
'pytest --noconftest --check-links --check-links-cache --check-links-cache-expire-after 604800 --disable-warnings --quiet --check-links-cache-name /home/runner/.cache/releaser-link-check/check-release-links -p no:doctest -c _IGNORE_CONFIG --ignore-glob "docs/source/examples/Notebook/Working With Markdown Cells.ipynb" --ignore-glob "docs-translations/**/README.md" --ignore-glob "docs/source/contributing.rst" --ignore-glob "docs/source/examples/Notebook/JavaScript Notebook Extensions.ipynb" --ignore-glob "CHANGELOG.md" --ignore-glob "notebook/static/components/**/*.*" --check-links-ignore "https://github.com/.*/(pull|issues)/.*"
```