### PR TITLE
Add sys_info to page template for 6.5.x

### DIFF
--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -202,6 +202,7 @@ dir="ltr">
     }
   }
   _remove_token_from_url();
+  sys_info = {{sys_info|safe}};
 </script>
 </body>
 


### PR DESCRIPTION
This PR is to allow to infer the current notebook version using `sys_info.notebook_version` in a legacy notebook extension, when using the `page.html` template. This is similar to how it is done in the `notebook.html` template.

Use case is the `nbextensions` overview tab, where a compatibility check for the notebook version is performed.
As `Jupyter.version` no longer works, it should be replaced by `sys_info.notebook_version` here:  [PR](https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator/pull/149).

@echarles : What do you think ?