### PR TITLE
Fix SyntaxWarning from update message

### DIFF
--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -185,7 +185,7 @@ class NotebookWebApplication(web.Application):
         if settings['autoreload']:
             log.info('Autoreload enabled: the webapp will restart when any Python src file changes.')
 
-        print("""
+        print(r"""
   _   _          _      _
  | | | |_ __  __| |__ _| |_ ___
  | |_| | '_ \/ _` / _` |  _/ -_)


### PR DESCRIPTION
The use of backslashes in the ASCII-art "Update" banner results in an "invalid escape sequence" SyntaxWarning under Python 3.12.  Fix by changing the banner string to a raw string (which ignores backslashes).