### PR TITLE
Add an empty splash screen on notebook launch to avoid a flash of unstyled content 

### DIFF
--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
@@ -13,6 +14,7 @@ import {
   DOMUtils,
   ICommandPalette,
   ISanitizer,
+  ISplashScreen,
   IToolbarWidgetRegistry,
 } from '@jupyterlab/apputils';
 
@@ -391,6 +393,29 @@ const shell: JupyterFrontEndPlugin<INotebookShell> = {
   },
   autoStart: true,
   provides: INotebookShell,
+};
+
+/**
+ * The default splash screen provider.
+ */
+const splash: JupyterFrontEndPlugin<ISplashScreen> = {
+  id: '@jupyterlab/apputils-extension:splash',
+  description: 'Provides an empty splash screen.',
+  autoStart: true,
+  provides: ISplashScreen,
+  activate: () => {
+    return {
+      show: () => {
+        const splashNode = document.createElement('div');
+        document.body.appendChild(splashNode);
+        document.body.removeChild(splashNode);
+
+        return new DisposableDelegate(() => {
+          // Splash creates no resources, no cleanup needed.
+        });
+      },
+    };
+  },
 };
 
 /**
@@ -1005,6 +1030,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   rendermime,
   shell,
   sidePanelVisibility,
+  splash,
   status,
   tabTitle,
   title,

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -398,7 +398,7 @@ const shell: JupyterFrontEndPlugin<INotebookShell> = {
  * The default splash screen provider.
  */
 const splash: JupyterFrontEndPlugin<ISplashScreen> = {
-  id: '@jupyterlab/apputils-extension:splash',
+  id: '@jupyter-notebook/application-extension:splash',
   description: 'Provides an empty splash screen.',
   autoStart: true,
   provides: ISplashScreen,

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -403,15 +403,21 @@ const splash: JupyterFrontEndPlugin<ISplashScreen> = {
   description: 'Provides an empty splash screen.',
   autoStart: true,
   provides: ISplashScreen,
-  activate: () => {
-    return {
-      show: () => {
-        const splashNode = document.createElement('div');
-        document.body.appendChild(splashNode);
-        document.body.removeChild(splashNode);
+  activate: (app: JupyterFrontEnd) => {
+    const { restored } = app;
+    const splash = document.createElement('div');
+    splash.style.position = 'absolute';
+    splash.style.width = '100%';
+    splash.style.height = '100%';
+    splash.style.zIndex = '10';
 
-        return new DisposableDelegate(() => {
-          // Splash creates no resources, no cleanup needed.
+    return {
+      show: (light = true) => {
+        splash.style.backgroundColor = light ? 'white' : '#111111';
+        document.body.appendChild(splash);
+        return new DisposableDelegate(async () => {
+          await restored;
+          document.body.removeChild(splash);
         });
       },
     };


### PR DESCRIPTION
Add an empty splash screen on notebook launch to avoid a flash of unstyled content while custom CSS is loading.

Fixes #6790.

Without this PR:

(slowed down)
![without_new](https://github.com/jupyter/notebook/assets/26686070/25422a60-ff08-4633-9404-dd2d95f731ad)

![without_dark](https://github.com/jupyter/notebook/assets/26686070/42e15c52-b1f9-49b3-b3b0-44e38e7ea400)

With this PR:

(slowed down)
![with_light_new](https://github.com/jupyter/notebook/assets/26686070/2f53511e-2eb8-4eb1-bba9-1c8a01d55b11)

![with_dark](https://github.com/jupyter/notebook/assets/26686070/1044c5b7-29e8-40a3-9f21-5c253ee8d25e)
