### PR TITLE
Update to TypeScript 4.6

### DIFF
--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -33,7 +33,7 @@
     "@jupyterlab/buildutils": "^4.0.0-alpha.8",
     "commander": "^6.2.0",
     "fs-extra": "^9.1.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.6.3"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.10",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.0",
     "rimraf": "^3.0.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.6.3"
   },
   "jupyter-releaser": {
     "hooks": {

--- a/packages/_metapackage/package.json
+++ b/packages/_metapackage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupyter-notebook/metapackage",
-  "private": true,
   "version": "7.0.0-alpha.2",
+  "private": true,
   "description": "Jupyter Notebook - Metapackage",
   "homepage": "https://github.com/jupyter/notebook",
   "bugs": {
@@ -33,6 +33,6 @@
     "@jupyter-notebook/ui-components": "file:../ui-components"
   },
   "devDependencies": {
-    "typescript": "~4.1.3"
+    "typescript": "~4.6.3"
   }
 }

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -63,7 +63,7 @@
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/documentsearch-extension/package.json
+++ b/packages/documentsearch-extension/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lab-extension/package.json
+++ b/packages/lab-extension/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@jupyterlab/builder": "^4.0.0-alpha.8",
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tree-extension/package.json
+++ b/packages/tree-extension/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -56,7 +56,7 @@
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
-    "typescript": "~4.1.3"
+    "typescript": "~4.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,7 +1331,6 @@
     "@jupyterlab/apputils" "^4.0.0-alpha.8"
     "@jupyterlab/coreutils" "^6.0.0-alpha.8"
     "@jupyterlab/docregistry" "^4.0.0-alpha.8"
-    "@jupyterlab/mainmenu" "^4.0.0-alpha.8"
     "@jupyterlab/notebook" "^4.0.0-alpha.8"
     "@jupyterlab/translation" "^4.0.0-alpha.8"
     "@lumino/commands" "^1.20.0"
@@ -13212,15 +13211,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@~4.1.3:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
-  integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
-
 typescript@~4.5.2:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+
+typescript@~4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 typestyle@^2.0.4:
   version "2.3.0"


### PR DESCRIPTION
We were still using 4.1 up until now.

This PR updates to the latest stable version of TypeScript.