### PR TITLE
fix: Update lower bound of required python to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "notebook"
 description = "Jupyter Notebook - A web-based notebook environment for interactive computing"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Jupyter Development Team", email = "jupyter@googlegroups.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,6 +267,7 @@ ignore = [
   "PLR",    # Design related pylint codes
   "C408", "C416",  # Unnecessary `dict` call (rewrite as a literal)
   "RUF012",   # Mutable class attributes should be annotated with `typing.ClassVar`
+  "UP006",  # non-pep585-annotation
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
Python 3.8 is no longer supported by notebook, so this lower bound needs to be changed.

```shell
$ pip3.8 index versions notebook
WARNING: pip index is currently an experimental command. It may be removed/changed in a future release without prior warning.
notebook (7.4.0)
```