### PR TITLE
Enable single click by default in the file browser

### DIFF
--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -367,6 +367,7 @@ const notebookTreeWidget: JupyterFrontEndPlugin<INotebookTree> = {
         [
           'showFileCheckboxes',
           'showFileSizeColumn',
+          'singleClickNavigation',
           'sortNotebooksFirst',
           'showFullPath',
         ].forEach((setting) => {


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/6396

Based on the upstream PR in JupyterLab: https://github.com/jupyterlab/jupyterlab/pull/16598

As with the other file browser settings, changing it here in Notebook modifies it in JupyterLab too. Ideally this should only apply to Notebook. But this may still require: https://github.com/jupyterlab/jupyterlab/issues/14623