### PR TITLE
Ignore `check-wheel-content` duplicate file error

### DIFF
--- a/notebook/bundler/tests/resources/another_subdir/test_file.txt
+++ b/notebook/bundler/tests/resources/another_subdir/test_file.txt
@@ -1,1 +1,1 @@
-Test file used to test globbing.
+Used to test globbing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,6 @@ tag_template = "v{new_version}"
 
 [[tool.tbump.file]]
 src = "notebook/_version.py"
+
+[tool.check-wheel-contents]
+ignore = ["W002"]


### PR DESCRIPTION
In attempting to make a release for `6.5.x`, during `jupyter-releaser check-python`, `check-wheel-content` gives a duplicate file error: https://github.com/jupyter/notebook/actions/runs/8851516368/job/24308219469