### PR TITLE
Remove `RedirectHandler`

### DIFF
--- a/notebook/app.py
+++ b/notebook/app.py
@@ -111,15 +111,6 @@ class NotebookBaseHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, Jup
         return page_config
 
 
-class RedirectHandler(NotebookBaseHandler):
-    """A redirect handler."""
-
-    @web.authenticated
-    def get(self):
-        """Get the redirect url."""
-        return self.redirect(self.base_url + "tree")
-
-
 class TreeHandler(NotebookBaseHandler):
     """A tree page handler."""
 
@@ -329,7 +320,6 @@ class JupyterNotebookApp(NotebookConfigShimMixin, LabServerApp):
             # if the serverapp set one
             page_config["token"] = ""
 
-        self.handlers.append(("/?", RedirectHandler))
         self.handlers.append(("/tree(.*)", TreeHandler))
         self.handlers.append(("/notebooks(.*)", NotebookHandler))
         self.handlers.append(("/edit(.*)", FileHandler))


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/6954

Investigate https://github.com/jupyter/notebook/issues/6954.

Jupyter Server already provides a redirect handler which looks at the `default_url` here:


https://github.com/jupyter-server/jupyter_server/blob/c5dc0f696f376e1db5a9a0cbcebb40a0bf98875c/jupyter_server/serverapp.py#L440-L451

Which means the one in `notebook` can likely be removed.

Testing with:

```
npm i -g configurable-http-proxy
jupyterhub --config jupyterhub_config.py
```

`jupyterhub_config.py`:

```py
c = get_config()  # noqa

from jupyterhub.auth import DummyAuthenticator

c.JupyterHub.authenticator_class = DummyAuthenticator

from jupyterhub.spawner import SimpleLocalProcessSpawner

c.JupyterHub.spawner_class = SimpleLocalProcessSpawner
c.JupyterHub.bind_url = 'http://0.0.0.0:8000'
c.Spawner.default_url = '/tree'
```