### PR TITLE
Strip newlines from token file

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -995,7 +995,7 @@ class NotebookApp(JupyterApp):
         if os.getenv('JUPYTER_TOKEN_FILE'):
             self._token_generated = False
             with open(os.getenv('JUPYTER_TOKEN_FILE')) as token_file:
-                return token_file.read()
+                return token_file.read().strip("\n\r")
         if self.password:
             # no token if password is enabled
             self._token_generated = False


### PR DESCRIPTION
It's common for text editors and shell redirection to generate a file that ends in a newline, which is then extremely difficult, if not impossible, to enter into the browser. After a...while...debugging, I realized that in generating my token file with 

```
$ python3 -c "print(__import__('secrets').token_urlsafe())" > .tokenfile
$ xxd .tokenfile 
00000000: 6c6f 7036 7675 6637 6e38 396c 3677 7538  lop6vuf7n89l6wu8
00000010: 2d79 7039 5768 7665 755f 385a 786b 4b31  -yp9Whveu_8ZxkK1
00000020: 3034 6e35 456c 464c 4e73 510a            04n5ElFLNsQ.
```

There's that trailing `0a`, or `\n`. I hot-hacked on an all-encompassing `.strip()` onto my local Jupyter, but just stripping `\n\r` is probably the most conservative. If a user really hates themselves, they can put tabs in there, or a newline in the middle.

Theoretically, this is a breaking change, but if that's the case, then I'd like to know how to get a newline in a browser's password field. 7.x/main branch seems to have radically refactored code, so I don't know where this logic is there.

If this was new, I'd probably have examined the token string and either raised a warning or just flat out refuse to start if it's a multiline string, e.g. if someone tried to generate a token but the generation failed for some reason and the file was just a traceback.