### PR TITLE
Add project URLs to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,10 @@ author = Jupyter Development Team
 author_email = jupyter@googlegroups.com
 url = https://github.com/jupyter/notebook
 platforms = Linux, Mac OS X, Windows
+project_urls =
+    Documentation = https://jupyter-notebook.readthedocs.io/
+    Source = https://github.com/jupyter/notebook
+    Tracker = https://github.com/jupyter/notebook/issues
 keywords = Jupyter, JupyterLab, Notebook
 classifiers =
     Intended Audience :: Developers


### PR DESCRIPTION
Adding project URLs (especially source code URL) makes it easier for dependency management tools (like Renovate).