### PR TITLE
Add Skip Link to Notebook

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -448,6 +448,6 @@ export namespace Private {
     }
 
     private _skipLinkWidget: Widget;
-    private _isDisposed: boolean = false;
+    private _isDisposed = false;
   }
 }

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -116,7 +116,7 @@ export class NotebookShell extends Widget implements JupyterFrontEnd.IShell {
     rootLayout.addWidget(hsplitPanel);
 
     this.layout = rootLayout;
-        
+
     // Added Skip to Main Link
     const skipLinkWidgetHandler = (this._skipLinkWidgetHandler = new Private.SkipLinkWidgetHandler(
       this
@@ -454,4 +454,3 @@ export namespace Private {
     private _isDisposed: boolean = false;
   }
 }
-

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -118,9 +118,8 @@ export class NotebookShell extends Widget implements JupyterFrontEnd.IShell {
     this.layout = rootLayout;
 
     // Added Skip to Main Link
-    const skipLinkWidgetHandler = (this._skipLinkWidgetHandler = new Private.SkipLinkWidgetHandler(
-      this
-    ));
+    const skipLinkWidgetHandler = (this._skipLinkWidgetHandler =
+      new Private.SkipLinkWidgetHandler(this));
 
     this.add(skipLinkWidgetHandler.skipLinkWidget, 'top', { rank: 0 });
     this._skipLinkWidgetHandler.show();
@@ -374,37 +373,35 @@ export namespace Shell {
   export type Area = 'main' | 'top' | 'left' | 'right' | 'menu';
 }
 
-
 export namespace Private {
-
   export class SkipLinkWidgetHandler {
-  /**
-   * Construct a new skipLink widget handler.
-   */
-  constructor(shell: INotebookShell) {
-    const skipLinkWidget = (this._skipLinkWidget = new Widget());
-    const skipToMain = document.createElement('a');
-    skipToMain.href = '#first-cell';
-    skipToMain.tabIndex = 1;
-    skipToMain.text = 'Skip to Main';
-    skipToMain.className = 'skip-link';
-    skipToMain.addEventListener('click', this);
-    skipLinkWidget.addClass('jp-skiplink');
-    skipLinkWidget.id = 'jp-skiplink';
-    skipLinkWidget.node.appendChild(skipToMain);
-  }
-
-  handleEvent(event: Event): void {
-    switch (event.type) {
-      case 'click':
-        this._focusMain();
-        break;
+    /**
+     * Construct a new skipLink widget handler.
+     */
+    constructor(shell: INotebookShell) {
+      const skipLinkWidget = (this._skipLinkWidget = new Widget());
+      const skipToMain = document.createElement('a');
+      skipToMain.href = '#first-cell';
+      skipToMain.tabIndex = 1;
+      skipToMain.text = 'Skip to Main';
+      skipToMain.className = 'skip-link';
+      skipToMain.addEventListener('click', this);
+      skipLinkWidget.addClass('jp-skiplink');
+      skipLinkWidget.id = 'jp-skiplink';
+      skipLinkWidget.node.appendChild(skipToMain);
     }
-  }
 
-  private _focusMain() {
-    const input = document.querySelector(
-      '#main-panel .jp-InputArea-editor'
+    handleEvent(event: Event): void {
+      switch (event.type) {
+        case 'click':
+          this._focusMain();
+          break;
+      }
+    }
+
+    private _focusMain() {
+      const input = document.querySelector(
+        '#main-panel .jp-InputArea-editor'
       ) as HTMLInputElement;
       input.tabIndex = 1;
       input.focus();

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -116,6 +116,14 @@ export class NotebookShell extends Widget implements JupyterFrontEnd.IShell {
     rootLayout.addWidget(hsplitPanel);
 
     this.layout = rootLayout;
+        
+    // Added Skip to Main Link
+    const skipLinkWidgetHandler = (this._skipLinkWidgetHandler = new Private.SkipLinkWidgetHandler(
+      this
+    ));
+
+    this.add(skipLinkWidgetHandler.skipLinkWidget, 'top', { rank: 0 });
+    this._skipLinkWidgetHandler.show();
   }
 
   /**
@@ -349,6 +357,7 @@ export class NotebookShell extends Widget implements JupyterFrontEnd.IShell {
   private _rightHandler: SidePanelHandler;
   private _spacer_top: Widget;
   private _spacer_bottom: Widget;
+  private _skipLinkWidgetHandler: Private.SkipLinkWidgetHandler;
   private _main: Panel;
   private _translator: ITranslator = nullTranslator;
   private _currentChanged = new Signal<this, void>(this);
@@ -364,3 +373,85 @@ export namespace Shell {
    */
   export type Area = 'main' | 'top' | 'left' | 'right' | 'menu';
 }
+
+
+export namespace Private {
+
+  export class SkipLinkWidgetHandler {
+  /**
+   * Construct a new skipLink widget handler.
+   */
+  constructor(shell: INotebookShell) {
+    const skipLinkWidget = (this._skipLinkWidget = new Widget());
+    const skipToMain = document.createElement('a');
+    skipToMain.href = '#first-cell';
+    skipToMain.tabIndex = 1;
+    skipToMain.text = 'Skip to Main';
+    skipToMain.className = 'skip-link';
+    skipToMain.addEventListener('click', this);
+    skipLinkWidget.addClass('jp-skiplink');
+    skipLinkWidget.id = 'jp-skiplink';
+    skipLinkWidget.node.appendChild(skipToMain);
+  }
+
+  handleEvent(event: Event): void {
+    switch (event.type) {
+      case 'click':
+        this._focusMain();
+        break;
+    }
+  }
+
+  private _focusMain() {
+    const input = document.querySelector(
+      '#main-panel .jp-InputArea-editor'
+      ) as HTMLInputElement;
+      input.tabIndex = 1;
+      input.focus();
+    }
+
+    /**
+     * Get the input element managed by the handler.
+     */
+    get skipLinkWidget(): Widget {
+      return this._skipLinkWidget;
+    }
+
+    /**
+     * Dispose of the handler and the resources it holds.
+     */
+    dispose(): void {
+      if (this.isDisposed) {
+        return;
+      }
+      this._isDisposed = true;
+      this._skipLinkWidget.node.removeEventListener('click', this);
+      this._skipLinkWidget.dispose();
+    }
+
+    /**
+     * Hide the skipLink widget.
+     */
+    hide(): void {
+      this._skipLinkWidget.hide();
+    }
+
+    /**
+     * Show the skipLink widget.
+     */
+    show(): void {
+      this._skipLinkWidget.show();
+    }
+
+    /**
+     * Test whether the handler has been disposed.
+     */
+    get isDisposed(): boolean {
+      return this._isDisposed;
+    }
+
+    private _skipLinkWidget: Widget;
+    private _isDisposed: boolean = false;
+  }
+}
+

--- a/packages/application/test/shell.spec.ts
+++ b/packages/application/test/shell.spec.ts
@@ -137,11 +137,16 @@ describe('Shell for tree view', () => {
       expect(shell).toBeInstanceOf(NotebookShell);
     });
 
-    it('should make all areas empty initially', () => {
-      ['main', 'top', 'left', 'right', 'menu'].forEach((area) => {
+    it('should make some areas empty initially', () => {
+      ['main', 'left', 'right', 'menu'].forEach((area) => {
         const widgets = Array.from(shell.widgets(area as Shell.Area));
         expect(widgets.length).toEqual(0);
       });
+    });
+
+    it('should have the skip link widget in the top area initially', () => {
+      const widgets = Array.from(shell.widgets('top'));
+      expect(widgets.length).toEqual(1);
     });
   });
 

--- a/packages/application/test/shell.spec.ts
+++ b/packages/application/test/shell.spec.ts
@@ -28,11 +28,16 @@ describe('Shell for notebooks', () => {
       expect(shell).toBeInstanceOf(NotebookShell);
     });
 
-    it('should make all areas empty initially', () => {
-      ['main', 'top', 'left', 'right', 'menu'].forEach((area) => {
+    it('should make some areas empty initially', () => {
+      ['main', 'left', 'right', 'menu'].forEach((area) => {
         const widgets = Array.from(shell.widgets(area as Shell.Area));
         expect(widgets.length).toEqual(0);
       });
+    });
+
+    it('should have the skip link widget in the top area initially', () => {
+      const widgets = Array.from(shell.widgets('top'));
+      expect(widgets.length).toEqual(1);
     });
   });
 

--- a/packages/notebook-extension/style/base.css
+++ b/packages/notebook-extension/style/base.css
@@ -304,4 +304,3 @@ body[data-notebook='notebooks']
   text-decoration: underline;
   color: var(--jp-content-link-color);
 }
-

--- a/packages/notebook-extension/style/base.css
+++ b/packages/notebook-extension/style/base.css
@@ -280,3 +280,28 @@ body[data-notebook='notebooks']
   overflow: hidden;
   white-space: nowrap;
 }
+
+.jp-skiplink {
+  position: absolute;
+  top: -100em;
+}
+
+.jp-skiplink:focus-within {
+  position: absolute;
+  z-index: 10000;
+  top: 0;
+  left: 46%;
+  margin: 0 auto;
+  padding: 1em;
+  width: 15%;
+  box-shadow: var(--jp-elevation-z4);
+  border-radius: 4px;
+  background: var(--jp-layout-color0);
+  text-align: center;
+}
+
+.jp-skiplink:focus-within a {
+  text-decoration: underline;
+  color: var(--jp-content-link-color);
+}
+


### PR DESCRIPTION
Closes one of the tasks on #6800

Problem: "No skip link found (keyboard-only users have to tab 20 times every time to get to main region to do work)."
Changes to Code: Added a SkipLink widget

To Fix: Fails test case checking that all areas are empty by default. Skip to Link is only functional for Notebook page, not for Tree header page (where I wasn't sure what the desired "main" content to skip to should be)

Without using the skip link: User has to click through every single tab in the menu before reaching the edit feature of the first cell.

https://user-images.githubusercontent.com/92682603/232935674-0873aba7-3441-41b0-8689-5ab468577d14.mov

With the functional skip link: User tabs to "Skip to Main" first, then can click enter to go directly to the first cell edit.


https://user-images.githubusercontent.com/92682603/232935712-12b4173d-0389-4220-b185-6a763a8d3875.mov
