### PR TITLE
Updated fav-icon Base URL from JupyterLab PageConfig.

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -415,8 +415,8 @@ const tabIcon: JupyterFrontEndPlugin<void> = {
   activate: (app: JupyterFrontEnd, tracker: INotebookTracker) => {
     // the favicons are provided by Jupyter Server
     const baseURL = PageConfig.getBaseUrl();
-    const notebookIcon = ' /static/favicons/favicon-notebook.ico';
-    const busyIcon = ' /static/favicons/favicon-busy-1.ico';
+    const notebookIcon = `${baseURL}/static/favicons/favicon-notebook.ico`;
+    const busyIcon = `${baseURL}/static/favicons/favicon-busy-1.ico`;
 
     const updateBrowserFavicon = (
       status: ISessionContext.KernelDisplayStatus
@@ -426,10 +426,10 @@ const tabIcon: JupyterFrontEndPlugin<void> = {
       ) as HTMLLinkElement;
       switch (status) {
         case 'busy':
-          link.href = baseURL + busyIcon;
+          link.href = busyIcon;
           break;
         case 'idle':
-          link.href = baseURL + notebookIcon;
+          link.href = notebookIcon;
           break;
       }
     };

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -14,7 +14,7 @@ import {
 
 import { Cell, CodeCell } from '@jupyterlab/cells';
 
-import { Text, Time } from '@jupyterlab/coreutils';
+import { PageConfig, Text, Time, URLExt } from '@jupyterlab/coreutils';
 
 import { IDocumentManager } from '@jupyterlab/docmanager';
 
@@ -37,9 +37,6 @@ import { Poll } from '@lumino/polling';
 import { Widget } from '@lumino/widgets';
 
 import { TrustedComponent } from './trusted';
-
-import { PageConfig, URLExt } from '@jupyterlab/coreutils';
-
 
 /**
  * The class for kernel status errors.
@@ -415,7 +412,10 @@ const tabIcon: JupyterFrontEndPlugin<void> = {
   activate: (app: JupyterFrontEnd, tracker: INotebookTracker) => {
     // the favicons are provided by Jupyter Server
     const baseURL = PageConfig.getBaseUrl();
-    const notebookIcon = URLExt.join(baseURL, 'static/favicons/favicon-notebook.ico');
+    const notebookIcon = URLExt.join(
+      baseURL,
+      'static/favicons/favicon-notebook.ico'
+    );
     const busyIcon = URLExt.join(baseURL, 'static/favicons/favicon-busy-1.ico');
 
     const updateBrowserFavicon = (

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -38,6 +38,9 @@ import { Widget } from '@lumino/widgets';
 
 import { TrustedComponent } from './trusted';
 
+import { PageConfig } from '@jupyterlab/coreutils';
+
+
 /**
  * The class for kernel status errors.
  */
@@ -411,6 +414,7 @@ const tabIcon: JupyterFrontEndPlugin<void> = {
   requires: [INotebookTracker],
   activate: (app: JupyterFrontEnd, tracker: INotebookTracker) => {
     // the favicons are provided by Jupyter Server
+    const baseURL = PageConfig.getBaseUrl();
     const notebookIcon = ' /static/favicons/favicon-notebook.ico';
     const busyIcon = ' /static/favicons/favicon-busy-1.ico';
 
@@ -422,10 +426,10 @@ const tabIcon: JupyterFrontEndPlugin<void> = {
       ) as HTMLLinkElement;
       switch (status) {
         case 'busy':
-          link.href = busyIcon;
+          link.href = baseURL + busyIcon;
           break;
         case 'idle':
-          link.href = notebookIcon;
+          link.href = baseURL + notebookIcon;
           break;
       }
     };

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -38,7 +38,7 @@ import { Widget } from '@lumino/widgets';
 
 import { TrustedComponent } from './trusted';
 
-import { PageConfig } from '@jupyterlab/coreutils';
+import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
 
 /**
@@ -415,8 +415,8 @@ const tabIcon: JupyterFrontEndPlugin<void> = {
   activate: (app: JupyterFrontEnd, tracker: INotebookTracker) => {
     // the favicons are provided by Jupyter Server
     const baseURL = PageConfig.getBaseUrl();
-    const notebookIcon = `${baseURL}/static/favicons/favicon-notebook.ico`;
-    const busyIcon = `${baseURL}/static/favicons/favicon-busy-1.ico`;
+    const notebookIcon = URLExt.join(baseURL, 'static/favicons/favicon-notebook.ico');
+    const busyIcon = URLExt.join(baseURL, 'static/favicons/favicon-busy-1.ico');
 
     const updateBrowserFavicon = (
       status: ISessionContext.KernelDisplayStatus


### PR DESCRIPTION
We were Getting 404 because base URL of binder(different base url) was used for fetching fav-icons I have update code to use Base URL from JupyterLab PageConfig. 
This closes issue #7076 