### PR TITLE
Force notebook windowing mode to `defer`

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -564,27 +564,18 @@ const editNotebookMetadata: JupyterFrontEndPlugin<void> = {
 };
 
 /**
- * A plugin to set the default windowing mode for the notebook
- * TODO: remove
+ * A plugin to set the default windowing mode to defer for the notebook
+ * TODO: remove?
  */
 const windowing: JupyterFrontEndPlugin<void> = {
   id: '@jupyter-notebook/notebook-extension:windowing',
   autoStart: true,
-  requires: [ISettingRegistry],
-  activate: (app: JupyterFrontEnd, settingRegistry: ISettingRegistry): void => {
-    // default to `none` to avoid notebook rendering glitches
-    const settings = settingRegistry.load(
-      '@jupyterlab/notebook-extension:tracker'
-    );
-    Promise.all([settings, app.restored])
-      .then(([settings]) => {
-        if (settings.user.windowing === undefined) {
-          void settings.set('windowingMode', 'defer');
-        }
-      })
-      .catch((reason: Error) => {
-        console.error(reason.message);
-      });
+  requires: [INotebookTracker],
+  activate: (app: JupyterFrontEnd, notebookTracker: INotebookTracker): void => {
+    notebookTracker.widgetAdded.connect((sender, widget) => {
+      widget.content['_viewModel'].windowingActive = false;
+      widget.content.notebookConfig.windowingMode = 'defer';
+    });
   },
 };
 

--- a/packages/notebook-extension/style/base.css
+++ b/packages/notebook-extension/style/base.css
@@ -51,6 +51,12 @@ body[data-notebook='notebooks']
   min-height: 100px;
 }
 
+/* Workaround for disabling the full windowing mode */
+body[data-notebook='notebooks']
+  .jp-Toolbar-item[data-jp-item-name='scrollbar'] {
+  display: none;
+}
+
 /* Fix background colors */
 
 body[data-notebook='notebooks'] .jp-WindowedPanel-outer > * {


### PR DESCRIPTION
Work around the default `full` windowing mode to force Notebook 7 to use `defer` instead, but avoid changing the settings.

This prevents altering the JupyterLab configuration after using Notebook.