### PR TITLE
fix import of warnings.warn

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install the Python dependencies
       run: |
-        pip install -e .[test] codecov
+        pip install -e .[test]
         pip install -r docs/doc-requirements.txt
         wget https://github.com/jgm/pandoc/releases/download/1.19.1/pandoc-1.19.1-1-amd64.deb && sudo dpkg -i pandoc-1.19.1-1-amd64.deb
     - name: List installed packages

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,7 +37,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install the Python dependencies
       run: |
-        pip install -e .[test] codecov
+        pip install -e .[test]
     - name: List installed packages
       run: |
         pip freeze
@@ -48,6 +48,3 @@ jobs:
     - name: Run Integration Tests
       run: |
         pytest -v notebook/tests/test_notebookapp_integration.py --integration_tests
-    - name: Coverage
-      run: |
-        codecov

--- a/notebook/traittypes.py
+++ b/notebook/traittypes.py
@@ -1,5 +1,6 @@
 import inspect
-from traitlets import ClassBasedTraitType, Undefined, warn
+from warnings import warn
+from traitlets import ClassBasedTraitType, Undefined
 
 # Traitlet's 5.x includes a set of utilities for building
 # description strings for objects. Traitlets 5.x does not


### PR DESCRIPTION
`warn` was never part of the traitlets API, and changed in https://github.com/ipython/traitlets/pull/838