### PR TITLE
Require importlib_resources for testing on Python < 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        # used by the jupyterlab/maintainer-tools base-setup action
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,7 @@ filterwarnings = [
     "ignore:There is no current event loop:DeprecationWarning",
     "ignore:make_current is deprecated; start the event loop first",
     "ignore:clear_current is deprecated",
-    "ignore:datetime.utcnow.* is deprecated",
+    "ignore:datetime.utc.* is deprecated",
 ]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
 ]
 dependencies = [
     "jupyter_server>=2.4.0,<3",
-    "importlib-resources>=5.0;python_version<\"3.9\"",
     "jupyterlab>=4.0.2,<5",
     "jupyterlab_server>=2.22.1,<3",
     "notebook_shim>=0.2,<0.3",
@@ -59,6 +58,7 @@ test = [
     "ipykernel",
     "jupyter_server[test]>=2.4.0,<3",
     "jupyterlab_server[test]>=2.22.1,<3",
+    "importlib-resources>=5.0;python_version<\"3.10\"",
 ]
 docs = [
     "myst_parser",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,8 @@ filterwarnings = [
     "error",
     "ignore:There is no current event loop:DeprecationWarning",
     "ignore:make_current is deprecated; start the event loop first",
-    "ignore:clear_current is deprecated"
+    "ignore:clear_current is deprecated",
+    "ignore:datetime.utcnow.* is deprecated",
 ]
 
 [tool.coverage.report]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,9 @@ import shutil
 import sys
 
 if sys.version_info < (3, 10):
-    from importlib_resources import files  # type:ignore
+    from importlib_resources import files
 else:
-    from importlib.resources import files  # type:ignore
+    from importlib.resources import files
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,12 @@ import os
 import os.path as osp
 import pathlib
 import shutil
+import sys
 
-try:
-    from importlib.resources import files
-except ImportError:
+if sys.version_info < (3, 10):
     from importlib_resources import files  # type:ignore
+else:
+    from importlib.resources import files  # type:ignore
 
 import pytest
 


### PR DESCRIPTION
Closes #7014

importlib.resources is only used in the tests. Version 5.0 is included in python 3.10+