### PR TITLE
Add task to auto activate the dev environment on Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -30,7 +30,7 @@ tasks:
       source /workspace/bin/activate-env.sh
       jupyter notebook --no-browser --JupyterNotebookApp.token='' --JupyterNotebookApp.allow_origin=* --JupyterNotebookApp.tornado_settings='{"headers": {"Content-Security-Policy": "frame-ancestors *"}}'
 
-  - name: watch
+  - name: auto-activate
     command: |
       gp sync-await setup
       source /workspace/bin/activate-env.sh

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,7 +22,6 @@ tasks:
       micromamba activate
       EOT
       source /workspace/bin/activate-env.sh
-      echo "source /workspace/bin/activate-env.sh" >> ~/.bashrc
       micromamba install -n base -y -c conda-forge python=3.10 nodejs=14 yarn
       python -m pip install -e ".[dev,test]" && jlpm && jlpm run build && jlpm develop
       gp sync-done setup
@@ -36,6 +35,11 @@ tasks:
       gp sync-await setup
       source /workspace/bin/activate-env.sh
       jlpm watch
+      
+  - name: shell
+    command: |
+      gp sync-await setup
+      echo "source /workspace/bin/activate-env.sh" >> ~/.bashrc
 
 ports:
   - port: 8888

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -40,6 +40,7 @@ tasks:
     command: |
       gp sync-await setup
       echo "source /workspace/bin/activate-env.sh" >> ~/.bashrc
+      source /workspace/bin/activate-env.sh
 
 ports:
   - port: 8888

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -35,7 +35,7 @@ tasks:
       gp sync-await setup
       source /workspace/bin/activate-env.sh
       jlpm watch
-      
+
   - name: shell
     command: |
       gp sync-await setup


### PR DESCRIPTION
Follow-up to #6518 

So the micromamba environment is automatically activated when new terminals are created: 

![image](https://user-images.githubusercontent.com/591645/187139400-424680ea-c641-4a97-a7e1-188b0ac4c4a4.png)
