### PR TITLE
Fix for #7565 to move add cell button to the inner notebook area

### DIFF
--- a/packages/notebook-extension/style/base.css
+++ b/packages/notebook-extension/style/base.css
@@ -33,22 +33,37 @@ body[data-notebook='notebooks'] .jp-NotebookPanel-toolbar {
   padding-right: calc(calc(100% - var(--jp-notebook-max-width)) * 0.5);
 }
 
-body[data-notebook='notebooks'] .jp-WindowedPanel-outer {
-  width: unset !important;
-  padding-top: unset;
+body[data-notebook='notebooks'] .jp-WindowedPanel {
+  background: var(--jp-layout-color2);
   padding-left: calc(calc(100% - var(--jp-notebook-max-width)) * 0.5);
   padding-right: calc(
     calc(
-        100% - var(--jp-notebook-max-width) - var(--jp-notebook-padding-offset)
-      ) * 0.5
+    100% - var(--jp-notebook-max-width) - var(--jp-notebook-padding-offset)
+    ) * 0.5
   ) !important;
-  background: var(--jp-layout-color2);
+  padding-top: calc(1*var(--jp-notebook-padding-offset));
+  height: 100%;
+  overflow-y: auto;
+
+}
+
+body[data-notebook='notebooks'] .jp-WindowedPanel-outer {
+  width: unset !important;
+  height: fit-content;
+
+
+  background: var(--jp-layout-color0);
+  box-shadow: var(--jp-elevation-z4);
+
+  /* Extra padding at the top and bottom so the notebook looks nicer */
+  padding-top: calc(2 * var(--jp-notebook-padding));
+  padding-bottom: calc(2 * var(--jp-notebook-padding));
 }
 
 body[data-notebook='notebooks'] .jp-WindowedPanel-inner {
   margin-top: var(--jp-notebook-toolbar-margin-bottom);
   /* Adjustments for the extra top and bottom notebook padding */
-  margin-bottom: calc(4 * var(--jp-notebook-padding));
+  margin-bottom: calc(1.5 * var(--jp-notebook-padding));
 }
 
 body[data-notebook='notebooks'] .jp-Notebook-cell {
@@ -57,8 +72,7 @@ body[data-notebook='notebooks'] .jp-Notebook-cell {
 
 /* Empty space at the bottom of the notebook (similar to classic) */
 body[data-notebook='notebooks']
-  .jp-Notebook.jp-mod-scrollPastEnd
-  .jp-WindowedPanel-outer::after {
+  .jp-Notebook.jp-mod-scrollPastEnd {
   min-height: 100px;
 }
 
@@ -112,13 +126,17 @@ body[data-notebook='notebooks']
   body[data-notebook='notebooks'] .jp-RawCell .jp-cell-toolbar {
     top: calc(0.5 * var(--jp-notebook-padding));
   }
+
+  body[data-notebook='notebooks'] .jp-Notebook-footer {
+    width: calc(100vw - 43px);
+    margin-left: 28px;
+    margin-right: 15px;
+    margin-top: 10px;
+  }
 }
 
 /* Tweak the notebook footer (to add a new cell) */
 body[data-notebook='notebooks'] .jp-Notebook-footer {
-  background: unset;
-  width: 100%;
-  margin-left: unset;
 }
 
 /* Mobile View */
@@ -136,12 +154,7 @@ body[data-format='mobile'] .jp-ToolbarButton .jp-DebuggerBugButton {
 }
 
 body[data-notebook='notebooks'] .jp-WindowedPanel-viewport {
-  background: var(--jp-layout-color0);
-  box-shadow: var(--jp-elevation-z4);
 
-  /* Extra padding at the top and bottom so the notebook looks nicer */
-  padding-top: calc(2 * var(--jp-notebook-padding));
-  padding-bottom: calc(2 * var(--jp-notebook-padding));
 }
 
 /* Notebook box shadow */

--- a/packages/notebook-extension/style/base.css
+++ b/packages/notebook-extension/style/base.css
@@ -41,7 +41,7 @@ body[data-notebook='notebooks'] .jp-WindowedPanel {
     100% - var(--jp-notebook-max-width) - var(--jp-notebook-padding-offset)
     ) * 0.5
   ) !important;
-  padding-top: calc(1*var(--jp-notebook-padding-offset));
+  padding-top: var(--jp-notebook-padding-offset);
   height: 100%;
   overflow-y: auto;
 


### PR DESCRIPTION
In both desktop and mobile the add cell button design did not match JupyterLab's design for the add a cell button. This change adjusts the CSS to bring the button into the inner notebook area to harmonize the designs.

Addresses #7565

Original Mobile (on hover):
<img width="432" height="206" alt="image" src="https://github.com/user-attachments/assets/a87e3b67-24d6-47c0-8e85-53a221290d59" />
Original Desktop (on hover):
<img width="1238" height="138" alt="image" src="https://github.com/user-attachments/assets/e600f8a5-9579-4d14-8f98-c2bba6832d36" />

Modified Mobile (on hover):
<img width="734" height="195" alt="image" src="https://github.com/user-attachments/assets/829ac431-5cb0-4f43-938b-edccaa44086e" />
Modified Desktop (on hover):
<img width="1013" height="108" alt="image" src="https://github.com/user-attachments/assets/22a81152-1343-4bcd-a50c-1f5e9539c9ec" />

Button is not visible when not hovering:
<img width="1068" height="384" alt="image" src="https://github.com/user-attachments/assets/87a14948-3f40-4083-a934-9c3883df3a4b" />

