### PR TITLE
[7.0.x] Install stable JupyterLab 4.0 in the releaser hook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,7 @@ version-cmd = "jlpm run release:bump --force --skip-commit"
 
 [tool.jupyter-releaser.hooks]
 before-bump-version = [
-    "python -m pip install --pre -U jupyterlab",
+    "python -m pip install -U jupyterlab~=4.0",
     "jlpm",
     "jlpm run build:utils",
     "python -m pip install hatch"


### PR DESCRIPTION
Investigate CI failures:

- [x] Use stable JupyterLab 4.0 in the releaser hook to avoid https://github.com/jupyterlab/jupyterlab/issues/15503
- [x] ~Fix typings~ -> defered to backporting some other PRs

![image](https://github.com/jupyter/notebook/assets/591645/09dd7542-e8d8-42a1-97ba-9836668ae41d)
