### PR TITLE
Rename browser tab title to Home

### DIFF
--- a/notebook/templates/tree.html
+++ b/notebook/templates/tree.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{page_config['appName'] | e}} - Tree</title>
+  <title>Home</title>
   {% block favicon %}
   <link rel="icon" type="image/x-icon" href="{{ base_url | escape }}static/favicons/favicon.ico" class="favicon">
   {% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -40,7 +40,7 @@ async def test_tree_handler(notebooks, notebookapp, jp_fetch):
 
     # Check that the tree template is loaded
     html = r.body.decode()
-    assert "- Tree</title>" in html
+    assert "<title>Home</title>" in html
 
     redirected_url = None
 


### PR DESCRIPTION
When showing `tree` the title is `Home` in the classic notebook UI. This fix makes it consistent.

closes #6912 