### PR TITLE
Remove the `nbclassic` explicit uninstall on Binder

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -3,9 +3,5 @@ set -euo pipefail
 
 python -m pip install -e . --force-reinstall
 
-# TODO: remove when it's possible to install nbclassic next to Notebook v7
-# without nbclassic shadowing the v7 endpoints
-python -m pip uninstall nbclassic -y
-
 jlpm && jlpm run build
 jlpm run develop


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/6547

The Binder build should hopefully pick up the `nbclassic>=0.4.4`: https://github.com/jupyter/nbclassic/pull/141#issuecomment-1262584381