### PR TITLE
Increase the checkpoint polling interval to 30s

### DIFF
--- a/packages/notebook-extension/schema/checkpoints.json
+++ b/packages/notebook-extension/schema/checkpoints.json
@@ -4,7 +4,15 @@
   "jupyter.lab.toolbars": {
     "TopBar": [{ "name": "checkpoint", "rank": 20 }]
   },
-  "properties": {},
+  "properties": {
+    "checkpointPollingInterval": {
+      "type": "number",
+      "title": "Checkpoint Polling Interval (seconds)",
+      "description": "How often to check for checkpoints (in seconds). Set to 0 to disable polling.",
+      "default": 30,
+      "minimum": 0
+    }
+  },
   "additionalProperties": false,
   "type": "object"
 }


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/6995

Increase the checkpoint poll interval so there are fewer requests made to the server in order to get information about the new checkpoints.

The new value is also exposed as a setting so folks can tweak it, for example, as part of a deployment via an `overrides.json` file.

Also, add some logic to make sure that the checkpoint indicator is updated in the UI when the notebook is saved, so the UX is a little better than having to wait for the next poll tick to update the checkpoint indicator.

<img width="2446" height="634" alt="image" src="https://github.com/user-attachments/assets/2209df34-ca8e-4c31-a16e-0e2cc7e93898" />
