### PR TITLE
Fix scrollbar always showing up by default

### DIFF
--- a/packages/notebook-extension/style/base.css
+++ b/packages/notebook-extension/style/base.css
@@ -45,7 +45,9 @@ body[data-notebook='notebooks'] .jp-Notebook-cell {
 }
 
 /* Empty space at the bottom of the notebook (similar to classic) */
-body[data-notebook='notebooks'] .jp-Notebook.jp-mod-scrollPastEnd::after {
+body[data-notebook='notebooks']
+  .jp-Notebook.jp-mod-scrollPastEnd
+  .jp-WindowedPanel-outer::after {
   min-height: 100px;
 }
 


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/7326

No browser scrollbar for small notebooks: 

![image](https://github.com/jupyter/notebook/assets/591645/62a8636e-a88d-43de-8cd0-7340c3e4d187)
