### PR TITLE
Rename some header links to fit better

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -172,7 +172,7 @@ html_theme = "pydata_sphinx_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "header_links_before_dropdown": 4,
+    "header_links_before_dropdown": 5,
     "icon_links": [
         {
             "name": "jupyter.org",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -172,6 +172,7 @@ html_theme = "pydata_sphinx_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
+    "header_links_before_dropdown": 4,
     "icon_links": [
         {
             "name": "jupyter.org",

--- a/docs/source/contributor.md
+++ b/docs/source/contributor.md
@@ -1,4 +1,4 @@
-# Contributor
+# Contributing
 
 ```{toctree}
 :caption: Contributor Documentation

--- a/docs/source/migrate_to_notebook7.md
+++ b/docs/source/migrate_to_notebook7.md
@@ -1,4 +1,4 @@
-# Migrating to Notebook 7
+# Migrating
 
 _Updated 2023-05-17_
 

--- a/docs/source/user-documentation.md
+++ b/docs/source/user-documentation.md
@@ -1,4 +1,4 @@
-# User Documentation
+# Documentation
 
 Use this page to navigate to different parts of the user documentation.
 


### PR DESCRIPTION
Small fix for #7495. 

This just shortens the titles used in the navbar so they fit better, and adds a dropdown menu after 4 items. . 

![docs](https://github.com/user-attachments/assets/a995f2c5-bab1-4099-bb32-c77b171391dc)
