### PR TITLE
fix: update link to troubleshooting guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -40,7 +40,7 @@ Here, we're looking for specific bugs in the Jupyter Notebook codebase. If you t
 4. See error '...'
 
 <!--Describe how you diagnosed the issue. See the guidelines at
-https://jupyter-notebook.readthedocs.io/en/latest/troubleshooting -->
+https://jupyter-notebook.readthedocs.io/en/latest/troubleshooting.html -->
 
 ## Expected behavior
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -11,4 +11,4 @@ contact_links:
     about: Ask short questions about using Jupyter Notebook
   - name: 📝 Do you have a feature request that may be applied upstream? See JupyterLab.
     url: https://github.com/jupyterlab/jupyterlab
-    about: We recommend that you cross-referrence JupyterLab for information when requesting new features and support for Notebook 7. We won't likely accept new features for Jupyter Notebook 6.x.
+    about: We recommend that you cross-reference JupyterLab for information when requesting new features and support for Notebook 7. We won't likely accept new features for Jupyter Notebook 6.x.


### PR DESCRIPTION
**PR Summary**:
The PR contains a fix to broken link found in the `.github/ISSUE_TEMPLATE/bug_report.md` file. It prevents users from checking the troubleshooting guidelines. Also fixed small typo in `.github/ISSUE_TEMPLATE/config.yml`.