### PR TITLE
Troubleshoot failing `macos` check on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           architecture: 'x64'
       - name: Install the prerequisites
         run: |
-          ${{ matrix.py_cmd }} -m pip install pip wheel
+          ${{ matrix.py_cmd }} -m pip install -U pip wheel
       - name: Install the package
         run: |
           cd dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ concurrency:
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
+  SYSTEM_VERSION_COMPAT: 0
 
 defaults:
   run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,15 +79,15 @@ jobs:
           - os: ubuntu-latest
             py_cmd: python
     steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: notebook-dist-${{ github.run_number }}
-          path: ./dist
       - name: Install Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: 'x64'
+      - uses: actions/download-artifact@v2
+        with:
+          name: notebook-dist-${{ github.run_number }}
+          path: ./dist
       - name: Install the prerequisites
         run: |
           ${{ matrix.py_cmd }} -m pip install -U pip wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
             py_cmd: python
     steps:
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: 'x64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,10 @@ concurrency:
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
 
+defaults:
+  run:
+    shell: bash -e {0}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,15 +76,15 @@ jobs:
           - os: ubuntu-latest
             py_cmd: python
     steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: notebook-dist-${{ github.run_number }}
+          path: ./dist
       - name: Install Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: 'x64'
-      - uses: actions/download-artifact@v2
-        with:
-          name: notebook-dist-${{ github.run_number }}
-          path: ./dist
       - name: Install the prerequisites
         run: |
           ${{ matrix.py_cmd }} -m pip install pip wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    shell: bash -l {0}
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
-env:
-  PIP_DISABLE_PIP_VERSION_CHECK: 1
-  SYSTEM_VERSION_COMPAT: 0
-
 defaults:
   run:
     shell: bash -l {0}

--- a/.github/workflows/buildutils.yml
+++ b/.github/workflows/buildutils.yml
@@ -74,7 +74,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
         architecture: 'x64'


### PR DESCRIPTION
Trying to fixing the `macos` failure on CI with mismatched Python versions.