### PR TITLE
Remove link to the PDF documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This repository is a Jupyter project and follows the Jupyter
 - [Online Demo at jupyter.org/try](https://jupyter.org/try)
 - [Documentation for Jupyter notebook](https://jupyter-notebook.readthedocs.io/en/latest/)
 - [Korean Version of Installation](https://github.com/ChungJooHo/Jupyter_Kor_doc/)
-- [Documentation for Project Jupyter](https://jupyter.readthedocs.io/en/latest/index.html) \[[PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)\]
+- [Documentation for Project Jupyter](https://jupyter.readthedocs.io/en/latest/index.html)
 - [Issues](https://github.com/jupyter/notebook/issues)
 - [Technical support - Jupyter Google Group](https://discourse.jupyter.org/)
 


### PR DESCRIPTION
This should fix the failing check links on CI:

![image](https://github.com/jupyter/notebook/assets/591645/4008ffad-590a-42bc-a9b0-ecbb4c109310)
