### PR TITLE
fix traitlets warning->error on 6.5.x

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1408,7 +1408,7 @@ class NotebookApp(JupyterApp):
             # and allow jupyter_server contents managers to pass
             # through. If jupyter_server is not installed, this class
             # will be ignored.
-            'jupyter_server.contents.services.managers.ContentsManager'
+            "jupyter_server.services.contents.managers.ContentsManager",
         ],
         config=True,
         help=_('The notebook manager class to use.')

--- a/notebook/traittypes.py
+++ b/notebook/traittypes.py
@@ -1,5 +1,6 @@
 import inspect
-from traitlets import ClassBasedTraitType, Undefined, warn
+from warnings import warn
+from traitlets import ClassBasedTraitType, Undefined
 
 # Traitlet's 5.x includes a set of utilities for building
 # description strings for objects. Traitlets 5.x does not


### PR DESCRIPTION
#6840 didn't get applied to 6.5.x, causing startup failure with recent traitlets 5.10

also fixes the typo that causes the import to always fail, which should only produce a warning, not an error.

closes #7048