### PR TITLE
Use var instead of const in sanitizer to partially fix ci js tests

### DIFF
--- a/notebook/static/base/js/security.js
+++ b/notebook/static/base/js/security.js
@@ -16,7 +16,7 @@ define([
          * if allow_css is true (default: false), CSS is sanitized as well.
          * otherwise, CSS elements and attributes are simply removed.
          */
-         const options = {};
+         var options = {};
          if (!allow_css) {
              options.allowedStyles = {};
          }


### PR DESCRIPTION
Partially fixes https://github.com/jupyter/notebook/issues/6319 for the js-tests

Phantom.js does not seem to recognize `const` keyword. We just have to change that to `var`. No sanitizer behavior is changed with this PR.