### PR TITLE
Add --user option to pip install command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ mamba create -n notebook -c conda-forge python nodejs -y
 mamba activate notebook
 
 # Install package in development mode
-pip install -e ".[dev,test]"
+pip install -e ".[dev,test]" --user
 
 # Link the notebook extension and @jupyter-notebook schemas
 jlpm develop


### PR DESCRIPTION
this adjustment was made to address installation issues observed during compilation on my local machine

by adding --user , we avoid the need for administrative permissions when installing the package. This makes it more practical for users to install the package without requiring elevated privileges