### PR TITLE
6.5.x: Unpin pyzmq

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ for more information.
         'tornado>=6.1',
         # pyzmq>=17 is not technically necessary,
         # but hopefully avoids incompatibilities with Tornado 5. April 2018
-        'pyzmq>=17,<25',
+        'pyzmq>=17',
         'argon2-cffi',
         'traitlets>=4.2.1',
         'jupyter_core>=4.6.1',


### PR DESCRIPTION
temporary pin applied to both jupyter-client 8 and pyzmq 25 in #6749 _appears_ resolved with jupyter-client 7.4.9 (or [jupyter-core 5.3.2](https://github.com/jupyter/notebook/issues/6721#issuecomment-1737177339)?), at least in terms of pyzmq.

I tried to follow all of the examples in #6721 with pyzmq 25.1.2 and saw no errors.

Pinning down pyzmq prevents installation of `notebook` (and thereby [jupyterlab 3](https://github.com/jupyterlab/jupyterlab/issues/15332) and others) on Python 3.12, since pyzmq 25.1 is the first version to support 3.12, so there's a real cost to keeping a pin here if the problem is fixed elsewhere.