### PR TITLE
Add documentation for updating `notebook` imports

### DIFF
--- a/docs/source/configuring/config_overview.md
+++ b/docs/source/configuring/config_overview.md
@@ -52,6 +52,12 @@ front-end Notebook client (i.e. the familiar notebook interface).
 > - Related: [Configuring a language kernel](https://ipython.readthedocs.io/en/latest/install/kernel_install.html)
 >   to run in the Jupyter Server enables your server to run other languages, like R or Julia.
 
+```{warning}
+Jupyter Notebook 7 is now based on Jupyter Server. This may break some previous `notebook` imports you may have been using, such as `notebook.auth` or `notebook.notebookapp`.
+
+Check out the [migration guide](../migrating/server-imports.md) to learn more on how to update these server imports.
+```
+
 (configure-nbextensions)=
 
 ## Notebook extensions

--- a/docs/source/migrate_to_notebook7.md
+++ b/docs/source/migrate_to_notebook7.md
@@ -73,6 +73,7 @@ notebook_7_features.md
 
 migrating/frontend-extensions.md
 migrating/server-extensions.md
+migrating/server-imports.md
 migrating/custom-themes.md
 migrating/multiple-interfaces.md
 ```

--- a/docs/source/migrating/server-imports.md
+++ b/docs/source/migrating/server-imports.md
@@ -1,0 +1,33 @@
+# Server Imports in Notebook 7
+
+Notebook 7 is now based on Jupyter Server, which is a new server application that allows to run multiple Jupyter frontends (e.g. Notebook, JupyterLab, NBClassic, etc.) on the same server.
+
+Prior to Notebook 7, the classic notebook server include the server modules in the `notebook` package. This means it was possible to import the server modules from the `notebook` package, for example:
+
+```python
+from notebook.auth import passwd
+passwd("foo")
+```
+
+Or:
+
+```python
+from notebook import notebookapp
+notebookapp.list_running_servers()
+```
+
+In Notebook 7, these server modules are now exposed by the `jupyter_server` package. The code snippets above should be updated to:
+
+```python
+from jupyter_server.auth import passwd
+passwd("foo")
+```
+
+And:
+
+```python
+from jupyter_server import serverapp
+serverapp.list_running_servers()
+```
+
+These are just examples, so you may have to adjust based on the specific server modules you were using.

--- a/docs/source/migrating/server-imports.md
+++ b/docs/source/migrating/server-imports.md
@@ -1,8 +1,8 @@
 # Server Imports in Notebook 7
 
-Notebook 7 is now based on Jupyter Server, which is a new server application that allows to run multiple Jupyter frontends (e.g. Notebook, JupyterLab, NBClassic, etc.) on the same server.
+Notebook 7 is now based on Jupyter Server, which lets users run multiple Jupyter frontends (e.g. Notebook, JupyterLab, NBClassic, etc.) on the same server.
 
-Prior to Notebook 7, the classic notebook server include the server modules in the `notebook` package. This means it was possible to import the server modules from the `notebook` package, for example:
+Prior to Notebook 7, the Classic Notebook server included the server modules in the `notebook` package. This means it was possible to import the server modules from the `notebook` package, for example:
 
 ```python
 from notebook.auth import passwd
@@ -30,4 +30,4 @@ from jupyter_server import serverapp
 serverapp.list_running_servers()
 ```
 
-These are just examples, so you may have to adjust based on the specific server modules you were using.
+These are just examples, so you may have to adjust your use of `notebook` imports based on the specific server modules you were using.


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/7015

Documentation preview: https://jupyter-notebook--7244.org.readthedocs.build/en/7244/migrating/server-imports.html