### PR TITLE
Add nbviewer.jupyter.org to the ignore list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,7 +175,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
-          ignore_links: 'https://playwright.dev/docs/test-cli/ https://blog.jupyter.org/the-big-split-9d7b88a031a7 https://blog.jupyter.org/jupyter-ascending-1bf5b362d97e https://mybinder.org/v2/gh/jupyter/notebook/main'
+          ignore_links: 'https://playwright.dev/docs/test-cli/ https://blog.jupyter.org/the-big-split-9d7b88a031a7 https://blog.jupyter.org/jupyter-ascending-1bf5b362d97e https://mybinder.org/v2/gh/jupyter/notebook/main https://nbviewer.jupyter.org'
           ignore_glob: 'ui-tests/test/notebooks/*'
 
   test_lint:

--- a/docs/source/examples/Notebook/Notebook Basics.ipynb
+++ b/docs/source/examples/Notebook/Notebook Basics.ipynb
@@ -185,7 +185,7 @@
    "source": [
     "The first idea of mouse based navigation is that **cells can be selected by clicking on them.** The currently selected cell gets a grey or green border depending on whether the notebook is in edit or command mode. If you click inside a cell's editor area, you will enter edit mode. If you click on the prompt or output area of a cell you will enter command mode.\n",
     "\n",
-    "If you are running this notebook in a live session (not on http://nbviewer.jupyter.org) try selecting different cells and going between edit and command mode. Try typing into a cell."
+    "If you are running this notebook in a live session (not on https://nbviewer.jupyter.org) try selecting different cells and going between edit and command mode. Try typing into a cell."
    ]
   },
   {


### PR DESCRIPTION
https://nbviewer.org/ has been down for a couple of days now, and is making the check-links check fail on CI.

Example run: https://github.com/jupyter/notebook/actions/runs/7279681520/job/19852693160?pr=7196

![image](https://github.com/jupyter/notebook/assets/591645/879cc8ad-96a8-47f5-8a6f-62f520a8075d)
