### PR TITLE
Default `windowingMode` to `none` or `defer`

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -410,7 +410,7 @@ const windowing: JupyterFrontEndPlugin<void> = {
     Promise.all([settings, app.restored])
       .then(([settings]) => {
         if (settings.user.windowing === undefined) {
-          void settings.set('windowingMode', 'none');
+          void settings.set('windowingMode', 'defer');
         }
       })
       .catch((reason: Error) => {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -396,6 +396,30 @@ const trusted: JupyterFrontEndPlugin<void> = {
 };
 
 /**
+ * A plugin to set the default windowing mode for the notebook
+ */
+const windowing: JupyterFrontEndPlugin<void> = {
+  id: '@jupyter-notebook/notebook-extension:windowing',
+  autoStart: true,
+  requires: [ISettingRegistry],
+  activate: (app: JupyterFrontEnd, settingRegistry: ISettingRegistry): void => {
+    // default to `none` to avoid notebook rendering glitches
+    const settings = settingRegistry.load(
+      '@jupyterlab/notebook-extension:tracker'
+    );
+    Promise.all([settings, app.restored])
+      .then(([settings]) => {
+        if (settings.user.windowing === undefined) {
+          void settings.set('windowingMode', 'none');
+        }
+      })
+      .catch((reason: Error) => {
+        console.error(reason.message);
+      });
+  },
+};
+
+/**
  * Export the plugins as default.
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
@@ -405,6 +429,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   scrollOutput,
   notebookToolsWidget,
   trusted,
+  windowing,
 ];
 
 export default plugins;


### PR DESCRIPTION
**Before**

Keeping the default setting to `full` adds a few glitches as mentioned in https://github.com/jupyterlab/jupyterlab/issues/13343 and in the following screencast:

https://user-images.githubusercontent.com/591645/235083468-256eaf09-35ec-4d74-9fbf-34ec20a2a9fc.mp4

**After**

Switching to `none` seems to be fixing most of these issues:

https://user-images.githubusercontent.com/591645/235083483-74ae2935-672d-43f2-839f-1c51271aa350.mp4


- [x] Switch `windowingMode` to `none` by default
- [ ] Document how to switch to `full` or `defer` (maybe just a link to the JupyterLab docs)