### PR TITLE
Improve handling of optional notebook tracker

### DIFF
--- a/packages/lab-extension/src/index.ts
+++ b/packages/lab-extension/src/index.ts
@@ -69,8 +69,9 @@ const interfaceSwitcher: JupyterFrontEndPlugin<void> = {
   id: '@jupyter-notebook/lab-extension:interface-switcher',
   description: 'A plugin to add custom toolbar items to the notebook page.',
   autoStart: true,
-  requires: [ITranslator, INotebookTracker],
+  requires: [ITranslator],
   optional: [
+    INotebookTracker,
     ICommandPalette,
     INotebookPathOpener,
     INotebookShell,
@@ -80,13 +81,18 @@ const interfaceSwitcher: JupyterFrontEndPlugin<void> = {
   activate: (
     app: JupyterFrontEnd,
     translator: ITranslator,
-    notebookTracker: INotebookTracker,
+    notebookTracker: INotebookTracker | null,
     palette: ICommandPalette | null,
     notebookPathOpener: INotebookPathOpener | null,
     notebookShell: INotebookShell | null,
     labShell: ILabShell | null,
     toolbarRegistry: IToolbarWidgetRegistry | null
   ) => {
+    if (!notebookTracker) {
+      // bail if trying to use this plugin without a notebook tracker
+      return;
+    }
+
     const { commands, shell } = app;
     const baseUrl = PageConfig.getBaseUrl();
     const trans = translator.load('notebook');


### PR DESCRIPTION
Make `INotebookTracker` optional, so it removes a bit of noise in the dev tools console when trying to load the lab extension (for the interface switcher) in an app which does not expose a notebook tracker.