### PR TITLE
Revert "CI: pin to `jupyter-core<5.8.0` on Windows"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,11 +157,6 @@ jobs:
         run: |
           ${{ matrix.py_cmd }} -m pip freeze
           ${{ matrix.py_cmd }} -m pip check
-      - name: Temporary pin for jupyter-core on Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          # See https://github.com/jupyter-server/jupyter_server/issues/1527
-          ${{ matrix.py_cmd }} -m pip install "jupyter-core<5.8.0"
       - name: Validate the install
         run: |
           jupyter labextension list


### PR DESCRIPTION
Reverts jupyter/notebook#7655

closes #7654 

this should hopefully verify that 5.8.1 fixes the issue