### PR TITLE
traitlets.warn is private, use warnings.warn

### DIFF
--- a/notebook/traittypes.py
+++ b/notebook/traittypes.py
@@ -1,5 +1,6 @@
 import inspect
-from traitlets import ClassBasedTraitType, Undefined, warn
+from traitlets import ClassBasedTraitType, Undefined
+from warnings import warn
 
 # Traitlet's 5.x includes a set of utilities for building
 # description strings for objects. Traitlets 5.x does not


### PR DESCRIPTION
As pointed out by @blink1073 in https://github.com/jupyterhub/jupyterhub/issues/4418 `traitlets.warn` is private. The signature of the `traitlets.warn` method changed in https://github.com/ipython/traitlets/pull/838 which means notebook 6.* will break when traitlets is next released.

This switches to the standard `warnings.warn` instead.