### PR TITLE
Fix Python 3.12 compatibility

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,7 +91,7 @@ def make_notebook_app(  # noqa PLR0913
     )
 
     # Copy the schema files.
-    test_data = str(files("jupyterlab_server.test_data").joinpath(""))
+    test_data = str(files("jupyterlab_server.test_data")._paths[0])  # type: ignore
     src = pathlib.PurePath(test_data, "schemas", "@jupyterlab")
     dst = pathlib.PurePath(str(schemas_dir), "@jupyterlab")
     if os.path.exists(dst):


### PR DESCRIPTION
.joinpath with an empty argument no longer works as before thanks to this change in CPython: https://github.com/python/cpython/commit/cea910ebf14d1bd9d8bc0c8a5046e69ae8f5be17#diff-2e741d925220d74a9cc04cda1314d3649d9d189c0efc7db18e5387a51225b61c

This change mimics the old internal behavior by using _paths attribute directly.

I'm not saying it's perfect but it's the shortest solution I was able to come up with when building notebook 7rc2 with Python 3.12 in Fedora rawhide.