### PR TITLE
Use correct canonical URL while building docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -265,6 +265,11 @@ html_static_path = ["_static"]
 # Output file base name for HTML help builder.
 htmlhelp_basename = "JupyterNotebookdoc"
 
+# This will ensure that we use the correctly set environment for canonical URLs
+# Old Read the Docs injections makes it point only to the default version,
+# for instance /en/stable/
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {}


### PR DESCRIPTION
As noted in https://github.com/readthedocs/readthedocs.org/pull/10224 with the current configuration the canonical URL is wrong with different sphinx builds. For instance the "latest" docs point to "stable". This leads to apps like Mastodon to generate previews to pages which don't exist since they rely on

    <link rel="canonical" href="https://jupyter-notebook.readthedocs.io/en/stable/notebook_7_features.html" />

This should fix that.