### PR TITLE
Pin `ypy-websocket` to `0.2`

### DIFF
--- a/.github/actions/build-dist/action.yml
+++ b/.github/actions/build-dist/action.yml
@@ -9,7 +9,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        python -m pip install --upgrade jupyter_packaging~=0.10 "jupyterlab>=4.0.0a25,<5" build
+        python -m pip install --upgrade jupyter_packaging~=0.10 "jupyterlab>=4.0.0a25,<5" ypy-websocket==0.2 build
 
     - name: Build pypi distributions
       shell: bash

--- a/.github/workflows/buildutils.yml
+++ b/.github/workflows/buildutils.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install -U "jupyterlab>=4.0.0a25,<5" hatch
+        python -m pip install -U "jupyterlab>=4.0.0a25,<5" ypy-websocket==0.2 hatch
         jlpm
         jlpm run build
 
@@ -81,6 +81,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install -U "jupyterlab>=4.0.0a25,<5" pip
+        python -m pip install -U "jupyterlab>=4.0.0a25,<5" ypy-websocket==0.2 pip
         jlpm
         jlpm run build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.0", "jupyterlab>=4.0.0a25,<5"]
+requires = ["hatchling>=1.0", "jupyterlab>=4.0.0a25,<5", "ypy-websocket==0.2"]
 build-backend = "hatchling.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "jupyterlab_server>=2.13,<3",
     "notebook_shim>=0.1,<0.2",
     "tornado>=6.1.0",
+    "ypy-websocket==0.2",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Temporary pin for `ypy-websocket` to help fix the broken CI.