### PR TITLE
Fix rename_file to handle relative paths properly (related to GHSA-v7vq-3x77-87vg?)

### DIFF
--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -526,13 +526,13 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         os_path = self._get_os_path(path)
         rm = os.unlink
         
+        if is_hidden(os_path, self.root_dir) and not self.allow_hidden:
+            raise web.HTTPError(400, f'Cannot delete file or directory {os_path!r}')
+
         four_o_four = "file or directory does not exist: %r" % path
 
         if not self.exists(path):
             raise web.HTTPError(404, four_o_four)
-
-        if is_hidden(os_path, self.root_dir) and not self.allow_hidden:
-            raise web.HTTPError(400, f'Cannot delete file or directory {os_path!r}')
 
         def is_non_empty_dir(os_path):
             if os.path.isdir(os_path):

--- a/notebook/services/contents/filemanager.py
+++ b/notebook/services/contents/filemanager.py
@@ -575,15 +575,15 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         if new_path == old_path:
             return
 
-        if (is_hidden(old_path, self.root_dir) or is_hidden(new_path, self.root_dir)) and not self.allow_hidden:
-            raise web.HTTPError(400, f'Cannot rename file or directory {old_path!r}')
-
         # Perform path validation prior to converting to os-specific value since this
         # is still relative to root_dir.
         self._validate_path(new_path)
 
         new_os_path = self._get_os_path(new_path)
         old_os_path = self._get_os_path(old_path)
+
+        if (is_hidden(old_os_path, self.root_dir) or is_hidden(new_os_path, self.root_dir)) and not self.allow_hidden:
+            raise web.HTTPError(400, f'Cannot rename file or directory {old_path!r}')
 
         # Should we proceed with the move?
         if os.path.exists(new_os_path) and not samefile(old_os_path, new_os_path):

--- a/notebook/services/contents/tests/test_manager.py
+++ b/notebook/services/contents/tests/test_manager.py
@@ -253,76 +253,68 @@ class TestFileContentsManager(TestCase):
 
         #Test rename behavior
         #Test rename with source file in hidden directory
-        with self.assertRaises(HTTPError) as excinfo:
-            with TemporaryDirectory() as td:
-                cm = FileContentsManager(root_dir=td)
-                hidden_dir = '.hidden'
-                file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
-                _make_dir(cm, hidden_dir)
-                model = cm.new(path=file_in_hidden_path)
-                old_path = cm._get_os_path(model['path'])
-                new_path = "new.txt"
+        with TemporaryDirectory() as td:
+            cm = FileContentsManager(root_dir=td)
+            hidden_dir = '.hidden'
+            file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
+            _make_dir(cm, hidden_dir)
+            old_path = file_in_hidden_path
+            new_path = "new.txt"
 
-                try:
-                    result = cm.rename_file(old_path, new_path)
-                except HTTPError as e:
-                    self.assertEqual(e.status_code, 400)
-                else:
-                    self.fail("Should have raised HTTPError(400)")
+            try:
+                result = cm.rename_file(old_path, new_path)
+            except HTTPError as e:
+                self.assertEqual(e.status_code, 400)
+            else:
+                self.fail("Should have raised HTTPError(400)")
 
         #Test rename of dest file in hidden directory
-        with self.assertRaises(HTTPError) as excinfo:
-            with TemporaryDirectory() as td:
-                cm = FileContentsManager(root_dir=td)
-                hidden_dir = '.hidden'
-                file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
-                _make_dir(cm, hidden_dir)
-                model = cm.new(path=file_in_hidden_path)
-                new_path = cm._get_os_path(model['path'])
-                old_path = "old.txt"
+        with TemporaryDirectory() as td:
+            cm = FileContentsManager(root_dir=td)
+            hidden_dir = '.hidden'
+            file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
+            _make_dir(cm, hidden_dir)
+            new_path = file_in_hidden_path
+            old_path = "old.txt"
 
-                try:
-                    result = cm.rename_file(old_path, new_path)
-                except HTTPError as e:
-                    self.assertEqual(e.status_code, 400)
-                else:
-                    self.fail("Should have raised HTTPError(400)")
+            try:
+                result = cm.rename_file(old_path, new_path)
+            except HTTPError as e:
+                self.assertEqual(e.status_code, 400)
+            else:
+                self.fail("Should have raised HTTPError(400)")
 
         #Test rename with hidden source file in visible directory
-        with self.assertRaises(HTTPError) as excinfo:
-            with TemporaryDirectory() as td:
-                cm = FileContentsManager(root_dir=td)
-                hidden_dir = 'visible'
-                file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
-                _make_dir(cm, hidden_dir)
-                model = cm.new(path=file_in_hidden_path)
-                old_path = cm._get_os_path(model['path'])
-                new_path = "new.txt"
+        with TemporaryDirectory() as td:
+            cm = FileContentsManager(root_dir=td)
+            hidden_dir = 'visible'
+            file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
+            _make_dir(cm, hidden_dir)
+            old_path = file_in_hidden_path
+            new_path = "new.txt"
 
-                try:
-                    result = cm.rename_file(old_path, new_path)
-                except HTTPError as e:
-                    self.assertEqual(e.status_code, 400)
-                else:
-                    self.fail("Should have raised HTTPError(400)")
+            try:
+                result = cm.rename_file(old_path, new_path)
+            except HTTPError as e:
+                self.assertEqual(e.status_code, 400)
+            else:
+                self.fail("Should have raised HTTPError(400)")
 
         #Test rename with hidden dest file in visible directory
-        with self.assertRaises(HTTPError) as excinfo:
-            with TemporaryDirectory() as td:
-                cm = FileContentsManager(root_dir=td)
-                hidden_dir = 'visible'
-                file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
-                _make_dir(cm, hidden_dir)
-                model = cm.new(path=file_in_hidden_path)
-                new_path = cm._get_os_path(model['path'])
-                old_path = "old.txt"
+        with TemporaryDirectory() as td:
+            cm = FileContentsManager(root_dir=td)
+            hidden_dir = 'visible'
+            file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
+            _make_dir(cm, hidden_dir)
+            new_path = file_in_hidden_path
+            old_path = "old.txt"
 
-                try:
-                    result = cm.rename_file(old_path, new_path)
-                except HTTPError as e:
-                    self.assertEqual(e.status_code, 400)
-                else:
-                    self.fail("Should have raised HTTPError(400)")
+            try:
+                result = cm.rename_file(old_path, new_path)
+            except HTTPError as e:
+                self.assertEqual(e.status_code, 400)
+            else:
+                self.fail("Should have raised HTTPError(400)")
 
     @skipIf(sys.platform.startswith('win'), "Can't test hidden files on Windows")
     def test_404(self):

--- a/notebook/services/contents/tests/test_manager.py
+++ b/notebook/services/contents/tests/test_manager.py
@@ -261,12 +261,9 @@ class TestFileContentsManager(TestCase):
             old_path = file_in_hidden_path
             new_path = "new.txt"
 
-            try:
-                result = cm.rename_file(old_path, new_path)
-            except HTTPError as e:
-                self.assertEqual(e.status_code, 400)
-            else:
-                self.fail("Should have raised HTTPError(400)")
+            with self.assertRaises(HTTPError) as excinfo:
+                cm.rename_file(old_path, new_path)
+            self.assertEqual(excinfo.exception.status_code, 400)
 
         #Test rename of dest file in hidden directory
         with TemporaryDirectory() as td:
@@ -277,12 +274,9 @@ class TestFileContentsManager(TestCase):
             new_path = file_in_hidden_path
             old_path = "old.txt"
 
-            try:
-                result = cm.rename_file(old_path, new_path)
-            except HTTPError as e:
-                self.assertEqual(e.status_code, 400)
-            else:
-                self.fail("Should have raised HTTPError(400)")
+            with self.assertRaises(HTTPError) as excinfo:
+                cm.rename_file(old_path, new_path)
+            self.assertEqual(excinfo.exception.status_code, 400)
 
         #Test rename with hidden source file in visible directory
         with TemporaryDirectory() as td:
@@ -293,12 +287,9 @@ class TestFileContentsManager(TestCase):
             old_path = file_in_hidden_path
             new_path = "new.txt"
 
-            try:
-                result = cm.rename_file(old_path, new_path)
-            except HTTPError as e:
-                self.assertEqual(e.status_code, 400)
-            else:
-                self.fail("Should have raised HTTPError(400)")
+            with self.assertRaises(HTTPError) as excinfo:
+                cm.rename_file(old_path, new_path)
+            self.assertEqual(excinfo.exception.status_code, 400)
 
         #Test rename with hidden dest file in visible directory
         with TemporaryDirectory() as td:
@@ -309,12 +300,9 @@ class TestFileContentsManager(TestCase):
             new_path = file_in_hidden_path
             old_path = "old.txt"
 
-            try:
-                result = cm.rename_file(old_path, new_path)
-            except HTTPError as e:
-                self.assertEqual(e.status_code, 400)
-            else:
-                self.fail("Should have raised HTTPError(400)")
+            with self.assertRaises(HTTPError) as excinfo:
+                cm.rename_file(old_path, new_path)
+            self.assertEqual(excinfo.exception.status_code, 400)
 
     @skipIf(sys.platform.startswith('win'), "Can't test hidden files on Windows")
     def test_404(self):

--- a/notebook/services/contents/tests/test_manager.py
+++ b/notebook/services/contents/tests/test_manager.py
@@ -185,37 +185,26 @@ class TestFileContentsManager(TestCase):
     def test_400(self):
         #Test Delete behavior
         #Test delete of file in hidden directory
-        with self.assertRaises(HTTPError) as excinfo:
-            with TemporaryDirectory() as td:
-                cm = FileContentsManager(root_dir=td)
-                hidden_dir = '.hidden'
-                file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
-                _make_dir(cm, hidden_dir)
-                model = cm.new(path=file_in_hidden_path)
-                os_path = cm._get_os_path(model['path'])
+        with TemporaryDirectory() as td:
+            cm = FileContentsManager(root_dir=td)
+            hidden_dir = '.hidden'
+            file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
+            _make_dir(cm, hidden_dir)
 
-                try:
-                    result = cm.delete_file(os_path)
-                except HTTPError as e:
-                    self.assertEqual(e.status_code, 400)
-                else:
-                    self.fail("Should have raised HTTPError(400)")
+            with self.assertRaises(HTTPError) as excinfo:
+                cm.delete_file(file_in_hidden_path)
+            self.assertEqual(excinfo.exception.status_code, 400)
+
         #Test delete hidden file in visible directory
-        with self.assertRaises(HTTPError) as excinfo:
-            with TemporaryDirectory() as td:
-                cm = FileContentsManager(root_dir=td)
-                hidden_dir = 'visible'
-                file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
-                _make_dir(cm, hidden_dir)
-                model = cm.new(path=file_in_hidden_path)
-                os_path = cm._get_os_path(model['path'])
+        with TemporaryDirectory() as td:
+            cm = FileContentsManager(root_dir=td)
+            hidden_dir = 'visible'
+            file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
+            _make_dir(cm, hidden_dir)
 
-                try:
-                    result = cm.delete_file(os_path)
-                except HTTPError as e:
-                    self.assertEqual(e.status_code, 400)
-                else:
-                    self.fail("Should have raised HTTPError(400)")
+            with self.assertRaises(HTTPError) as excinfo:
+                cm.delete_file(file_in_hidden_path)
+            self.assertEqual(excinfo.exception.status_code, 400)
 
         #Test Save behavior
         #Test save of file in hidden directory


### PR DESCRIPTION
Fix #6473 and I assume that this completely resolves [GHSA-v7vq-3x77-87vg](https://github.com/jupyter/notebook/security/advisories/GHSA-v7vq-3x77-87vg).

As @jinzhen-lin mentions in #6473, if a path of the same length as notebook_dir is given in `rename_file`, it is interpreted as an attempt to rename a file named `.ipynb`, which is misjudged as a hidden file because the first character is `.`.
This problem could be caused by old_path and new_path of `rename_file` are relative paths, but `is_hidden` is assumed to be an absolute path. Therefore, I modified the code of `rename_file` so that absolute paths are provided to `is_hidden`.

Additionally, the test was also fixed. The test passed until now, but it did not test if `rename_file` raises the expected error. Because the `FileContentsManager.new` before it raised `HTTPError` and marks it as success. (`is_hidden` is also called in `new`.)

**[Related to the security advisory?]**
The original commit seems to be https://github.com/jupyter-server/jupyter_server/commit/877da10cd0d7ae45f8b1e385fa1f5a335e7adf1f on jupyter_server. (This commit seems to handle absolute paths properly.) This appears to be related to Security Advisory [GHSA-v7vq-3x77-87vg](https://github.com/jupyter/notebook/security/advisories/GHSA-v7vq-3x77-87vg) So I consider this PR may be an important fix.