### PR TITLE
Add the extension manager

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -44,6 +44,8 @@
     "@jupyterlab/docmanager-extension": "~4.0.0-alpha.19",
     "@jupyterlab/documentsearch": "~4.0.0-alpha.19",
     "@jupyterlab/documentsearch-extension": "~4.0.0-alpha.19",
+    "@jupyterlab/extensionmanager": "~4.0.0-alpha.19",
+    "@jupyterlab/extensionmanager-extension": "~4.0.0-alpha.19",
     "@jupyterlab/filebrowser": "~4.0.0-alpha.19",
     "@jupyterlab/filebrowser-extension": "~4.0.0-alpha.19",
     "@jupyterlab/fileeditor": "~4.0.0-alpha.19",
@@ -128,6 +130,7 @@
     "@jupyterlab/debugger-extension": "^4.0.0-alpha.19",
     "@jupyterlab/docmanager-extension": "^4.0.0-alpha.19",
     "@jupyterlab/documentsearch-extension": "^4.0.0-alpha.19",
+    "@jupyterlab/extensionmanager-extension": "^4.0.0-alpha.19",
     "@jupyterlab/filebrowser-extension": "^4.0.0-alpha.19",
     "@jupyterlab/fileeditor-extension": "^4.0.0-alpha.19",
     "@jupyterlab/htmlviewer-extension": "^4.0.0-alpha.19",
@@ -230,6 +233,7 @@
         "@jupyterlab/documentsearch-extension": [
           "@jupyterlab/documentsearch-extension:plugin"
         ],
+        "@jupyterlab/extensionmanager-extension": true,
         "@jupyterlab/filebrowser-extension": [
           "@jupyterlab/filebrowser-extension:factory",
           "@jupyterlab/filebrowser-extension:default-file-browser"
@@ -330,6 +334,7 @@
       "@jupyterlab/debugger",
       "@jupyterlab/docmanager",
       "@jupyterlab/documentsearch",
+      "@jupyterlab/extensionmanager",
       "@jupyterlab/filebrowser",
       "@jupyterlab/fileeditor",
       "@jupyterlab/htmlviewer",

--- a/app/package.json
+++ b/app/package.json
@@ -233,7 +233,6 @@
         "@jupyterlab/documentsearch-extension": [
           "@jupyterlab/documentsearch-extension:plugin"
         ],
-        "@jupyterlab/extensionmanager-extension": true,
         "@jupyterlab/filebrowser-extension": [
           "@jupyterlab/filebrowser-extension:factory",
           "@jupyterlab/filebrowser-extension:default-file-browser"
@@ -263,6 +262,7 @@
         "@jupyterlab/hub-extension": true
       },
       "/tree": {
+        "@jupyterlab/extensionmanager-extension": true,
         "@jupyterlab/filebrowser-extension": [
           "@jupyterlab/filebrowser-extension:browser",
           "@jupyterlab/filebrowser-extension:download",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2212,6 +2212,35 @@
     "@lumino/widgets" "^2.0.0-beta.1"
     react "^18.2.0"
 
+"@jupyterlab/extensionmanager-extension@^4.0.0-alpha.19":
+  version "4.0.0-alpha.19"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/extensionmanager-extension/-/extensionmanager-extension-4.0.0-alpha.19.tgz#953e21205c4fb541b4303d6913e6eefe4ac7e57a"
+  integrity sha512-4Vdq8HfoHTP7AOz7PMD13e2XKvMDikFTkZXVuxff+Z8rcrEKI/Qsk6WbCTy+gAbCBG1e0CdUE2hNl8+qe4gxYQ==
+  dependencies:
+    "@jupyterlab/application" "^4.0.0-alpha.19"
+    "@jupyterlab/apputils" "^4.0.0-alpha.19"
+    "@jupyterlab/extensionmanager" "^4.0.0-alpha.19"
+    "@jupyterlab/settingregistry" "^4.0.0-alpha.19"
+    "@jupyterlab/translation" "^4.0.0-alpha.19"
+    "@jupyterlab/ui-components" "^4.0.0-alpha.34"
+
+"@jupyterlab/extensionmanager@^4.0.0-alpha.19":
+  version "4.0.0-alpha.19"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/extensionmanager/-/extensionmanager-4.0.0-alpha.19.tgz#6289cc34eec65f9ffd0eacf7d3c109a9ab55df00"
+  integrity sha512-PlVg/hGNvVOpeJnEyCzFIQBNEIzsp8SVxIKzlXW6LcjXr8bUy7X051ETQd13U1FfhmfNChh57UDOlogDugDsUg==
+  dependencies:
+    "@jupyterlab/apputils" "^4.0.0-alpha.19"
+    "@jupyterlab/coreutils" "^6.0.0-alpha.19"
+    "@jupyterlab/services" "^7.0.0-alpha.19"
+    "@jupyterlab/translation" "^4.0.0-alpha.19"
+    "@jupyterlab/ui-components" "^4.0.0-alpha.34"
+    "@lumino/messaging" "^2.0.0-beta.0"
+    "@lumino/polling" "^2.0.0-beta.0"
+    "@lumino/widgets" "^2.0.0-beta.1"
+    react "^18.2.0"
+    react-paginate "^6.3.2"
+    semver "^7.3.2"
+
 "@jupyterlab/filebrowser-extension@^4.0.0-alpha.19":
   version "4.0.0-alpha.19"
   resolved "https://registry.yarnpkg.com/@jupyterlab/filebrowser-extension/-/filebrowser-extension-4.0.0-alpha.19.tgz#befcbdea206cae096f2da87072cdc06f90f022a8"
@@ -10884,7 +10913,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.6.0, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -11076,6 +11105,13 @@ react-json-tree@^0.16.1:
     "@types/prop-types" "^15.7.4"
     prop-types "^15.8.1"
     react-base16-styling "^0.9.1"
+
+react-paginate@^6.3.2:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/react-paginate/-/react-paginate-6.5.0.tgz#b9baf53627b115cfd688afa048776aa45bffda19"
+  integrity sha512-H7xSi9jyiJzgfaj+2nNhQcjZfwzJ/Mxb64V2RiyDctjZyCWojwsaGwMqhLBpQ58iAuMVtBMRQ7ECqMcUKG9QSQ==
+  dependencies:
+    prop-types "^15.6.1"
 
 react-toastify@^9.0.8:
   version "9.1.1"


### PR DESCRIPTION
Add the extension manager to the Notebook 7 interface:

https://user-images.githubusercontent.com/591645/221237823-9dd6b830-8066-4ee6-87b9-cc39ba9e87f3.mp4

### Changes

- [x] Add `@jupyterlab/extensionmanager-extension
- [ ] Should it be accessible from all the pages, or just from the tree view next to the other tabs?

![image](https://user-images.githubusercontent.com/591645/221238171-b6f087d6-1bfc-47c2-b7dc-3daac51ab54e.png)


