### PR TITLE
Update Jupytext Notebook url path

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -42,8 +42,7 @@ const opener: JupyterFrontEndPlugin<IDocumentWidgetOpener> = {
           let route = 'edit';
           if (
             (widgetName === 'default' && ext === '.ipynb') ||
-            widgetName === 'Notebook' ||
-            widgetName === 'Jupytext Notebook'
+            widgetName.includes('Notebook')
           ) {
             route = 'notebooks';
           }

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -42,7 +42,8 @@ const opener: JupyterFrontEndPlugin<IDocumentWidgetOpener> = {
           let route = 'edit';
           if (
             (widgetName === 'default' && ext === '.ipynb') ||
-            widgetName === 'Notebook'
+            widgetName === 'Notebook' ||
+            widgetName === 'Jupytext Notebook'
           ) {
             route = 'notebooks';
           }


### PR DESCRIPTION
Fixes #6942 
I believe this addresses the last point in the issue above, as when a Jupytext Notebook is opened it no longer adds the  `/edit` route but rather `/notebooks`.