### PR TITLE
Fix jupyterlab install command in the releaser hook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ version-cmd = "jlpm run release:bump --force --skip-commit"
 
 [tool.jupyter-releaser.hooks]
 before-bump-version = [
-    "python -m pip install --pre -U jupyterlab",
+    "python -m pip install -U jupyterlab>=4.1.1,<4.2",
     "jlpm",
     "jlpm run build:utils",
     "python -m pip install hatch"


### PR DESCRIPTION
Properly pin the version of JupyterLab instead of pulling a pre-release.