### PR TITLE
fix activate environment according to mamba documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ The `jlpm` command is JupyterLab's pinned version of [yarn](https://yarnpkg.com/
 mamba create -n notebook -c conda-forge python nodejs -y
 
 # activate the environment
-mamba activate notebook
+conda activate notebook
 
 # Install package in development mode
 pip install -e ".[dev,test]"


### PR DESCRIPTION
According to mamba [documentation](https://mamba.readthedocs.io/en/latest/user_guide/mamba.html#mamba-vs-conda-clis), 

![image](https://user-images.githubusercontent.com/10113390/193402540-c57f2fb4-a397-4832-8a09-6f08752f2d18.png)

`mamba activate notebook` has to be changed to `conda activate notebook`.