### PR TITLE
Workaround for the file browser tracker focus issue

### DIFF
--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -397,6 +397,8 @@ const notebookTreeWidget: JupyterFrontEndPlugin<INotebookTree> = {
       setCurrentToDefaultBrower()
     );
 
+    setCurrentToDefaultBrower();
+
     return nbTreeWidget;
   },
 };

--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -18,6 +18,7 @@ import {
   FileBrowser,
   Uploader,
   IDefaultFileBrowser,
+  IFileBrowserFactory,
 } from '@jupyterlab/filebrowser';
 
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
@@ -263,6 +264,7 @@ const notebookTreeWidget: JupyterFrontEndPlugin<INotebookTree> = {
     ITranslator,
     ISettingRegistry,
     IToolbarWidgetRegistry,
+    IFileBrowserFactory,
   ],
   optional: [
     IRunningSessionManagers,
@@ -277,6 +279,7 @@ const notebookTreeWidget: JupyterFrontEndPlugin<INotebookTree> = {
     translator: ITranslator,
     settingRegistry: ISettingRegistry,
     toolbarRegistry: IToolbarWidgetRegistry,
+    factory: IFileBrowserFactory,
     manager: IRunningSessionManagers | null,
     settingEditorTracker: ISettingEditorTracker | null,
     jsonSettingEditorTracker: IJSONSettingEditorTracker | null
@@ -379,6 +382,19 @@ const notebookTreeWidget: JupyterFrontEndPlugin<INotebookTree> = {
           });
         }
       }
+    );
+
+    const { tracker } = factory;
+
+    // TODO: remove
+    // Workaround to force the focus on the default file browser
+    // See https://github.com/jupyterlab/jupyterlab/issues/15629 for more info
+    const setCurrentToDefaultBrower = () => {
+      tracker['_pool'].current = browser;
+    };
+
+    tracker.widgetAdded.connect((sender, widget) =>
+      setCurrentToDefaultBrower()
     );
 
     return nbTreeWidget;


### PR DESCRIPTION
Workaround for https://github.com/jupyter/notebook/issues/7210

Also reported upstream in JupyterLab: https://github.com/jupyterlab/jupyterlab/issues/15629

This workaround should be temporary until https://github.com/jupyterlab/jupyterlab/issues/15629 is fixed. Also it should not impact users too much as we do not "officially" support drives yet (so forcing the focus in the default file browser is not too disruptive): https://github.com/jupyter/notebook/pull/7212