### PR TITLE
Using group method to match regex items 

### DIFF
--- a/notebook/_version.py
+++ b/notebook/_version.py
@@ -10,7 +10,7 @@ __version__ = '5.7.14.dev'
 # Build up version_info tuple for backwards compatibility
 pattern = r'(?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)(?P<rest>.*)'
 match = re.match(pattern, __version__)
-parts = [int(match[part]) for part in ['major', 'minor', 'patch']]
-if match['rest']:
-    parts.append(match['rest'])
+parts = [int(match.group(part)) for part in ['major', 'minor', 'patch']]
+if match.group('rest'):
+    parts.append(match.group('rest'))
 version_info = tuple(parts)


### PR DESCRIPTION
Works for Python versions < 3.6. Fixes #6521 so users can install extensions as noted by @GaspardBT