### PR TITLE
Switch from `hub` to `gh` in the Playwright snapshots update workflow

### DIFF
--- a/.github/workflows/playwright-update.yml
+++ b/.github/workflows/playwright-update.yml
@@ -27,7 +27,7 @@ jobs:
           # PR branch remote must be checked out using https URL
           git config --global hub.protocol https
 
-          hub pr checkout ${{ github.event.issue.number }}
+          gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Similar to https://github.com/jupyterlab/jupyterlab/issues/15212

`hub` cli was removed from the runner images: https://github.com/actions/runner-images/issues/8362