### PR TITLE
Fix undefined error when checkpoints is empty

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -124,7 +124,7 @@ const checkpoints: JupyterFrontEndPlugin<void> = {
       context?.fileChanged.connect(onChange);
 
       const checkpoints = await context?.listCheckpoints();
-      if (!checkpoints) {
+      if (!checkpoints || !checkpoints.length) {
         return;
       }
       const checkpoint = checkpoints[checkpoints.length - 1];


### PR DESCRIPTION
```python
      const checkpoints = await context?.listCheckpoints();       <== if checkpoints is an empty array
      if (!checkpoints) {                                         <== this will be false
        return;
      }
      const checkpoint = checkpoints[checkpoints.length - 1];     <== then checkpoint will be undefined
      node.textContent = trans.__(
        'Last Checkpoint: %1',
        Time.formatHuman(new Date(checkpoint.last_modified))      <== here will trigger an undefined error
      );
```

We found the problem while integrating jupyterlite with a FastAPI project.

