### PR TITLE
Move handling of the file browser settings to a separate plugin, enable file browser single click navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ The file browser now:
 
 ![a screenshot showing that it's now possible to resize the file browser columns](https://github.com/user-attachments/assets/b0d9cd0a-2828-43f7-a922-e8b271e5f7fc)
 
-In Jupyter Notebook, the single click navigation is enabled by default. If you would like to disable it to get the same experience as in JupyterLab, go to `Settings → File Browser` and make sure "Navigate files and directories with single click" is disabled.
+In Jupyter Notebook, the single click navigation is enabled by default. If you would like to disable it to get the same experience as in JupyterLab, go to `Settings → File Browser` and make sure "Navigate files and directories with single click" is unchecked.
 
 ### Improved kernel and server interactions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,12 @@ The file browser now:
 
 - supports resizing the columns and remembers the column sizes after reloading JupyterLab
 - supports uploading folders by drag-and-drop
-- supports navigation with a single click (opt-in)
+- supports navigation with a single click
 - adds a file filter collapsed by default (funnel icon)
 
 ![a screenshot showing that it's now possible to resize the file browser columns](https://github.com/user-attachments/assets/b0d9cd0a-2828-43f7-a922-e8b271e5f7fc)
+
+In Jupyter Notebook, the single click navigation is enabled by default. If you would like to disable it to get the same experience as in JupyterLab, go to `Settings → File Browser` and make sure "Navigate files and directories with single click" is disabled.
 
 ### Improved kernel and server interactions
 

--- a/app/package.json
+++ b/app/package.json
@@ -310,7 +310,6 @@
           "@jupyterlab/filebrowser-extension:file-upload-status",
           "@jupyterlab/filebrowser-extension:open-with",
           "@jupyterlab/filebrowser-extension:search",
-          "@jupyterlab/filebrowser-extension:settings",
           "@jupyterlab/filebrowser-extension:share-file"
         ],
         "@jupyter-notebook/tree-extension": true,

--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -171,7 +171,6 @@ const fileActions: JupyterFrontEndPlugin<void> = {
       };
     });
     browser.model.pathChanged.connect(() => {
-      console.log('path changed');
       selectionChanged.emit(void 0);
     });
 

--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -203,9 +203,8 @@ const fileBrowserSettings: JupyterFrontEndPlugin<void> = {
     browser: IDefaultFileBrowser,
     settingRegistry: ISettingRegistry | null
   ) => {
-    /**
-     * File browser default configuration.
-     */
+    // Default config for notebook.
+    // This is a different set of defaults than JupyterLab.
     const defaultFileBrowserConfig = {
       navigateToCurrentDirectory: false,
       singleClickNavigation: true,
@@ -217,7 +216,7 @@ const fileBrowserSettings: JupyterFrontEndPlugin<void> = {
       showFullPath: false,
     };
 
-    // apply defaults
+    // Apply defaults on plugin activation
     let key: keyof typeof defaultFileBrowserConfig;
     for (key in defaultFileBrowserConfig) {
       browser[key] = defaultFileBrowserConfig[key];

--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -192,12 +192,13 @@ const fileActions: JupyterFrontEndPlugin<void> = {
 const fileBrowserSettings: JupyterFrontEndPlugin<void> = {
   id: '@jupyter-notebook/tree-extension:settings',
   description: 'Set up the default file browser settings',
-  requires: [IDefaultFileBrowser, ISettingRegistry],
+  requires: [IDefaultFileBrowser],
+  optional: [ISettingRegistry],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     browser: IDefaultFileBrowser,
-    settingRegistry: ISettingRegistry
+    settingRegistry: ISettingRegistry | null
   ) => {
     /**
      * File browser default configuration.
@@ -219,20 +220,22 @@ const fileBrowserSettings: JupyterFrontEndPlugin<void> = {
       browser[key] = defaultFileBrowserConfig[key];
     }
 
-    void settingRegistry.load(FILE_BROWSER_PLUGIN_ID).then((settings) => {
-      function onSettingsChanged(settings: ISettingRegistry.ISettings): void {
-        let key: keyof typeof defaultFileBrowserConfig;
-        for (key in defaultFileBrowserConfig) {
-          const value = settings.get(key).user as boolean;
-          // only set the setting if it is defined by the user
-          if (value !== undefined) {
-            browser[key] = value;
+    if (settingRegistry) {
+      void settingRegistry.load(FILE_BROWSER_PLUGIN_ID).then((settings) => {
+        function onSettingsChanged(settings: ISettingRegistry.ISettings): void {
+          let key: keyof typeof defaultFileBrowserConfig;
+          for (key in defaultFileBrowserConfig) {
+            const value = settings.get(key).user as boolean;
+            // only set the setting if it is defined by the user
+            if (value !== undefined) {
+              browser[key] = value;
+            }
           }
         }
-      }
-      settings.changed.connect(onSettingsChanged);
-      onSettingsChanged(settings);
-    });
+        settings.changed.connect(onSettingsChanged);
+        onSettingsChanged(settings);
+      });
+    }
   },
 };
 

--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -170,6 +170,10 @@ const fileActions: JupyterFrontEndPlugin<void> = {
         selectionChanged.emit(void 0);
       };
     });
+    browser.model.pathChanged.connect(() => {
+      console.log('path changed');
+      selectionChanged.emit(void 0);
+    });
 
     // Create a toolbar item that adds buttons to the file browser toolbar
     // to perform actions on the files

--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -225,7 +225,7 @@ const fileBrowserSettings: JupyterFrontEndPlugin<void> = {
         for (key in defaultFileBrowserConfig) {
           const value = settings.get(key).user as boolean;
           // only set the setting if it is defined by the user
-          if (value === undefined) {
+          if (value !== undefined) {
             browser[key] = value;
           }
         }

--- a/ui-tests/test/filebrowser.spec.ts
+++ b/ui-tests/test/filebrowser.spec.ts
@@ -20,6 +20,7 @@ test.describe('File Browser', () => {
   test('Select one folder', async ({ page, tmpPath }) => {
     await page.filebrowser.refresh();
 
+    await page.keyboard.down('Control');
     await page.getByText('folder1').last().click();
 
     const toolbar = page.getByRole('toolbar');
@@ -31,6 +32,7 @@ test.describe('File Browser', () => {
   test('Select one file', async ({ page, tmpPath }) => {
     await page.filebrowser.refresh();
 
+    await page.keyboard.down('Control');
     await page.getByText('empty.ipynb').last().click();
 
     const toolbar = page.getByRole('toolbar');


### PR DESCRIPTION
Needs https://github.com/jupyterlab/jupyterlab/pull/16870

Improvements towards https://github.com/jupyter/notebook/issues/6397
Closes https://github.com/jupyter/notebook/pull/7480
Fixes https://github.com/jupyter/notebook/issues/6396
Fixes https://github.com/jupyter/notebook/issues/7287

- [x] Provide a custom plugin, remove the upstream plugin
- [x] Add to the changelog, with explanations on how to disable it

[filebrowser-settings-notebook-lab.webm](https://github.com/user-attachments/assets/35a9e35e-d54a-473b-a7b8-d6a891fb3c03)

