### PR TITLE
Restore close and shutdown confirmation dialog

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -163,9 +163,15 @@ const closeTab: JupyterFrontEndPlugin<void> = {
     commands.addCommand(id, {
       label: trans.__('Close and Shut Down Notebook'),
       execute: async () => {
-        // Shut the kernel down, without confirmation
-        await commands.execute('notebook:shutdown-kernel', { activate: false });
-        window.close();
+        const confirm = window.confirm(
+          trans.__('Are you sure you want to close and shut down the notebook?')
+        );
+        if (confirm) {
+          await commands.execute('notebook:shutdown-kernel', {
+            activate: false,
+          });
+          window.close();
+        }
       },
     });
     menu.fileMenu.closeAndCleaners.add({


### PR DESCRIPTION
issue: #7398 

This pull request restore the close and shutdown confirmation dialog.
