### PR TITLE
Explicitly specify favicon for /tree view in Notebook

### DIFF
--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{page_config['appName'] | e}} - Tree</title>
+  {% block favicon %}
+  <link rel="icon" type="image/x-icon" href="{{ base_url | escape }}static/favicons/favicon.ico" class="favicon">
+  {% endblock %}
 </head>
 <body>
 


### PR DESCRIPTION
This is instead of relying on /favicon.ico resolving to the correct artifact

Closes #6607 