### PR TITLE
Fix for auto scroll output option

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -439,6 +439,7 @@ const scrollOutput: JupyterFrontEndPlugin<void> = {
     const autoScroll = (cell: CodeCell) => {
       if (!autoScrollOutputs) {
         // bail if disabled via the settings
+        cell.removeClass(SCROLLED_OUTPUTS_CLASS);
         return;
       }
       const { outputArea } = cell;


### PR DESCRIPTION
Addresses #6443. 

![scroll_again](https://github.com/user-attachments/assets/94e4a226-a242-427e-b5ad-2b9d84526d69)
