### PR TITLE
Fix: No mouse pointer when hovering on the Jupyter icon

### DIFF
--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -138,7 +138,8 @@ const logo: JupyterFrontEndPlugin<void> = {
       elementPosition: 'center',
       padding: '2px 2px 2px 8px',
       height: '28px',
-      width: 'auto'
+      width: 'auto',
+      cursor: 'pointer'
     });
     logo.id = 'jp-NotebookLogo';
     app.shell.add(logo, 'top', { rank: 0 });


### PR DESCRIPTION
Fix for issue #6532

Quick context: 
The cursor was not changing into a pointer when hovered over Jupyter icon on navbar.

https://user-images.githubusercontent.com/26214265/193533886-8450bb4b-83c0-4eef-b212-42b75f23df15.mp4

