### PR TITLE
Fix ESLint config for tests

### DIFF
--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -8,5 +8,7 @@
     "docs/**/*",
     ".eslintrc.js"
   ],
-  "types": ["jest"]
+  "compilerOptions": {
+    "types": ["jest"]
+  }
 }


### PR DESCRIPTION
ESLint would otherwise give the following error when used in VS Code:

```
Parsing error: 'types' should be set inside the 'compilerOptions' object of the config json file
```