### PR TITLE
workflow to transfer issues from notebook repo to nbclassic repo

### DIFF
--- a/.github/workflows/transfer-issue.yml
+++ b/.github/workflows/transfer-issue.yml
@@ -1,0 +1,43 @@
+name: Transfer Issue
+on:
+  issues:
+    types:
+      - labeled
+    if: github.event.label == 'nbclassic'
+
+jobs:
+  transfer-and-comment-action:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        router:
+        # label_triggering_workflow:destination_repository_name
+          - nbclassic:nbclassic
+    steps:
+      - uses: actions/checkout@v3
+      - name: Transfer Issue
+        uses: lando/transfer-issue-action@v2.0.3
+        id: transfer-issue
+        with:
+          token: ${{ secrets.TRANSFER_ISSUE }} 
+          # applied_label:color_of_applied_label
+          apply_label: "transferred:D5B795"
+          router: ${{ matrix.router}}
+          debug: true
+      - name: Echo New Issue Data
+        run: |
+          echo "DESTINATION REPO: ${{steps.transfer-issue.outputs.destination_repo}}"
+          echo "NEW ISSUE NUMBER: ${{steps.transfer-issue.outputs.new_issue_number}}"
+          echo "NEW ISSUE URL: ${{steps.transfer-issue.outputs.new_issue_url}}"
+      - name: Update Transferred Issue with Comment
+        uses: actions/github-script@v6.1.0
+        if: steps.transfer-issue.outputs.new_issue_number != ''
+        with:
+          github-token: ${{ secrets.TRANSFER_ISSUE }}
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: `${{ steps.transfer-issue.outputs.new_issue_number}}`,
+              owner: context.repo.owner,
+              repo: `${{ steps.transfer-issue.outputs.destination_repo }}`,
+              body: `@${ context.payload.issue.user.login } your issue is has been moved to the appropriate repo!`
+            });


### PR DESCRIPTION
 After 'nbclassic' label is added.

**Purpose**:
Workflow moves an issue submitted to this repository to another repository based on the label added, so long as the proper `label_name:destination_repository` is added to the router list in the yaml file. Repositories should be within the same organization.
- Currently, this workflow will only move an issue in this repository to the jupyter/nbclassic repository, if it gets labeled with the label ‘nbclassic’.

**Needs**:
1. A bot account with admin permissions at the organization level.
2. A personal access token, created by the bot account, with scope for workflow (automatically includes repo scopes).
3. The bot account’s personal access token added to the organization as a secret named ‘TRANSFER_ISSUE’.
4. After adding the personal access token as a secret in the organization, we can downgrade bot user to ‘Write’ permissions only.

**Users Involved**:
1. A user who submits the issue.
2. The labeler of the issue will remain as the person who added the label.
3. The “bot” account which will be the owner of the personal access token created.
	- This account only needs to be an admin at the organization level so that it can add it’s own personal access token as a secret in the organization.
	- The name of this bot account will be displayed as the user who moved the issue to another repo and as the author of the comment pinging the user who submitted the issue, notifying them that their issue was moved.

**Permissions Needed for the Personal Access Token**:
Workflow —> automatically gives access to all repo checkboxes
* repo Full control of private repositories
    * repo:status Access commit status
    * repo_deployment Access deployment status
    * public_repo Access public repositories
    * repo:invite Access repository invitations
    * security_events Read and write security events
* workflow Update GitHub Action workflows