### PR TITLE
Adds message about building code before running 'develop'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,10 @@ mamba activate notebook
 # Install package in development mode
 pip install -e ".[dev,test]"
 
+# Install dependencies and build packages
+jlpm
+jlpm build
+
 # Link the notebook extension and @jupyter-notebook schemas
 jlpm develop
 


### PR DESCRIPTION
Updates `CONTRIBUTING.md` to mention that one needs to install dependencies and build the code before running `jlpm develop`, as advised by @jtpio in https://github.com/jupyter/notebook/issues/7379#issuecomment-2134643437. Fixes #7379.