### PR TITLE
Allow owners/members/collab to trigger galata update on other's PR

### DIFF
--- a/.github/workflows/playwright-update.yml
+++ b/.github/workflows/playwright-update.yml
@@ -13,7 +13,10 @@ jobs:
       (
         github.event.issue.author_association == 'OWNER' ||
         github.event.issue.author_association == 'COLLABORATOR' ||
-        github.event.issue.author_association == 'MEMBER'
+        github.event.issue.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.comment.author_association == 'MEMBER'
       ) && github.event.issue.pull_request && (
         contains(github.event.comment.body, 'please update playwright snapshots') ||
         contains(github.event.comment.body, 'please update galata snapshots') ||


### PR DESCRIPTION
Mirrors:
- https://github.com/jupyterlab/jupyterlab/pull/16872
- https://github.com/jupyterlab/extension-template/pull/96

Noticed in https://github.com/jupyter/notebook/pull/7570 (but still does not explain why it happened as Andrii is a Member)