### PR TITLE
Remove the `StateDB` file browser trick

### DIFF
--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -384,23 +384,6 @@ const notebookTreeWidget: JupyterFrontEndPlugin<INotebookTree> = {
     // See https://github.com/jupyterlab/jupyterlab/issues/15629 for more info
     const setCurrentToDefaultBrower = () => {
       tracker['_pool'].current = browser;
-
-      // TODO: remove?
-      // provide some default state so the file browser widths are consistent and predictable
-      setTimeout(() => {
-        stateDB
-          .save('file-browser-filebrowser:columns', {
-            sizes: {
-              name: 738.65625,
-              file_size: 109.95727378063403,
-              is_selected: 18,
-              last_modified: 406.5739762193659,
-            },
-          })
-          .then(async () => {
-            await browser['listing'].restore('filebrowser');
-          });
-      });
     };
 
     tracker.widgetAdded.connect((sender, widget) => {


### PR DESCRIPTION
Normally with the UI tests introducing a `maxDiffPixels` we may be able to remove that workaround for now, let's see what CI says.