### PR TITLE
chore: Fix UP006

### DIFF
--- a/notebook/app.py
+++ b/notebook/app.py
@@ -39,7 +39,7 @@ from ._version import __version__
 
 HERE = Path(__file__).parent.resolve()
 
-Flags = t.Dict[t.Union[str, t.Tuple[str, ...]], t.Tuple[t.Union[t.Dict[str, t.Any], Config], str]]
+Flags = dict[t.Union[str, tuple[str, ...]], tuple[t.Union[dict[str, t.Any], Config], str]]
 
 app_dir = Path(get_app_dir())
 version = __version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,7 +267,6 @@ ignore = [
   "PLR",    # Design related pylint codes
   "C408", "C416",  # Unnecessary `dict` call (rewrite as a literal)
   "RUF012",   # Mutable class attributes should be annotated with `typing.ClassVar`
-  "UP006",  # non-pep585-annotation
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
This is a follow-up PR for #7628 where UP006 was ignored temporarily.

It turns out there aren't many UP006 violations (I enabled `--unsafe-fixes` (https://docs.astral.sh/ruff/rules/non-pep585-annotation/) for `ruff` and ran `pre-commit run --all-files ruff`, which should apply to the whole code base IIUC).

@jtpio PTAL. Thanks.