### PR TITLE
Update versioning mechanism and pin jupyter_client<7

### DIFF
--- a/notebook/_version.py
+++ b/notebook/_version.py
@@ -2,12 +2,15 @@
 store the current version info of the notebook.
 
 """
+import re
 
-# Downstream maintainer, when running `python.setup.py jsversion`,
-# the version string is propagated to the JavaScript files,  do not forget to
-# patch the JavaScript files in `.postN` release done by distributions.
+# Next beta (b)/ alpha (a)/ release candidate (rc) release: The version number for alpha is X.Y.ZaN
+__version__ = '5.7.14a0'
 
-# Next beta/alpha/rc release: The version number for beta is X.Y.ZbN **without dots**.
-
-version_info = (5, 7, 13)
-__version__ = '.'.join(map(str, version_info[:3])) + ''.join(version_info[3:])
+# Build up version_info tuple for backwards compatibility
+pattern = r'(?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)(?P<rest>.*)'
+match = re.match(pattern, __version__)
+parts = [int(match[part]) for part in ['major', 'minor', 'patch']]
+if match['rest']:
+    parts.append(match['rest'])
+version_info = tuple(parts)

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ for more information.
         'ipython_genutils',
         'traitlets>=4.2.1',
         'jupyter_core>=4.4.0',
-        'jupyter_client>=5.2.0',
+        'jupyter_client>=5.2.0,<7.0.0',
         'nbformat',
         'nbconvert<6.0',
         'ipykernel', # bless IPython kernel for now


### PR DESCRIPTION
- Use version parsing from 6.5.x branch to construct the version tuple here and allow use of 'a', 'b' and 'rc' strings in version.
- Pin jupyter_client<7 to avoid asyncio runtime error outlined [here](https://github.com/jupyter/notebook/issues/6164).