### PR TITLE
Fix the redirect handler

### DIFF
--- a/notebook/app.py
+++ b/notebook/app.py
@@ -117,7 +117,7 @@ class RedirectHandler(NotebookBaseHandler):
     @web.authenticated
     def get(self):
         """Get the redirect url."""
-        return self.redirect(self.base_url.strip("/") + "/" + self.default_url.strip("/"))
+        return self.redirect(self.base_url + "tree")
 
 
 class TreeHandler(NotebookBaseHandler):


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/6940

@balajialg trying locally with `jupyterhub` with the following config, it looks like this should fix the issue

```py
c = get_config()  # noqa

from jupyterhub.auth import DummyAuthenticator

c.JupyterHub.authenticator_class = DummyAuthenticator

from jupyterhub.spawner import SimpleLocalProcessSpawner

c.JupyterHub.spawner_class = SimpleLocalProcessSpawner
c.JupyterHub.bind_url = 'http://0.0.0.0:8000'
c.Spawner.cmd = ["jupyter-labhub"]
c.Spawner.default_url = '/tree'
```

**Before**


https://github.com/jupyter/notebook/assets/591645/dc76db51-6a13-40c8-96a7-a9fb4b0d158a



**After**


https://github.com/jupyter/notebook/assets/591645/4784b640-660c-4775-bfbe-92ba1e6101e9

