### PR TITLE
Handle execution errors with empty traceback entries similar to Lab

### DIFF
--- a/notebook/static/notebook/js/outputarea.js
+++ b/notebook/static/notebook/js/outputarea.js
@@ -505,14 +505,21 @@ define([
 
 
     OutputArea.prototype.append_error = function (json) {
+        var ename = json.ename;
+        var evalue = json.evalue;
         var tb = json.traceback;
+        var s = '';
         if (tb !== undefined && tb.length > 0) {
-            var s = '';
             var len = tb.length;
             for (var i=0; i<len; i++) {
                 s = s + tb[i] + '\n';
             }
             s = s + '\n';
+        } else if (ename !== undefined && ename.length > 0 && evalue !== undefined && evalue.length > 0) {
+            // If traceback is empty, and we have ename and evalue entries, concatenate the two to display
+            s = ename + ': ' + evalue;
+        }
+        if (s.length > 0) {
             var toinsert = this.create_output_area();
             var append_text = OutputArea.append_map[MIME_TEXT];
             if (append_text) {


### PR DESCRIPTION
Some kernels (like Apache Toree) don't always set a traceback entry when returning errors.  An example of this is an immediate syntax error that occurs for code like `sdfsf`.  In such cases, Notebook does not render any output for the error, 
![toree-current-nb](https://user-images.githubusercontent.com/22599560/177863154-387ba8ce-5ed3-4df3-a92a-3462b853c0b4.png)
yet Jupyter Lab does...
![toree-current-lab](https://user-images.githubusercontent.com/22599560/177863169-274476ad-194a-4b17-801b-aa74bfcfe437.png)

In analyzing both the message responses and code bases, it turns out that Lab will display [_either_ the traceback, if it has a value, or the composition of the `ename` and `evalue` entries](https://github.com/jupyterlab/jupyterlab/blob/a7bbd4b64d8c25f51d9fb040a22662b8324d032c/packages/rendermime/src/outputmodel.ts#L281-L282), while [Notebook only displays the `traceback` entry](https://github.com/jupyter/notebook/blob/6.4.x/notebook/static/notebook/js/outputarea.js#L507-L523) (if there's a value).

This pull request updates Notebook's 6.4.x branch with equivalent code to Lab - rendering similar output.  (Note that the second cell's output is produced from a non-empty `traceback`.)
![toree-fix-nb](https://user-images.githubusercontent.com/22599560/177865812-b2c4f945-0751-4490-9e2b-6d624d9d5094.png)

(Heads up.  I'm not a javascript dev and tried to follow current formatting and practices - so please feel free to correct anything that is superfluous or improper.)  
