### PR TITLE
Add `JSONLicenseWebpackPlugin`

### DIFF
--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -14,6 +14,7 @@ const BundleAnalyzerPlugin =
   require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const Build = require('@jupyterlab/builder').Build;
+const WPPlugin = require('@jupyterlab/builder').WPPlugin;
 const baseConfig = require('@jupyterlab/builder/lib/webpack.config.base');
 
 const data = require('./package.json');
@@ -219,6 +220,10 @@ module.exports = [
       fallback: { util: false },
     },
     plugins: [
+      new WPPlugin.JSONLicenseWebpackPlugin({
+        excludedPackageTest: (packageName) =>
+          packageName === '@jupyter-notebook/app',
+      }),
       new ModuleFederationPlugin({
         library: {
           type: 'var',


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/6817

Adding the upstream `JSONLicenseWebpackPlugin` webpack plugin to generate the `third-party-licenses.json` file on build:

![image](https://github.com/jupyter/notebook/assets/591645/eb1315ab-a61a-4987-b98b-46e5863f8b32)
