### PR TITLE
Bump Python version used on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          architecture: 'x64'
           allow-prereleases: true
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         # used by the jupyterlab/maintainer-tools base-setup action
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,18 +121,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, windows-latest]
-        python: ['3.8', '3.11', '3.12']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ['3.9', '3.11', '3.13']
         include:
-          - python: '3.8'
+          - python: '3.9'
             dist: 'notebook*.tar.gz'
           - python: '3.11'
             dist: 'notebook*.whl'
-          - python: '3.12'
+          - python: '3.13'
             dist: 'notebook*.whl'
           - os: windows-latest
             py_cmd: python
-          - os: macos-12
+          - os: macos-latest
             py_cmd: python3
           - os: ubuntu-latest
             py_cmd: python

--- a/.github/workflows/buildutils.yml
+++ b/.github/workflows/buildutils.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
 
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
 dependencies = [
@@ -228,7 +228,7 @@ source = ["notebook"]
 
 [tool.mypy]
 files = "notebook"
-python_version = "3.8"
+python_version = "3.9"
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true


### PR DESCRIPTION
Update the Python version used on CI to the range 3.9 - 3.13.

Looking into fixing the failing checks noticed in https://github.com/jupyter/notebook/pull/7527.