### PR TITLE
Update workflow improvements

### DIFF
--- a/.github/workflows/upgrade-jupyterlab-dependencies.yml
+++ b/.github/workflows/upgrade-jupyterlab-dependencies.yml
@@ -15,6 +15,11 @@ on:
         default: main
         required: false
         type: string
+      target_repo:
+        description: 'Target repository'
+        required: false
+        default: jupyter/notebook
+        type: string
 
 env:
   version_tag: 'latest'
@@ -70,11 +75,14 @@ jobs:
           if [[ ! -z "$(git status --porcelain package.json)" ]]; then
             jlpm install
             jlpm deduplicate
+
+            cd ui-tests
+            jlpm install
           fi
 
       - name: Create a PR
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -eux
 
@@ -95,9 +103,18 @@ jobs:
               git commit . -m "Update to JupyterLab v${LATEST}"
 
               git push --set-upstream origin "${BRANCH_NAME}"
-              gh pr create \
-                --base ${{ inputs.branch || 'main' }} \
-                --title "Update to JupyterLab v${LATEST}" \
+
+              PR_ARGS=(
+                --base "${{ inputs.branch || 'main' }}"
+                --title "Update to JupyterLab v${LATEST}"
                 --body "New JupyterLab release [v${LATEST}](https://github.com/jupyterlab/jupyterlab/releases/tag/v${LATEST}) is available. Please review the lock file carefully."
+              )
+
+              # Add --repo flag only if target_repo is specified
+              if [[ -n "${{ inputs.target_repo }}" ]]; then
+                PR_ARGS+=(--repo "${{ inputs.target_repo }}")
+              fi
+
+              gh pr create "${PR_ARGS[@]}"
             fi
           fi

--- a/.github/workflows/upgrade-jupyterlab-dependencies.yml
+++ b/.github/workflows/upgrade-jupyterlab-dependencies.yml
@@ -73,11 +73,12 @@ jobs:
           echo "latest=${LATEST}" >> $GITHUB_ENV
           jlpm upgrade:lab:dependencies --set-version ${LATEST}
           if [[ ! -z "$(git status --porcelain package.json)" ]]; then
-            jlpm install
+            jlpm
             jlpm deduplicate
 
             cd ui-tests
-            jlpm install
+            jlpm
+            jlpm deduplicate
           fi
 
       - name: Create a PR

--- a/buildutils/src/upgrade-lab-dependencies.ts
+++ b/buildutils/src/upgrade-lab-dependencies.ts
@@ -97,7 +97,7 @@ async function updatePackageJson(newVersion: string): Promise<void> {
     const newDependencies = {
       ...newPackageJson.devDependencies,
       ...newPackageJson.resolutions,
-      '@jupyterlab/galata': galataPackageJson.version,
+      [galataPackageJson.name]: galataPackageJson.version,
     };
 
     updateDependencyVersion(existingPackageJson, newDependencies);

--- a/buildutils/src/upgrade-lab-dependencies.ts
+++ b/buildutils/src/upgrade-lab-dependencies.ts
@@ -17,6 +17,7 @@ const PACKAGE_JSON_PATHS: string[] = [
   'packages/tree-extension/package.json',
   'packages/tree/package.json',
   'packages/ui-components/package.json',
+  'ui-tests/package.json',
 ];
 
 const DEPENDENCY_GROUP = '@jupyterlab';
@@ -78,7 +79,16 @@ async function updatePackageJson(newVersion: string): Promise<void> {
     throw new Error(errorMessage);
   }
 
+  // fetch the new galata version
+  const galataUrl = `https://raw.githubusercontent.com/jupyterlab/jupyterlab/v${newVersion}/galata/package.json`;
+  const galataResponse = await fetch(galataUrl);
+  if (!galataResponse.ok) {
+    const errorMessage = `Failed to fetch galata/package.json from ${galataUrl}. HTTP status code: ${galataResponse.status}`;
+    throw new Error(errorMessage);
+  }
+
   const newPackageJson = await response.json();
+  const galataPackageJson = await galataResponse.json();
 
   for (const packageJsonPath of PACKAGE_JSON_PATHS) {
     const filePath: string = path.resolve(packageJsonPath);
@@ -87,6 +97,7 @@ async function updatePackageJson(newVersion: string): Promise<void> {
     const newDependencies = {
       ...newPackageJson.devDependencies,
       ...newPackageJson.resolutions,
+      '@jupyterlab/galata': galataPackageJson.version,
     };
 
     updateDependencyVersion(existingPackageJson, newDependencies);

--- a/ui-tests/package.json
+++ b/ui-tests/package.json
@@ -6,9 +6,9 @@
   "license": "BSD-3-Clause",
   "description": "Jupyter Notebook UI Tests",
   "scripts": {
+    "deduplicate": "jlpm dlx yarn-berry-deduplicate -s fewerHighest && jlpm install",
     "rimraf": "rimraf",
     "start": "jupyter notebook --config test/jupyter_server_config.py",
-    "start:detached": "yarn run start&",
     "test": "playwright test",
     "test:debug": "PWDEBUG=1 playwright test",
     "test:report": "http-server ./playwright-report -a localhost -o",


### PR DESCRIPTION
Fixes #7545 

- [x] Bump `@jupyterlab/galata`
- [x] (optional) Allow running with a personal token so CI is triggered automatically.