### PR TITLE
"Close and Shut Down Notebook" shuts down without the confirmation dialog

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -163,7 +163,8 @@ const closeTab: JupyterFrontEndPlugin<void> = {
     commands.addCommand(id, {
       label: trans.__('Close and Shut Down Notebook'),
       execute: async () => {
-        await commands.execute('notebook:close-and-shutdown');
+        // Shut the kernel down, without confirmation
+        await commands.execute('notebook:shutdown-kernel', { activate: false });
         window.close();
       },
     });


### PR DESCRIPTION
Fixes #7359.

In Notebook 6 and nbclassic, the option "Close and Shut Down Notebook" (no ellipsis) in the File menu shuts the current notebook's kernel down immediately, and closes the browser window/tab. In Notebook 7, we had been using the JupyterLab "Close and Shut Down Notebook…" (with ellipsis) command, which causes a dialog to appear. In the interest of NB6 feature parity and consistency with the File menu's command name, this does not ask for additional confirmation before closing the notebook.