### PR TITLE
Define `O` as the keyboard shortcut to toggle cell outputs

### DIFF
--- a/packages/application-extension/schema/shortcuts.json
+++ b/packages/application-extension/schema/shortcuts.json
@@ -1,0 +1,16 @@
+{
+  "jupyter.lab.setting-icon": "notebook-ui-components:jupyter",
+  "jupyter.lab.setting-icon-label": "Jupyter Notebook shortcuts",
+  "title": "Jupyter Notebook Shortcuts",
+  "description": "Keyboard shortcuts for Jupyter Notebook",
+  "jupyter.lab.shortcuts": [
+    {
+      "args": {},
+      "command": "notebook:toggle-cell-outputs",
+      "keys": ["O"],
+      "selector": ".jp-Notebook.jp-mod-commandMode"
+    }
+  ],
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -997,6 +997,20 @@ const sidePanelVisibility: JupyterFrontEndPlugin<void> = {
 };
 
 /**
+ * A plugin for defining keyboard shortcuts specific to the notebook application.
+ */
+const shortcuts: JupyterFrontEndPlugin<void> = {
+  id: '@jupyter-notebook/application-extension:shortcuts',
+  description:
+    'A plugin for defining keyboard shortcuts specific to the notebook application.',
+  autoStart: true,
+  activate: (app: JupyterFrontEnd) => {
+    // for now this plugin is mostly useful for defining keyboard shortcuts
+    // specific to the notebook application
+  },
+};
+
+/**
  * The default tree route resolver plugin.
  */
 const tree: JupyterFrontEndPlugin<JupyterFrontEnd.ITreeResolver> = {
@@ -1175,6 +1189,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   rendermime,
   shell,
   sidePanelVisibility,
+  shortcuts,
   splash,
   status,
   tabTitle,

--- a/ui-tests/test/notebook.spec.ts
+++ b/ui-tests/test/notebook.spec.ts
@@ -223,4 +223,31 @@ test.describe('Notebook', () => {
 
     await expect(page.locator('.jp-LogConsole')).toBeVisible();
   });
+
+  test('Toggle cell outputs with the O keyboard shortcut', async ({
+    page,
+    tmpPath,
+  }) => {
+    const notebook = 'autoscroll.ipynb';
+    await page.contents.uploadFile(
+      path.resolve(__dirname, `./notebooks/${notebook}`),
+      `${tmpPath}/${notebook}`
+    );
+    await page.goto(`notebooks/${tmpPath}/${notebook}`);
+
+    await waitForKernelReady(page);
+
+    // run the two cells
+    await page.keyboard.press('Shift+Enter');
+    await page.keyboard.press('ControlOrMeta+Enter');
+
+    await page.keyboard.press('Escape');
+    await page.keyboard.press('O');
+
+    await page.waitForSelector('.jp-OutputPlaceholder', { state: 'visible' });
+
+    await page.keyboard.press('O');
+
+    await page.waitForSelector('.jp-OutputPlaceholder', { state: 'hidden' });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/7366

The shortcut can also be configured via the settings editor:

<img width="3140" height="1490" alt="image" src="https://github.com/user-attachments/assets/f6f5c428-c73d-4028-a376-0904d11f2e5a" />


https://github.com/user-attachments/assets/bd9ce548-d849-4dab-af3d-bec896fd58b4

