### PR TITLE
Provide a custom rendermime plugin to handle local links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,6 +169,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
           ignore_links: "https://playwright.dev/docs/test-cli/ https://blog.jupyter.org/the-big-split-9d7b88a031a7 https://blog.jupyter.org/jupyter-ascending-1bf5b362d97e https://mybinder.org/v2/gh/jupyter/notebook/main"
+          ignore_glob: "ui-tests/test/notebooks/*"
 
   test_lint:
     name: Test Lint

--- a/app/package.json
+++ b/app/package.json
@@ -71,7 +71,6 @@
     "@jupyterlab/outputarea": "~4.0.0",
     "@jupyterlab/pdf-extension": "~4.0.0",
     "@jupyterlab/rendermime": "~4.0.0",
-    "@jupyterlab/rendermime-extension": "~4.0.0",
     "@jupyterlab/rendermime-interfaces": "~3.8.0",
     "@jupyterlab/running-extension": "~4.0.0",
     "@jupyterlab/services": "~7.0.0",
@@ -151,7 +150,6 @@
     "@jupyterlab/metadataform-extension": "^4.0.0",
     "@jupyterlab/notebook-extension": "^4.0.0",
     "@jupyterlab/pdf-extension": "^4.0.0",
-    "@jupyterlab/rendermime-extension": "^4.0.0",
     "@jupyterlab/running-extension": "^4.0.0",
     "@jupyterlab/settingeditor": "^4.0.0",
     "@jupyterlab/settingeditor-extension": "^4.0.0",
@@ -261,7 +259,6 @@
           "@jupyterlab/notebook-extension:tracker",
           "@jupyterlab/notebook-extension:widget-factory"
         ],
-        "@jupyterlab/rendermime-extension": true,
         "@jupyterlab/shortcuts-extension": true,
         "@jupyterlab/terminal-extension": true,
         "@jupyterlab/theme-light-extension": true,

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -48,6 +48,7 @@
     "@jupyterlab/docmanager": "^4.0.0",
     "@jupyterlab/docregistry": "^4.0.0",
     "@jupyterlab/mainmenu": "^4.0.0",
+    "@jupyterlab/rendermime": "^4.0.0",
     "@jupyterlab/settingregistry": "^4.0.0",
     "@jupyterlab/translation": "^4.0.0",
     "@lumino/coreutils": "^2.1.1",

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -32,7 +32,7 @@ import {
   IRenderMime,
   IRenderMimeRegistry,
   RenderMimeRegistry,
-  standardRendererFactories
+  standardRendererFactories,
 } from '@jupyterlab/rendermime';
 
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
@@ -311,8 +311,8 @@ const paths: JupyterFrontEndPlugin<JupyterFrontEnd.IPaths> = {
 };
 
 /**
-  * A plugin providing a rendermime registry.*
-*/
+ * A plugin providing a rendermime registry.
+ */
 const rendermime: JupyterFrontEndPlugin<IRenderMimeRegistry> = {
   id: '@jupyter-notebook/application-extension:rendermime',
   autoStart: true,
@@ -323,7 +323,7 @@ const rendermime: JupyterFrontEndPlugin<IRenderMimeRegistry> = {
     ILatexTypesetter,
     ISanitizer,
     IMarkdownParser,
-    ITranslator
+    ITranslator,
   ],
   activate: (
     app: JupyterFrontEnd,
@@ -337,7 +337,7 @@ const rendermime: JupyterFrontEndPlugin<IRenderMimeRegistry> = {
     if (docManager) {
       app.commands.addCommand(CommandIDs.handleLink, {
         label: trans.__('Handle Local Link'),
-        execute: args => {
+        execute: (args) => {
           const path = args['path'] as string | undefined | null;
           if (path === undefined || path === null) {
             return;
@@ -350,7 +350,7 @@ const rendermime: JupyterFrontEndPlugin<IRenderMimeRegistry> = {
               const treeUrl = URLExt.join(url, 'tree', model.path);
               window.open(treeUrl, '_blank');
             });
-        }
+        },
       });
     }
     return new RenderMimeRegistry({
@@ -358,24 +358,24 @@ const rendermime: JupyterFrontEndPlugin<IRenderMimeRegistry> = {
       linkHandler: !docManager
         ? undefined
         : {
-          handleLink: (node: HTMLElement, path: string, id?: string) => {
-            // If node has the download attribute explicitly set, use the
-            // default browser downloading behavior.
-            if (node.tagName === 'A' && node.hasAttribute('download')) {
-              return;
-            }
-            app.commandLinker.connectNode(node, CommandIDs.handleLink, {
-              path,
-              id
-            });
-          }
-        },
+            handleLink: (node: HTMLElement, path: string, id?: string) => {
+              // If node has the download attribute explicitly set, use the
+              // default browser downloading behavior.
+              if (node.tagName === 'A' && node.hasAttribute('download')) {
+                return;
+              }
+              app.commandLinker.connectNode(node, CommandIDs.handleLink, {
+                path,
+                id,
+              });
+            },
+          },
       latexTypesetter: latexTypesetter ?? undefined,
       markdownParser: markdownParser ?? undefined,
       translator: translator ?? undefined,
-      sanitizer: sanitizer ?? undefined
+      sanitizer: sanitizer ?? undefined,
     });
-  }
+  },
 };
 
 /**

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -12,6 +12,7 @@ import {
 import {
   DOMUtils,
   ICommandPalette,
+  ISanitizer,
   IToolbarWidgetRegistry,
 } from '@jupyterlab/apputils';
 
@@ -25,9 +26,18 @@ import { DocumentWidget } from '@jupyterlab/docregistry';
 
 import { IMainMenu } from '@jupyterlab/mainmenu';
 
+import {
+  ILatexTypesetter,
+  IMarkdownParser,
+  IRenderMime,
+  IRenderMimeRegistry,
+  RenderMimeRegistry,
+  standardRendererFactories
+} from '@jupyterlab/rendermime';
+
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
-import { ITranslator } from '@jupyterlab/translation';
+import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 
 import {
   NotebookApp,
@@ -64,6 +74,11 @@ const STRIP_IPYNB = /\.ipynb$/;
  * The command IDs used by the application plugin.
  */
 namespace CommandIDs {
+  /**
+   * Handle local links
+   */
+  export const handleLink = 'application:handle-local-link';
+
   /**
    * Toggle Top Bar visibility
    */
@@ -293,6 +308,74 @@ const paths: JupyterFrontEndPlugin<JupyterFrontEnd.IPaths> = {
     }
     return app.paths;
   },
+};
+
+/**
+  * A plugin providing a rendermime registry.*
+*/
+const rendermime: JupyterFrontEndPlugin<IRenderMimeRegistry> = {
+  id: '@jupyter-notebook/application-extension:rendermime',
+  autoStart: true,
+  provides: IRenderMimeRegistry,
+  description: 'Provides the render mime registry.',
+  optional: [
+    IDocumentManager,
+    ILatexTypesetter,
+    ISanitizer,
+    IMarkdownParser,
+    ITranslator
+  ],
+  activate: (
+    app: JupyterFrontEnd,
+    docManager: IDocumentManager | null,
+    latexTypesetter: ILatexTypesetter | null,
+    sanitizer: IRenderMime.ISanitizer | null,
+    markdownParser: IMarkdownParser | null,
+    translator: ITranslator | null
+  ) => {
+    const trans = (translator ?? nullTranslator).load('jupyterlab');
+    if (docManager) {
+      app.commands.addCommand(CommandIDs.handleLink, {
+        label: trans.__('Handle Local Link'),
+        execute: args => {
+          const path = args['path'] as string | undefined | null;
+          if (path === undefined || path === null) {
+            return;
+          }
+          return docManager.services.contents
+            .get(path, { content: false })
+            .then((model) => {
+              // Open in a new browser tab
+              const url = PageConfig.getBaseUrl();
+              const treeUrl = URLExt.join(url, 'tree', model.path);
+              window.open(treeUrl, '_blank');
+            });
+        }
+      });
+    }
+    return new RenderMimeRegistry({
+      initialFactories: standardRendererFactories,
+      linkHandler: !docManager
+        ? undefined
+        : {
+          handleLink: (node: HTMLElement, path: string, id?: string) => {
+            // If node has the download attribute explicitly set, use the
+            // default browser downloading behavior.
+            if (node.tagName === 'A' && node.hasAttribute('download')) {
+              return;
+            }
+            app.commandLinker.connectNode(node, CommandIDs.handleLink, {
+              path,
+              id
+            });
+          }
+        },
+      latexTypesetter: latexTypesetter ?? undefined,
+      markdownParser: markdownParser ?? undefined,
+      translator: translator ?? undefined,
+      sanitizer: sanitizer ?? undefined
+    });
+  }
 };
 
 /**
@@ -919,6 +1002,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   opener,
   pages,
   paths,
+  rendermime,
   shell,
   sidePanelVisibility,
   status,

--- a/ui-tests/test/links.spec.ts
+++ b/ui-tests/test/links.spec.ts
@@ -23,7 +23,7 @@ test.describe('Local Links', () => {
 
     const [current] = await Promise.all([
       page.waitForEvent('popup'),
-      page.click('text="Current Directory"'),
+      page.getByText('Current Directory').last().click(),
     ]);
 
     await current.waitForLoadState();
@@ -42,7 +42,7 @@ test.describe('Local Links', () => {
 
     const [folder] = await Promise.all([
       page.waitForEvent('popup'),
-      page.click('text="Open Test Folder"'),
+      page.getByText('Open Test Folder').last().click(),
     ]);
 
     await folder.waitForLoadState();

--- a/ui-tests/test/links.spec.ts
+++ b/ui-tests/test/links.spec.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import path from 'path';
+
+import { expect } from '@playwright/test';
+
+import { test } from './fixtures';
+
+const NOTEBOOK = 'local_links.ipynb';
+const SUBFOLDER = 'test';
+
+test.describe('Local Links', () => {
+  test.beforeEach(async ({ page, tmpPath }) => {
+    await page.contents.uploadFile(
+      path.resolve(__dirname, `./notebooks/${NOTEBOOK}`),
+      `${tmpPath}/${NOTEBOOK}`
+    );
+  });
+
+  test('Open the current directory', async ({ page, tmpPath }) => {
+    await page.goto(`notebooks/${tmpPath}/${NOTEBOOK}`);
+
+    const [current] = await Promise.all([
+      page.waitForEvent('popup'),
+      page.click('text="Current Directory"'),
+    ]);
+
+    await current.waitForLoadState();
+    await current.waitForSelector('.jp-DirListing-content');
+
+    // Check that the link opened in a new tab
+    expect(current.url()).toContain(`tree/${tmpPath}`);
+    await current.close();
+  });
+
+  test('Open a folder', async ({ page, tmpPath }) => {
+    // Create a test folder
+    await page.contents.createDirectory(`${tmpPath}/${SUBFOLDER}`);
+
+    await page.goto(`notebooks/${tmpPath}/${NOTEBOOK}`);
+
+    const [folder] = await Promise.all([
+      page.waitForEvent('popup'),
+      page.click('text="Open Test Folder"'),
+    ]);
+
+    await folder.waitForLoadState();
+    await folder.waitForSelector('.jp-DirListing-content');
+
+    await folder.close();
+
+    // Check that the link opened in a new tab
+    expect(folder.url()).toContain(`tree/${tmpPath}/${SUBFOLDER}`);
+  });
+});

--- a/ui-tests/test/notebooks/local_links.ipynb
+++ b/ui-tests/test/notebooks/local_links.ipynb
@@ -5,12 +5,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Handle Local Links\n",
-    "\n",
-    "[Current Directory](./)\n",
-    "\n",
-    "[Open Test Folder](./test)\n",
-    "\n"
+    "# Handle Local Links"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Current Directory](./)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Open Test Folder](./test)"
    ]
   }
  ],

--- a/ui-tests/test/notebooks/local_links.ipynb
+++ b/ui-tests/test/notebooks/local_links.ipynb
@@ -1,0 +1,30 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Handle Local Links\n",
+    "\n",
+    "[Current Directory](./)\n",
+    "\n",
+    "[Open Test Folder](./test)\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ui-tests/test/notebooks/local_links.ipynb
+++ b/ui-tests/test/notebooks/local_links.ipynb
@@ -21,10 +21,18 @@
    "name": "python3"
   },
   "language_info": {
-   "name": "python"
-  },
-  "orig_nbformat": 4
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2029,7 +2029,6 @@ __metadata:
     "@jupyterlab/metadataform-extension": ^4.0.0
     "@jupyterlab/notebook-extension": ^4.0.0
     "@jupyterlab/pdf-extension": ^4.0.0
-    "@jupyterlab/rendermime-extension": ^4.0.0
     "@jupyterlab/running-extension": ^4.0.0
     "@jupyterlab/settingeditor": ^4.0.0
     "@jupyterlab/settingeditor-extension": ^4.0.0
@@ -2075,6 +2074,7 @@ __metadata:
     "@jupyterlab/docmanager": ^4.0.0
     "@jupyterlab/docregistry": ^4.0.0
     "@jupyterlab/mainmenu": ^4.0.0
+    "@jupyterlab/rendermime": ^4.0.0
     "@jupyterlab/settingregistry": ^4.0.0
     "@jupyterlab/translation": ^4.0.0
     "@lumino/coreutils": ^2.1.1
@@ -3610,19 +3610,6 @@ __metadata:
     "@lumino/widgets": ^2.1.1
     react: ^18.2.0
   checksum: a5bdf1a5cc5ea2794e152fe1d273d081c296c0e804471f398aad2edf95fb11c8d2fb79c2a6e7db96c6ac8c2b6537499afa6e77ab37d7bb17d849eb882c53d2b4
-  languageName: node
-  linkType: hard
-
-"@jupyterlab/rendermime-extension@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@jupyterlab/rendermime-extension@npm:4.0.0"
-  dependencies:
-    "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.0.0
-    "@jupyterlab/docmanager": ^4.0.0
-    "@jupyterlab/rendermime": ^4.0.0
-    "@jupyterlab/translation": ^4.0.0
-  checksum: 821ca4d0f098430780214d2a8a53fbdc53d60db1f839509c94381a4a4787a8fa7dc218d5e771c14b290e4f3a83c50d8c72d9295b126256af74b41acf8b67f85a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/6387

Provide a custom rendermime plugin to be able to define a custom command to handle local links via `{baseUrl}/tree/`.

- [x] Add the custom plugin
- [x] Add UI tests

https://github.com/jupyter/notebook/assets/591645/d3707137-4616-4282-9883-2de020b21737

