### PR TITLE
Uninstall `nbclassic` on Binder so Notebook v7 can load

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -2,6 +2,10 @@
 set -euo pipefail
 
 python -m pip install -e . --force-reinstall
+
+# TODO: remove when it's possible to install nbclassic next to Notebook v7
+# without nbclassic shadowing the v7 endpoints
 python -m pip uninstall nbclassic -y
+
 jlpm && jlpm run build
 jlpm run develop

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 python -m pip install -e . --force-reinstall
+python -m pip uninstall nbclassic
 jlpm && jlpm run build
 jlpm run develop

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-python -m pip install -e .
+python -m pip install -e . --force-reinstall
 jlpm && jlpm run build
 jlpm run develop

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -2,6 +2,6 @@
 set -euo pipefail
 
 python -m pip install -e . --force-reinstall
-python -m pip uninstall nbclassic
+python -m pip uninstall nbclassic -y
 jlpm && jlpm run build
 jlpm run develop


### PR DESCRIPTION
As noted in https://github.com/jupyter/notebook/pull/6496#issuecomment-1205422753, Binder does not start v7 anymore:

![image](https://user-images.githubusercontent.com/591645/182887751-7af5fd41-1585-4667-83a9-30b03065e694.png)

This is currently happening on the `main` branch. Opening this PR to troubleshoot the issue.