### PR TITLE
Add show_banner trait to control the banner display

### DIFF
--- a/docs/source/frontend_config.rst
+++ b/docs/source/frontend_config.rst
@@ -93,7 +93,7 @@ pages.
 Persisting configuration settings
 ---------------------------------
 
-A banner is shown to the user to inform him about news or updates. This 
+A banner might be shown to users to inform them about news or updates. This 
 banner can be hidden launching the server with the show_banner trait.::
 
    jupyter notebook --NotebookApp.show_banner=False

--- a/docs/source/frontend_config.rst
+++ b/docs/source/frontend_config.rst
@@ -89,3 +89,11 @@ taking various value depending on the page where the configuration is issued.
 ``<section>`` can take various values like ``notebook``, ``tree``, and
 ``editor``. A ``common`` section contains configuration settings shared by all
 pages.
+
+Persisting configuration settings
+---------------------------------
+
+A banner is shown to the user to inform him about news or updates. This 
+banner can be hidden launching the server with the show_banner trait.::
+
+   jupyter notebook --NotebookApp.show_banner=False

--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -245,6 +245,10 @@ class IPythonHandler(AuthenticatedHandler):
         return self.settings.get('websocket_url', '')
 
     @property
+    def show_banner(self):
+        return self.settings.get('show_banner', True)
+
+    @property
     def contents_js_source(self):
         self.log.debug("Using contents: %s", self.settings.get('contents_js_source',
             'services/contents'))
@@ -530,6 +534,7 @@ class IPythonHandler(AuthenticatedHandler):
             xsrf_token=self.xsrf_token.decode('utf8'),
             nbjs_translations=json.dumps(combine_translations(
                 self.request.headers.get('Accept-Language', ''))),
+            show_banner=self.show_banner,
             **self.jinja_template_vars
         )
 

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -278,6 +278,7 @@ Please note that updating to Notebook 7 might break some of your extensions.
             },
             version_hash=version_hash,
             ignore_minified_js=jupyter_app.ignore_minified_js,
+            show_banner=jupyter_app.show_banner,
 
             # rate limits
             iopub_msg_rate_limit=jupyter_app.iopub_msg_rate_limit,
@@ -1170,6 +1171,12 @@ class NotebookApp(JupyterApp):
        as local as well.
        """
     )
+
+    show_banner = Bool(True, config=True,
+                        help="""Whether to the banner is dislayed on the page.
+
+                        By default, the banner is displayed.
+                        """)
 
     open_browser = Bool(True, config=True,
                         help="""Whether to open in a browser after starting.

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1173,7 +1173,7 @@ class NotebookApp(JupyterApp):
     )
 
     show_banner = Bool(True, config=True,
-                        help="""Whether to the banner is dislayed on the page.
+                        help="""Whether the banner is displayed on the page.
 
                         By default, the banner is displayed.
                         """)

--- a/notebook/templates/page.html
+++ b/notebook/templates/page.html
@@ -136,6 +136,7 @@ dir="ltr">
 
 <div id="header" role="navigation" aria-label="{% trans %}Top Menu{% endtrans %}">
   <div  id="newsId" style="display: none">
+    {% if show_banner %}
     <div class="alert alert-info" role="alert">
       <div style="display: flex">
         <div>
@@ -153,6 +154,7 @@ dir="ltr">
         </div>
       </div>
     </div>
+    {% endif %}
   </div>
   <div id="header-container" class="container">
   <div id="ipython_notebook" class="nav navbar-brand"><a href="{{default_url}}


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/6798

Use `--NotebookApp.show_banner=False` to disable the banner display.