### PR TITLE
Add the `@jupyterlab/notebook-extension:copy-output` plugin

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -333,6 +333,7 @@
         "@jupyterlab/notebook-extension": [
           "@jupyterlab/notebook-extension:active-cell-tool",
           "@jupyterlab/notebook-extension:completer",
+          "@jupyterlab/notebook-extension:copy-output",
           "@jupyterlab/notebook-extension:metadata-editor",
           "@jupyterlab/notebook-extension:search",
           "@jupyterlab/notebook-extension:toc",


### PR DESCRIPTION
This should enable this context menu entry:

![image](https://github.com/jupyter/notebook/assets/591645/5bcd667e-04fd-473f-a83d-2d17f699b633)
