### PR TITLE
added white space to bottom of edit files

### DIFF
--- a/notebook/templates/edit.html
+++ b/notebook/templates/edit.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/x-icon" href="{{ base_url | escape }}static/favicons/favicon-file.ico" class="favicon">
   {% endblock %}
 </head>
-<body>
+<body data-edit="edit">
 
   {# Copy so we do not modify the page_config with updates. #}
   {% set page_config_full = page_config.copy() %}

--- a/notebook/templates/edit.html
+++ b/notebook/templates/edit.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/x-icon" href="{{ base_url | escape }}static/favicons/favicon-file.ico" class="favicon">
   {% endblock %}
 </head>
-<body data-edit="edit">
+<body data-notebook="edit">
 
   {# Copy so we do not modify the page_config with updates. #}
   {% set page_config_full = page_config.copy() %}

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -52,8 +52,10 @@ export class NotebookShell extends Widget implements JupyterFrontEnd.IShell {
     this._main.id = 'main-panel';
     this._main.node.setAttribute('role', 'main');
 
-    this._spacer = new Widget();
-    this._spacer.id = 'spacer-widget';
+    this._spacer_top = new Widget();
+    this._spacer_top.id = 'spacer-widget-top';
+    this._spacer_bottom = new Widget();
+    this._spacer_bottom.id = 'spacer-widget-bottom';
 
     // create wrappers around the top and menu areas
     topWrapper.id = 'top-panel-wrapper';
@@ -86,8 +88,9 @@ export class NotebookShell extends Widget implements JupyterFrontEnd.IShell {
     const middlePanel = new Panel({ layout: middleLayout });
     middlePanel.addWidget(this._topWrapper);
     middlePanel.addWidget(this._menuWrapper);
-    middlePanel.addWidget(this._spacer);
+    middlePanel.addWidget(this._spacer_top);
     middlePanel.addWidget(this._main);
+    middlePanel.addWidget(this._spacer_bottom);
     middlePanel.layout = middleLayout;
 
     // TODO: Consider storing this as an attribute this._hsplitPanel if saving/restoring layout needed
@@ -267,7 +270,7 @@ export class NotebookShell extends Widget implements JupyterFrontEnd.IShell {
    */
   collapseTop(): void {
     this._topWrapper.setHidden(true);
-    this._spacer.setHidden(true);
+    this._spacer_top.setHidden(true);
   }
 
   /**
@@ -275,7 +278,7 @@ export class NotebookShell extends Widget implements JupyterFrontEnd.IShell {
    */
   expandTop(): void {
     this._topWrapper.setHidden(false);
-    this._spacer.setHidden(false);
+    this._spacer_top.setHidden(false);
   }
 
   /**
@@ -344,7 +347,8 @@ export class NotebookShell extends Widget implements JupyterFrontEnd.IShell {
   private _menuHandler: PanelHandler;
   private _leftHandler: SidePanelHandler;
   private _rightHandler: SidePanelHandler;
-  private _spacer: Widget;
+  private _spacer_top: Widget;
+  private _spacer_bottom: Widget;
   private _main: Panel;
   private _translator: ITranslator = nullTranslator;
   private _currentChanged = new Signal<this, void>(this);

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -70,7 +70,7 @@ body {
 
 /* Only edit pages should have a bottom space */
 
-body[data-edit='edit'] #spacer-widget-bottom {
+body[data-notebook='edit'] #spacer-widget-bottom {
   min-height: 16px;
 }
 

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -64,7 +64,13 @@ body {
   max-width: var(--jp-notebook-max-width);
 }
 
-#spacer-widget {
+#spacer-widget-top {
+  min-height: 16px;
+}
+
+/* Only edit pages should have a bottom space */
+
+body[data-edit='edit'] #spacer-widget-bottom {
   min-height: 16px;
 }
 
@@ -80,6 +86,6 @@ body[data-notebook='notebooks'] #main-panel {
   max-width: unset;
 }
 
-body[data-notebook='notebooks'] #spacer-widget {
+body[data-notebook='notebooks'] #spacer-widget-top {
   min-height: unset;
 }


### PR DESCRIPTION
Fixes a part of #6785 - Text editor should display a partial view. 
New view: 
<img width="1440" alt="Screen Shot 2023-03-29 at 11 26 00 AM" src="https://user-images.githubusercontent.com/100455802/228633140-1f9e0978-ff66-4c66-af66-30a64ffea309.png">
