### PR TITLE
Resolving some accessibility issues

### DIFF
--- a/packages/application/src/panelhandler.ts
+++ b/packages/application/src/panelhandler.ts
@@ -90,6 +90,8 @@ export class SidePanelHandler extends PanelHandler {
       this.hide();
     };
     closeButton.className = 'jp-Button jp-SidePanel-collapse';
+    closeButton.title = 'Collapse side panel';
+
     const icon = new Widget({ node: closeButton });
     this._panel.addWidget(icon);
     this._panel.addWidget(this._widgetPanel);

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -45,8 +45,11 @@ export class NotebookShell extends Widget implements JupyterFrontEnd.IShell {
     const menuWrapper = (this._menuWrapper = new Panel());
 
     this._topHandler.panel.id = 'top-panel';
+    this._topHandler.panel.node.setAttribute('role', 'banner');
     this._menuHandler.panel.id = 'menu-panel';
+    this._menuHandler.panel.node.setAttribute('role', 'navigation');
     this._main.id = 'main-panel';
+    this._main.node.setAttribute('role', 'main');
 
     this._spacer = new Widget();
     this._spacer.id = 'spacer-widget';
@@ -63,7 +66,9 @@ export class NotebookShell extends Widget implements JupyterFrontEnd.IShell {
     const rightHandler = this._rightHandler;
 
     leftHandler.panel.id = 'jp-left-stack';
+    leftHandler.panel.node.setAttribute('role', 'complementary');
     rightHandler.panel.id = 'jp-right-stack';
+    rightHandler.panel.node.setAttribute('role', 'complementary');
 
     // Hide the side panels by default.
     leftHandler.hide();

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -141,12 +141,15 @@ const kernelLogo: JupyterFrontEndPlugin<void> = {
 
     const node = document.createElement('div');
     const img = document.createElement('img');
-    node.appendChild(img);
 
     const onChange = async () => {
       const current = shell.currentWidget;
       if (!(current instanceof NotebookPanel)) {
         return;
+      }
+
+      if (!node.hasChildNodes()) {
+        node.appendChild(img);
       }
 
       await current.sessionContext.ready;
@@ -156,11 +159,13 @@ const kernelLogo: JupyterFrontEndPlugin<void> = {
       const name = current.sessionContext.session?.kernel?.name ?? '';
       const spec = serviceManager.kernelspecs?.specs?.kernelspecs[name];
       if (!spec) {
+        node.childNodes[0].remove();
         return;
       }
 
       const kernelIconUrl = spec.resources['logo-64x64'];
       if (!kernelIconUrl) {
+        node.childNodes[0].remove();
         return;
       }
 

--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -185,7 +185,7 @@ const notebookTreeWidget: JupyterFrontEndPlugin<INotebookTree> = {
 
     if (manager) {
       const running = new RunningSessions(manager, translator);
-      running.id = 'jp-running-sessions';
+      running.id = 'jp-running-sessions-tree';
       running.title.label = trans.__('Running');
       running.title.icon = runningIcon;
       nbTreeWidget.addWidget(running);

--- a/ui-tests/test/tree.spec.ts
+++ b/ui-tests/test/tree.spec.ts
@@ -40,7 +40,9 @@ test('should update url when navigating in filebrowser', async ({
 test('Should activate file browser tab', async ({ page, tmpPath }) => {
   await page.goto(`tree/${tmpPath}`);
   await page.click('text="Running"');
-  await expect(page.locator('#main-panel #jp-running-sessions-tree')).toBeVisible();
+  await expect(
+    page.locator('#main-panel #jp-running-sessions-tree')
+  ).toBeVisible();
 
   await page.menu.clickMenuItem('View>File Browser');
   await expect(page.locator('#main-panel #filebrowser')).toBeVisible();

--- a/ui-tests/test/tree.spec.ts
+++ b/ui-tests/test/tree.spec.ts
@@ -40,7 +40,7 @@ test('should update url when navigating in filebrowser', async ({
 test('Should activate file browser tab', async ({ page, tmpPath }) => {
   await page.goto(`tree/${tmpPath}`);
   await page.click('text="Running"');
-  await expect(page.locator('#main-panel #jp-running-sessions')).toBeVisible();
+  await expect(page.locator('#main-panel #jp-running-sessions-tree')).toBeVisible();
 
   await page.menu.clickMenuItem('View>File Browser');
   await expect(page.locator('#main-panel #filebrowser')).toBeVisible();


### PR DESCRIPTION
This PR addresses some accessibility issues:
- adds landmarks roles
- removes duplicate id on *running session* from side panel and form main area
- adds title on the sidebar button (a later PR will be necessary for translation)
- avoids adding kernel logo image if not necessary, to avoid image without title

Related to https://github.com/jupyter/notebook/issues/6671