### PR TITLE
Back to 6.4.10 main version, instead of 6.5.0.dev0

### DIFF
--- a/notebook/_version.py
+++ b/notebook/_version.py
@@ -5,7 +5,7 @@ store the current version info of the notebook.
 import re
 
 # Version string must appear intact for tbump versioning
-__version__ = '6.5.0.dev0'
+__version__ = '6.4.10'
 
 # Build up version_info tuple for backwards compatibility
 pattern = r'(?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)(?P<rest>.*)'

--- a/notebook/static/base/js/namespace.js
+++ b/notebook/static/base/js/namespace.js
@@ -73,7 +73,7 @@ define(function(){
     // tree
     jglobal('SessionList','tree/js/sessionlist');
 
-    Jupyter.version = "6.5.0.dev0";
+    Jupyter.version = "6.4.10";
     Jupyter._target = '_blank';
 
     return Jupyter;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ before-build-python = ["pip install babel", "npm install -g po2json"]
 ignore-glob = ["docs/source/examples/Notebook/Working With Markdown Cells.ipynb", "docs-translations/**/README.md", "docs/source/contributing.rst", "docs/source/examples/Notebook/JavaScript Notebook Extensions.ipynb", "CHANGELOG.md", "notebook/static/components/**/*.*"]
 
 [tool.tbump.version]
-current = "6.5.0.dev0"
+current = "6.4.10"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?


### PR DESCRIPTION
This PR reverts https://github.com/jupyter/notebook/commit/232f724c64ddf84d8a21d630bde5ea2be3f4b586 in an attempt to use the jupyter_releaser to cut 6.4.11 as discussed with @blink1073 