### PR TITLE
Move the filebrowser search bar to the toolbar

### DIFF
--- a/packages/tree-extension/schema/widget.json
+++ b/packages/tree-extension/schema/widget.json
@@ -4,7 +4,6 @@
   "jupyter.lab.toolbars": {
     "FileBrowser": [
       { "name": "searcher", "rank": 0 },
-      { "name": "spacer", "type": "spacer", "rank": 900 },
       { "name": "new-dropdown", "rank": 1000 },
       { "name": "uploader", "rank": 1010 },
       { "name": "refresh", "command": "filebrowser:refresh", "rank": 1020 }

--- a/packages/tree-extension/schema/widget.json
+++ b/packages/tree-extension/schema/widget.json
@@ -3,6 +3,7 @@
   "description": "File Browser widget settings.",
   "jupyter.lab.toolbars": {
     "FileBrowser": [
+      { "name": "searcher", "rank": 0 },
       { "name": "spacer", "type": "spacer", "rank": 900 },
       { "name": "new-dropdown", "rank": 1000 },
       { "name": "uploader", "rank": 1010 },

--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -139,6 +139,7 @@ const browserWidget: JupyterFrontEndPlugin<void> = {
       (browser: FileBrowser) => {
         const searcher = FilenameSearcher({
           updateFilter: (filterFn: (item: string) => boolean) => {
+            // TODO: access via readonly attribute? (needs fix upstream)
             browser['listing'].model.setFilter(value => {
               return filterFn(value.name.toLowerCase());
             });

--- a/packages/tree-extension/style/base.css
+++ b/packages/tree-extension/style/base.css
@@ -41,3 +41,9 @@
 .jp-DropdownMenu .lm-MenuBar-itemIcon svg {
   vertical-align: sub;
 }
+
+.jp-FileBrowser-filterBox {
+  margin: 0;
+  padding-top: 5px;
+  padding-bottom: 5px;
+}

--- a/packages/tree-extension/style/base.css
+++ b/packages/tree-extension/style/base.css
@@ -42,7 +42,9 @@
   vertical-align: sub;
 }
 
-.jp-FileBrowser-filterBox {
+.jp-TreePanel .jp-FileBrowser-filterBox {
+  flex-grow: 1;
+  flex-shrink: 1;
   margin: 0;
   padding-top: 5px;
   padding-bottom: 5px;


### PR DESCRIPTION
Fixes #6341 

Opening early as a proof of concept.

This help save some vertical space, which is particularly useful on mobile devices.

## TODO

- [x] Register the file searcher via the toolbar registry
- [ ] Fix upstream to allow to not show the file search bar
- [ ] Fix upstream to access `listing`?

## Before

![image](https://user-images.githubusercontent.com/591645/161591188-0c9db8a9-6a1d-465e-91c7-23c327aa8c81.png)


## After

![image](https://user-images.githubusercontent.com/591645/161593232-fb1b1a08-b90e-4229-a17a-40ee5d03a603.png)

