### PR TITLE
Renames Interface menu to "Open in", shortens menu options

### DIFF
--- a/packages/lab-extension/src/index.ts
+++ b/packages/lab-extension/src/index.ts
@@ -44,6 +44,7 @@ namespace CommandIDs {
 interface ISwitcherChoice {
   command: string;
   commandLabel: string;
+  commandCaption?: string;
   buttonLabel: string;
   urlPrefix: string;
 }
@@ -78,7 +79,7 @@ const interfaceSwitcher: JupyterFrontEndPlugin<void> = {
     };
     const menubar = new MenuBar(overflowOptions);
     const switcher = new Menu({ commands });
-    switcher.title.label = trans.__('Interface');
+    switcher.title.label = trans.__('Open in');
     switcher.title.icon = caretDownIcon;
     menubar.addMenu(switcher);
 
@@ -90,10 +91,10 @@ const interfaceSwitcher: JupyterFrontEndPlugin<void> = {
     };
 
     const addInterface = (option: ISwitcherChoice) => {
-      const { command, commandLabel, urlPrefix } = option;
+      const { command, commandLabel, commandCaption, urlPrefix } = option;
       commands.addCommand(command, {
         label: (args) => (args.noLabel ? '' : commandLabel),
-        caption: commandLabel,
+        caption: commandCaption ?? commandLabel,
         execute: () => {
           const current = notebookTracker.currentWidget;
           if (!current) {
@@ -114,7 +115,11 @@ const interfaceSwitcher: JupyterFrontEndPlugin<void> = {
     if (!notebookShell) {
       addInterface({
         command: CommandIDs.openNotebook,
-        commandLabel: trans.__('Open With %1', 'Jupyter Notebook'),
+        commandLabel: trans.__('Notebook'),
+        commandCaption: trans.__(
+          'Open this notebook in %1',
+          'Jupyter Notebook'
+        ),
         buttonLabel: 'openNotebook',
         urlPrefix: `${baseUrl}tree/`,
       });
@@ -123,7 +128,8 @@ const interfaceSwitcher: JupyterFrontEndPlugin<void> = {
     if (!labShell) {
       addInterface({
         command: CommandIDs.openLab,
-        commandLabel: trans.__('Open With %1', 'JupyterLab'),
+        commandLabel: trans.__('JupyterLab'),
+        commandCaption: trans.__('Open this notebook in %1', 'JupyterLab'),
         buttonLabel: 'openLab',
         urlPrefix: `${baseUrl}doc/tree/`,
       });

--- a/packages/lab-extension/src/index.ts
+++ b/packages/lab-extension/src/index.ts
@@ -43,8 +43,9 @@ namespace CommandIDs {
 
 interface ISwitcherChoice {
   command: string;
-  commandLabel: string;
   commandCaption?: string;
+  commandLabel: string;
+  commandShortLabel?: string;
   buttonLabel: string;
   urlPrefix: string;
 }
@@ -91,9 +92,24 @@ const interfaceSwitcher: JupyterFrontEndPlugin<void> = {
     };
 
     const addInterface = (option: ISwitcherChoice) => {
-      const { command, commandLabel, commandCaption, urlPrefix } = option;
+      const {
+        command,
+        commandCaption,
+        commandLabel,
+        commandShortLabel,
+        urlPrefix,
+      } = option;
       commands.addCommand(command, {
-        label: (args) => (args.noLabel ? '' : commandLabel),
+        label: (args) => {
+          if (args.noLabel) {
+            return '';
+          }
+          if (args['isPalette']) {
+            return commandLabel;
+          }
+          // For display in the menu, use the short label if provided.
+          return commandShortLabel ?? commandLabel;
+        },
         caption: commandCaption ?? commandLabel,
         execute: () => {
           const current = notebookTracker.currentWidget;
@@ -115,11 +131,12 @@ const interfaceSwitcher: JupyterFrontEndPlugin<void> = {
     if (!notebookShell) {
       addInterface({
         command: CommandIDs.openNotebook,
-        commandLabel: trans.__('Notebook'),
         commandCaption: trans.__(
           'Open this notebook in %1',
           'Jupyter Notebook'
         ),
+        commandLabel: trans.__('Open in %1', 'Jupyter Notebook'),
+        commandShortLabel: trans.__('Notebook'),
         buttonLabel: 'openNotebook',
         urlPrefix: `${baseUrl}tree/`,
       });
@@ -128,8 +145,9 @@ const interfaceSwitcher: JupyterFrontEndPlugin<void> = {
     if (!labShell) {
       addInterface({
         command: CommandIDs.openLab,
-        commandLabel: trans.__('JupyterLab'),
         commandCaption: trans.__('Open this notebook in %1', 'JupyterLab'),
+        commandLabel: trans.__('Open in %1', 'JupyterLab'),
+        commandShortLabel: trans.__('JupyterLab'),
         buttonLabel: 'openLab',
         urlPrefix: `${baseUrl}doc/tree/`,
       });


### PR DESCRIPTION
Fix for #6806.

Renames the "Interface" menu to "Open in" and renames the commands to just the name of the desired interface.

In Notebook view:

![image](https://user-images.githubusercontent.com/93281816/229185056-89dcfab7-472e-4882-b913-a33fb42ab4d3.png)

In Lab view:

![image](https://user-images.githubusercontent.com/93281816/229185112-7cdfc7db-76ad-4c1e-88b7-c3f88e92dbe3.png)

Note that the commands have particularly short names because Lumino doesn't yet allow custom menu item labels; see https://github.com/jupyterlab/lumino/issues/570 .