### PR TITLE
Automated Changelog Entry for 7.0.0a2 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,37 @@ Use `pip install pip --upgrade` to upgrade pip. Check pip version with
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 7.0.0a2
+
+([Full Changelog](https://github.com/jupyter/notebook/compare/v7.0.0a1...9be03f5f27232d50b16dbbaa50a222260166694c))
+
+### Enhancements made
+
+- Add support for opening a document with a different factory [#6315](https://github.com/jupyter/notebook/pull/6315) ([@jtpio](https://github.com/jtpio))
+- Minor copy edit in README [#6313](https://github.com/jupyter/notebook/pull/6313) ([@jweill-aws](https://github.com/jweill-aws))
+
+### Bugs fixed
+
+- Fix rendering of markdown [#6318](https://github.com/jupyter/notebook/pull/6318) ([@jtpio](https://github.com/jtpio))
+
+### Maintenance and upkeep improvements
+
+- Update to JupyterLab 4.0.0a22 [#6314](https://github.com/jupyter/notebook/pull/6314) ([@jtpio](https://github.com/jtpio))
+
+### Documentation improvements
+
+- docs: fix spelling [#6317](https://github.com/jupyter/notebook/pull/6317) ([@dijonkitchen](https://github.com/dijonkitchen))
+- Minor copy edit in README [#6313](https://github.com/jupyter/notebook/pull/6313) ([@jweill-aws](https://github.com/jweill-aws))
+- Update example notebook on Binder [#6306](https://github.com/jupyter/notebook/pull/6306) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter/notebook/graphs/contributors?from=2022-03-09&to=2022-03-21&type=c))
+
+[@dijonkitchen](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Adijonkitchen+updated%3A2022-03-09..2022-03-21&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Afcollonval+updated%3A2022-03-09..2022-03-21&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Agithub-actions+updated%3A2022-03-09..2022-03-21&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Ajtpio+updated%3A2022-03-09..2022-03-21&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Ajweill-aws+updated%3A2022-03-09..2022-03-21&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 7.0.0a1
 
 ([Full Changelog](https://github.com/jupyter/notebook/compare/v6.4.8...22fe46f3e806aa346625f6ef2f2a024d030a068d))
@@ -37,8 +68,6 @@ Use `pip install pip --upgrade` to upgrade pip. Check pip version with
 ([GitHub contributors page for this release](https://github.com/jupyter/notebook/graphs/contributors?from=2022-01-25&to=2022-03-09&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Ablink1073+updated%3A2022-01-25..2022-03-09&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Adependabot+updated%3A2022-01-25..2022-03-09&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Agithub-actions+updated%3A2022-01-25..2022-03-09&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Ajtpio+updated%3A2022-01-25..2022-03-09&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Akevin-bates+updated%3A2022-01-25..2022-03-09&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3AZsailer+updated%3A2022-01-25..2022-03-09&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 6.4.8
 


### PR DESCRIPTION
Automated Changelog Entry for 7.0.0a2 on main
```
Python version: 7.0.0a2
npm version: @jupyter-notebook/root: 0.1.0
npm workspace versions:
@jupyter-notebook/app: 7.0.0-alpha.2
@jupyter-notebook/buildutils: 7.0.0-alpha.2
@jupyter-notebook/metapackage: 7.0.0-alpha.2
@jupyter-notebook/application: 7.0.0-alpha.2
@jupyter-notebook/application-extension: 7.0.0-alpha.2
@jupyter-notebook/console-extension: 7.0.0-alpha.2
@jupyter-notebook/docmanager-extension: 7.0.0-alpha.2
@jupyter-notebook/documentsearch-extension: 7.0.0-alpha.2
@jupyter-notebook/help-extension: 7.0.0-alpha.2
@jupyter-notebook/lab-extension: 7.0.0-alpha.2
@jupyter-notebook/notebook-extension: 7.0.0-alpha.2
@jupyter-notebook/terminal-extension: 7.0.0-alpha.2
@jupyter-notebook/tree-extension: 7.0.0-alpha.2
@jupyter-notebook/ui-components: 7.0.0-alpha.2
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter/notebook  |
| Branch  | main  |
| Version Spec | next |
| Since | v7.0.0a1 |