### PR TITLE
Add documentation for contributing to the docs

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -43,5 +43,14 @@ tasks:
       echo "source /workspace/bin/activate-env.sh" >> ~/.bashrc
       source /workspace/bin/activate-env.sh
 
+  - name: docs
+    command: |
+      gp sync-await setup
+      sudo apt-get update
+      sudo apt install enchant-2 -y
+      wget https://github.com/jgm/pandoc/releases/download/2.14.2/pandoc-2.14.2-1-amd64.deb -O /tmp/pandoc.deb && sudo dpkg -i /tmp/pandoc.deb
+      hatch run docs:build
+      hatch run docs:serve
+
 ports:
   - port: 8888

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -49,6 +49,7 @@ tasks:
       sudo apt-get update
       sudo apt install enchant-2 -y
       wget https://github.com/jgm/pandoc/releases/download/2.14.2/pandoc-2.14.2-1-amd64.deb -O /tmp/pandoc.deb && sudo dpkg -i /tmp/pandoc.deb
+      source /workspace/bin/activate-env.sh
       hatch run docs:build
       hatch run docs:serve
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,6 @@ Now open a web browser and navigate to `http://localhost:8000` to access the doc
 
 Alternatively you can also contribute to Jupyter Notebook without setting up a local environment, directly from a web browser:
 
-- Gitpod integration is enabled: https://gitpod.io/#https://github.com/jupyter/notebook. The Gitpod config automatically builds the Jupyter Notebook application and the documentation.
+- [Gitpod](https://gitpod.io/#https://github.com/jupyter/notebook) integration is enabled. The Gitpod config automatically builds the Jupyter Notebook application and the documentation.
 - GitHub’s [built-in editor](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files) is suitable for contributing small fixes
 - A more advanced [github.dev](https://docs.github.com/en/codespaces/the-githubdev-web-based-editor) editor can be accessed by pressing the dot (.) key while in the Jupyter Notebook GitHub repository,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,3 +170,11 @@ hatch run docs:serve
 ```
 
 Now open a web browser and navigate to `http://localhost:8000` to access the documentation.
+
+## Contributing from the browser
+
+Alternatively you can also contribute to Jupyter Notebook without setting up a local environment, directly from a web browser:
+
+- Gitpod integration is enabled: https://gitpod.io/#https://github.com/jupyter/notebook. The Gitpod config automatically builds the Jupyter Notebook application and the documentation.
+- GitHub’s [built-in editor](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files) is suitable for contributing small fixes
+- A more advanced [github.dev](https://docs.github.com/en/codespaces/the-githubdev-web-based-editor) editor can be accessed by pressing the dot (.) key while in the JupyterLab GitHub repository,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,3 +152,21 @@ automatically on save.
 
 Some of the hooks only run on CI by default, but you can invoke them by
 running with the `--hook-stage manual` argument.
+
+## Documentation
+
+First make sure you have set up a development environment as described above.
+
+Then run the following command to build the docs:
+
+```shell
+hatch run docs:build
+```
+
+In a separate terminal window, run the following command to serve the documentation:
+
+```shell
+hatch run docs:serve
+```
+
+Now open a web browser and navigate to `http://localhost:8000` to access the documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,4 +177,4 @@ Alternatively you can also contribute to Jupyter Notebook without setting up a l
 
 - Gitpod integration is enabled: https://gitpod.io/#https://github.com/jupyter/notebook. The Gitpod config automatically builds the Jupyter Notebook application and the documentation.
 - GitHub’s [built-in editor](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files) is suitable for contributing small fixes
-- A more advanced [github.dev](https://docs.github.com/en/codespaces/the-githubdev-web-based-editor) editor can be accessed by pressing the dot (.) key while in the JupyterLab GitHub repository,
+- A more advanced [github.dev](https://docs.github.com/en/codespaces/the-githubdev-web-based-editor) editor can be accessed by pressing the dot (.) key while in the Jupyter Notebook GitHub repository,

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Documentation Status](https://readthedocs.org/projects/jupyter-notebook/badge/?version=latest)](https://jupyter-notebook.readthedocs.io/en/latest/?badge=latest)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyter/notebook/main?urlpath=tree)
 [![codecov](https://codecov.io/gh/jupyter/notebook/branch/main/graph/badge.svg)](https://codecov.io/gh/jupyter/notebook)
+[![Gitpod](https://img.shields.io/badge/gitpod_editor-open-blue.svg)](https://gitpod.io/#https://github.com/jupyter/notebook)
 
 The Jupyter notebook is a web-based notebook environment for interactive
 computing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ include = ["/notebook"]
 features = ["docs"]
 [tool.hatch.envs.docs.scripts]
 build = "make -C docs html SPHINXOPTS='-W'"
+serve = "cd docs/build/html && python -m http.server"
 
 [tool.hatch.envs.default.scripts]
 npm_pack = "jlpm lerna exec -- npm pack"


### PR DESCRIPTION
Improvement to the contributing documentation:

- [x] Add a section to the contributing guide to make contribution to the docs
- [x] Build the docs on Gitpod
- [x] Mention Gitpod in the contributing guide