### PR TITLE
Use Playwright `webServer`

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -52,17 +52,6 @@ jobs:
           jlpm --frozen-lockfile
           jlpm playwright install
 
-      - name: Start Jupyter Notebook
-        run: |
-          cd ui-tests
-          jlpm start:detached
-
-      - name: Wait for Jupyter Notebook
-        uses: ifaxity/wait-on-action@v1
-        with:
-          resource: http-get://127.0.0.1:8888/
-          timeout: 360000
-
       - name: Test
         run: |
           cd ui-tests

--- a/ui-tests/playwright.config.ts
+++ b/ui-tests/playwright.config.ts
@@ -6,5 +6,13 @@ module.exports = {
     appPath: '',
     video: 'retain-on-failure'
   },
-  retries: 1
+  retries: 1,
+  webServer: [
+    {
+      command: 'jlpm start:detached',
+      port: 8888,
+      timeout: 120 * 1000,
+      reuseExistingServer: true,
+    }
+  ],
 };


### PR DESCRIPTION
This should help fix some Node 12 warnings happening on GitHub Actions:

![image](https://user-images.githubusercontent.com/591645/217609821-8f1fac77-6fdf-450c-bd4d-60090892795c.png)
