### PR TITLE
Fix tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ test = [
     "pytest>=6.0",
     "pytest-cov",
     "requests",
-    "pytest-tornasync",
     "pytest-timeout",
     "pytest-console-scripts",
     "ipykernel",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ test = [
     "pytest>=6.0",
     "pytest-cov",
     "requests",
+    "pytest-tornasync",
     "pytest-timeout",
     "pytest-console-scripts",
     "ipykernel",
@@ -123,4 +124,5 @@ timeout = 300
 filterwarnings = [
     "error",
     "ignore:There is no current event loop:DeprecationWarning",
+    "make_current is deprecated; start the event loop first"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,5 +124,6 @@ timeout = 300
 filterwarnings = [
     "error",
     "ignore:There is no current event loop:DeprecationWarning",
-    "ignore:make_current is deprecated; start the event loop first"
+    "ignore:make_current is deprecated; start the event loop first",
+    "ignore:clear_current is deprecated"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,5 +124,5 @@ timeout = 300
 filterwarnings = [
     "error",
     "ignore:There is no current event loop:DeprecationWarning",
-    "make_current is deprecated; start the event loop first"
+    "ignore:make_current is deprecated; start the event loop first"
 ]


### PR DESCRIPTION
Tests have started failing with the latest `tornado` release which deprecates: https://www.tornadoweb.org/en/stable/releases/v6.2.0.html#deprecation-notice

> The [IOLoop](https://www.tornadoweb.org/en/stable/ioloop.html#tornado.ioloop.IOLoop) constructor is deprecated unless the make_current=False argument is used. Use [IOLoop.current](https://www.tornadoweb.org/en/stable/ioloop.html#tornado.ioloop.IOLoop.current) when the loop is already running instead.

Example run: https://github.com/jupyter/notebook/runs/7191744285?check_suite_focus=true

This PR attempts at fixing it.