### PR TITLE
Fix handling of the default factory in the URL

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -24,6 +24,7 @@ const opener: JupyterFrontEndPlugin<IDocumentWidgetOpener> = {
   provides: IDocumentWidgetOpener,
   activate: (app: JupyterFrontEnd) => {
     const baseUrl = PageConfig.getBaseUrl();
+    const docRegistry = app.docRegistry;
     let id = 0;
     return new (class {
       open(widget: IDocumentWidget, options?: DocumentRegistry.IOpenOptions) {
@@ -42,7 +43,8 @@ const opener: JupyterFrontEndPlugin<IDocumentWidgetOpener> = {
           }
           let url = `${baseUrl}${route}/${path}`;
           // append ?factory only if it's not the default
-          if (widgetName !== 'default') {
+          const defaultFactory = docRegistry.defaultWidgetFactory(path);
+          if (widgetName !== defaultFactory.name) {
             url = `${url}?factory=${widgetName}`;
           }
           window.open(url);


### PR DESCRIPTION
Fix handling of default factory in the URL so it does not show up anymore when opening a file from the file browser with the default factory.

**Before**

![image](https://github.com/jupyter/notebook/assets/591645/0d227e50-70d1-4394-9f12-1678de4ac904)

**After**

![image](https://github.com/jupyter/notebook/assets/591645/101e317d-d721-4c3e-a81b-c3ed6b21982f)
