### PR TITLE
Remove PDF link to Jupyter Notebook docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This repository is a Jupyter project and follows the Jupyter
 
 - [Project Jupyter website](https://jupyter.org)
 - [Online Demo at jupyter.org/try](https://jupyter.org/try)
-- [Documentation for Jupyter notebook](https://jupyter-notebook.readthedocs.io/en/latest/) \[[PDF](https://media.readthedocs.org/pdf/jupyter-notebook/latest/jupyter-notebook.pdf)\]
+- [Documentation for Jupyter notebook](https://jupyter-notebook.readthedocs.io/en/latest/)
 - [Korean Version of Installation](https://github.com/ChungJooHo/Jupyter_Kor_doc/)
 - [Documentation for Project Jupyter](https://jupyter.readthedocs.io/en/latest/index.html) \[[PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)\]
 - [Issues](https://github.com/jupyter/notebook/issues)


### PR DESCRIPTION
Try fixing the `check-links` CI failure (https://github.com/jupyterlab/maintainer-tools/issues/160).

