### PR TITLE
Support custom page_data_hook function

### DIFF
--- a/notebook/app.py
+++ b/notebook/app.py
@@ -120,6 +120,12 @@ class NotebookBaseHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, Jup
                 logger=self.log,
             ),
         )
+
+        # modify page config with custom hook
+        page_config_hook = self.settings.get("page_config_hook", None)
+        if page_config_hook:
+            page_config = page_config_hook(self, page_config)
+
         return page_config
 
 


### PR DESCRIPTION
Adds support for `page_config_hook` which already exists in `LabHandler` https://github.com/jupyterlab/jupyterlab_server/pull/220