### PR TITLE
Ensure custom preload is correctly handled

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -13,7 +13,7 @@ dependencies:
 - sphinx
 - terminado
 - myst-parser
-- nbclassic==0.4.5
+- nbclassic==0.4.6
 - pip:
   - nbsphinx
   - Send2Trash

--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -98,6 +98,18 @@
           }
       })
 
+      // error-catching custom-preload.js shim.
+      define("custom-preload", function (require, exports, module) {
+          try {
+              var custom = require('custom/custom-preload');
+              console.debug('loaded custom-preload.js');
+              return custom;
+          } catch (e) {
+              console.error("error loading custom-preload.js", e);
+              return {};
+          }
+      })
+
     document.nbjs_translations = {{ nbjs_translations|safe }};
     document.documentElement.lang = navigator.language.toLowerCase();
     </script>

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ for more information.
         'Send2Trash>=1.8.0',
         'terminado>=0.8.3',
         'prometheus_client',
-        'nbclassic==0.4.5',
+        'nbclassic==0.4.6',
     ],
     extras_require = {
         'test': ['pytest', 'coverage', 'requests', 'testpath',

--- a/tools/build-main.js
+++ b/tools/build-main.js
@@ -60,6 +60,7 @@ var rjs_config = {
 
   exclude: [
     "custom/custom",
+    "custom/custom-preload",
   ]
 };
 


### PR DESCRIPTION
Follow-up of https://github.com/jupyter/nbclassic/pull/155

The custom preload needs to be handled in `page.html` and `build-main.js`.

We also bump and pin to `nbclassic==0.4.6`.