### PR TITLE
Add `datetime.datetime.utc()` to the filter list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,7 @@ filterwarnings = [
     "ignore:make_current is deprecated; start the event loop first",
     "ignore:clear_current is deprecated",
     "ignore:datetime.utc.* is deprecated",
+    "ignore:datetime.datetime.* is deprecated",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
Add addition entry to the `filterwarnings` list, as noticed in this failing check on the latest commit `main`: https://github.com/jupyter/notebook/actions/runs/6084077114/job/16607664845