### PR TITLE
Add JupyterCon banner and add Jupyter colors

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -172,6 +172,7 @@ html_theme = "pydata_sphinx_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
+    "announcement": "🚀 Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href=\"https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463\">SCHEDULE</a> · <a href=\"https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463\">REGISTER NOW</a>",
     "header_links_before_dropdown": 5,
     "icon_links": [
         {
@@ -400,3 +401,6 @@ intersphinx_mapping = {
 
 spelling_lang = "en_US"
 spelling_word_list_filename = "spelling_wordlist.txt"
+
+def setup(app):
+    app.add_css_file("https://docs.jupyter.org/en/latest/_static/jupyter.css")


### PR DESCRIPTION
This PR does a couple of things:

- Adds an announcement banner for JupyterCon
- Links a CSS file from the Jupyter documentation that we can use for jupyter colors in our docs

