### PR TITLE
Set `navigation_with_keys` to `False`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -203,6 +203,7 @@ html_theme_options = {
         "image_dark": "_static/logo-rectangle-dark.svg",
     },
     "use_edit_page_button": True,
+    "navigation_with_keys": False,
 }
 
 # Output for github to be used in links


### PR DESCRIPTION
Caused by this upstream PR: https://github.com/pydata/pydata-sphinx-theme/pull/1503


And causing the docs CI check to fail recently.