### PR TITLE
Fix link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ jupyter notebook
 
 ### Running in a remote installation
 
-You need some configuration before starting Jupyter notebook remotely. See [Running a notebook server](https://jupyter-notebook.readthedocs.io/en/stable/public_server.html).
+You need some configuration before starting Jupyter notebook remotely. See [Running a notebook server](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html).
 
 ## Development Installation
 


### PR DESCRIPTION
The old link pointing to `stable` was giving a 404 after the Notebook 7 release.

Instead we point to the Jupyter Server docs: https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html