### PR TITLE
Fix CSS for `full` windowing mode

### DIFF
--- a/packages/notebook-extension/style/base.css
+++ b/packages/notebook-extension/style/base.css
@@ -24,13 +24,14 @@ body[data-notebook='notebooks'] .jp-NotebookPanel-toolbar {
 }
 
 body[data-notebook='notebooks'] .jp-WindowedPanel-outer {
+  width: unset !important;
   padding-top: unset;
   padding-left: calc(calc(100% - var(--jp-notebook-max-width)) * 0.5);
   padding-right: calc(
     calc(
         100% - var(--jp-notebook-max-width) - var(--jp-notebook-padding-offset)
       ) * 0.5
-  );
+  ) !important;
   background: var(--jp-layout-color2);
 }
 


### PR DESCRIPTION
Extract part of https://github.com/jupyter/notebook/pull/7321.

Fixes https://github.com/jupyter/notebook/issues/7231
Closes https://github.com/jupyter/notebook/pull/7301