### PR TITLE
Make jupyter logo select properly (#6927)

### DIFF
--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -171,6 +171,7 @@ const logo: JupyterFrontEndPlugin<void> = {
       height: '28px',
       width: 'auto',
       cursor: 'pointer',
+      margin: 'auto',
     });
     logo.id = 'jp-NotebookLogo';
     app.shell.add(logo, 'top', { rank: 0 });

--- a/packages/application-extension/style/base.css
+++ b/packages/application-extension/style/base.css
@@ -33,3 +33,8 @@
 .jp-MainAreaWidget > .jp-Toolbar-micro {
   display: none;
 }
+
+#jp-NotebookLogo {
+  /* bring logo to the front so it is selectable by tab*/
+  z-index: 10 ;
+}

--- a/packages/application-extension/style/base.css
+++ b/packages/application-extension/style/base.css
@@ -36,5 +36,5 @@
 
 #jp-NotebookLogo {
   /* bring logo to the front so it is selectable by tab*/
-  z-index: 10 ;
+  z-index: 10;
 }


### PR DESCRIPTION
Adding `margin: auto` and `z-index: 10` to make the Jupyter logo tab selected properly.

closes #6927 