### PR TITLE
Ignore yarn.lock for codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
         args: ['-L', 'sur,nd']
         exclude: |
           (?x)^(
+              yarn.lock|
               binder/example.ipynb|
               docs/source/examples/images/FrontendKernel.graffle/data.plist|
           )$


### PR DESCRIPTION
Fix the recent CI failure as noticed on other PRs:

![image](https://github.com/jupyter/notebook/assets/591645/f1b1d8a0-0506-4ec4-b8ab-231334e2f8b1)
