### PR TITLE
Fix top bar visibility not picking up settings overrides (#6833)

### DIFF
--- a/packages/application-extension/schema/top.json
+++ b/packages/application-extension/schema/top.json
@@ -18,10 +18,11 @@
   },
   "properties": {
     "visible": {
-      "type": "boolean",
+      "type": "string",
+      "enum": ["yes", "no", "automatic"],
       "title": "Top Bar Visibility",
-      "description": "Whether to show the top bar or not",
-      "default": true
+      "description": "Whether to show the top bar or not, yes for always showing, no for always not showing, automatic for adjusting to screen size",
+      "default": "automatic"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
* The header part reflects both user preference and default settings overrides.
* Toggle 'Show Header' turns off the automatic adjustment.
* Before this commit behavior:
  * Automatically adjust header visibility to screen size at first
  * If manually check/uncheck the `visible` box in the settings editor, `not` automatically adjust header visibility.
  * If manually toggle `Show Header` in menu->view, `not` automatically adjust header visibility.
  * If overrides default settings at runtime, it doesn't reflect on the UI.
* After this commit behavior:
  * Automatically adjust header visibility to screen size at first
  * If manually `uncheck` the `adjustToScreen` box in the settings editor, `not` automatically adjust header visibility.
  * If manually toggle `Show Header` in menu->view, `not` automatically adjust header visibility.
  * If overrides default settings at runtime, it does reflect on the UI.
* Related issue: https://github.com/jupyter/notebook/issues/6833