### PR TITLE
Add Gitpod files

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,41 @@
+github:
+  prebuilds:
+    master: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: false
+    addComment: false
+    addBadge: false
+    addLabel: false
+tasks:
+  - name: setup
+    init: |
+      pushd /workspace
+      wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+      popd
+      # bootstrap activation commands for other tasks to reuse
+      cat <<EOT > /workspace/bin/activate-env.sh
+      export MAMBA_ROOT_PREFIX=/workspace/.micromamba
+      export MAMBA_EXE=/workspace/bin/micromamba
+      $(/workspace/bin/micromamba shell hook --shell=bash)
+      export JUPYTER_PREFER_ENV_PATH=1
+      micromamba activate
+      EOT
+      source /workspace/bin/activate-env.sh
+      echo "source /workspace/bin/activate-env.sh" >> ~/.bashrc
+      micromamba install -n base -y -c conda-forge python=3.10 nodejs=14 yarn
+      python -m pip install -e ".[dev,test]" && jlpm && jlpm run build && jlpm develop
+      gp sync-done setup
+    command: |
+      gp sync-done setup
+      source /workspace/bin/activate-env.sh
+      jupyter notebook --no-browser --JupyterNotebookApp.token='' --JupyterNotebookApp.allow_origin=* --JupyterNotebookApp.tornado_settings='{"headers": {"Content-Security-Policy": "frame-ancestors *"}}'
+
+  - name: watch
+    command: |
+      gp sync-await setup
+      source /workspace/bin/activate-env.sh
+      jlpm watch
+
+ports:
+  - port: 8888


### PR DESCRIPTION
Add a micromamba-based Gitpod setup to the repo so it's easier to:

- onboard new contributors
- make changes and open PRs
- review PRs

![image](https://user-images.githubusercontent.com/591645/186111556-ba9e9eff-4bf7-4941-81a5-1f2912d9ab90.png)

Everything is self-contained in the `.gitpod.yml` file. The `init` tasks generates the prefix under `/workspace/.micromamba` so the environment is not lost when a workspace is stopped and restarted (changes under `/workspace` are kept).