### PR TITLE
Update further to ipykernel comm refactoring

### DIFF
--- a/docs/source/comms.rst
+++ b/docs/source/comms.rst
@@ -78,7 +78,7 @@ containing Javascript to connect to it.
         # Send data to the frontend on creation
         comm.send({'foo': 5})
 
-    get_ipython().comm.comm_manager.register_target('my_comm_target', target_func)
+    get_ipython().kernel.comm_manager.register_target('my_comm_target', target_func)
 
 This example uses the IPython kernel again; this example will be different in
 other kernels that support comms. Refer to the specific language kernel's

--- a/docs/source/comms.rst
+++ b/docs/source/comms.rst
@@ -78,7 +78,7 @@ containing Javascript to connect to it.
         # Send data to the frontend on creation
         comm.send({'foo': 5})
 
-    get_ipython().kernel.comm_manager.register_target('my_comm_target', target_func)
+    get_ipython().comm.comm_manager.register_target('my_comm_target', target_func)
 
 This example uses the IPython kernel again; this example will be different in
 other kernels that support comms. Refer to the specific language kernel's

--- a/notebook/tests/services/kernel.js
+++ b/notebook/tests/services/kernel.js
@@ -310,7 +310,7 @@ casper.notebook_test(function () {
             this.thenEvaluate(function () {
                 var cell = IPython.notebook.get_cell(0);
                 cell.set_text("import os\n" +
-                              "from IPython.kernel.connect import get_connection_file\n" +
+                              "from ipykernel.connect import get_connection_file\n" +
                               "with open(get_connection_file(), 'w') as f:\n" +
                               "    f.write('garbage')\n" +
                               "os._exit(1)");

--- a/notebook/tests/services/serialize.js
+++ b/notebook/tests/services/serialize.js
@@ -33,7 +33,7 @@ casper.notebook_test(function () {
     this.then(function () {
         var index = this.append_cell([
             "import os",
-            "from IPython.comm.comm import Comm",
+            "from ipykernel.comm.comm import Comm",
             "comm = Comm(target_name='echo')",
             "msgs = []",
             "def on_msg(msg):",

--- a/notebook/tests/services/serialize.js
+++ b/notebook/tests/services/serialize.js
@@ -33,7 +33,7 @@ casper.notebook_test(function () {
     this.then(function () {
         var index = this.append_cell([
             "import os",
-            "from IPython.kernel.comm import Comm",
+            "from IPython.comm.comm import Comm",
             "comm = Comm(target_name='echo')",
             "msgs = []",
             "def on_msg(msg):",

--- a/notebook/tests/services/session.js
+++ b/notebook/tests/services/session.js
@@ -154,7 +154,7 @@ casper.notebook_test(function () {
             this.thenEvaluate(function () {
                 var cell = IPython.notebook.get_cell(0);
                 cell.set_text("import os\n" +
-                              "from IPython.kernel.connect import get_connection_file\n" +
+                              "from ipykernel.connect import get_connection_file\n" +
                               "with open(get_connection_file(), 'w') as f:\n" +
                               "    f.write('garbage')\n" +
                               "os._exit(1)");


### PR DESCRIPTION
This aims to fix the reported failing test on https://github.com/jupyter/notebook/runs/5984992147?check_suite_focus=true 

It just changes the needed imports to fit the latest and correct ipykernel package.

````
FAIL failed_restart: 3 events were triggered
#    type: assertEquals
#    file: /home/runner/work/notebook/notebook/notebook/tests/services/kernel.js
#    subject: 0
#    expected: 3
Test file: /home/runner/work/notebook/notebook/notebook/tests/services/serialize.js
PASS Created echo comm target
FAIL Error running cell:
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Input In [1], in <cell line: 2>()
```