### PR TITLE
Fix docs build on Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,6 +19,7 @@ tasks:
       export MAMBA_EXE=/workspace/bin/micromamba
       $(/workspace/bin/micromamba shell hook --shell=bash)
       export JUPYTER_PREFER_ENV_PATH=1
+      export TZ=UTC
       micromamba activate
       EOT
       source /workspace/bin/activate-env.sh


### PR DESCRIPTION
Similar to https://github.com/jupyterlab/jupyterlab/pull/15041

The docs build has been failing for a while on Gitpod with the following error:

```
ValueError: ZoneInfo keys may not be absolute paths, got: /UTC
```

![image](https://github.com/jupyterlab/jupyterlab/assets/591645/9c4113bd-8de3-4b65-a9c3-f805b74c40d6)


This seems to be related to https://github.com/nektos/act/issues/1853.
