### PR TITLE
Revert "Pin `click<8.3`"

### DIFF
--- a/.github/actions/build-dist/action.yml
+++ b/.github/actions/build-dist/action.yml
@@ -1,7 +1,5 @@
 name: 'Build Jupyter Notebook'
-
 description: 'Build Jupyter Notebook from source'
-
 runs:
   using: 'composite'
   steps:
@@ -11,7 +9,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        python -m pip install hatch "click<8.3.0"
+        python -m pip install hatch
 
     - name: Build pypi distributions
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,6 @@ jobs:
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-      - name: Pin click to avoid 8.3.0 issues
-        run: pipx inject --force hatch "click<8.3.0"
-
       - name: Test the package
         run: hatch run cov:test
 
@@ -82,8 +79,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - name: Pin click to avoid 8.3.0 issues
-        run: pipx inject --force hatch "click<8.3.0"
       - run: |
           sudo apt-get update
           sudo apt install enchant-2  # for spelling
@@ -102,8 +97,6 @@ jobs:
         with:
           dependency_type: minimum
           python_version: '3.10'
-      - name: Pin click to avoid 8.3.0 issues
-        run: pipx inject --force hatch "click<8.3.0"
       - name: Run the unit tests
         run: |
           hatch run test:nowarn || hatch run test:nowarn --lf
@@ -117,8 +110,6 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           dependency_type: pre
-      - name: Pin click to avoid 8.3.0 issues
-        run: pipx inject --force hatch "click<8.3.0"
       - name: Run the tests
         run: |
           hatch run test:nowarn || hatch run test:nowarn --lf
@@ -181,8 +172,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - name: Pin click to avoid 8.3.0 issues
-        run: pipx inject --force hatch "click<8.3.0"
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
           ignore_links: 'https://playwright.dev/docs/test-cli/ https://blog.jupyter.org/the-big-split-9d7b88a031a7 https://blog.jupyter.org/jupyter-ascending-1bf5b362d97e https://mybinder.org/v2/gh/jupyter/notebook/main https://nbviewer.jupyter.org https://stackoverflow.com https://github.com/[^/]+/?$'
@@ -194,8 +183,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - name: Pin click to avoid 8.3.0 issues
-        run: pipx inject --force hatch "click<8.3.0"
       - name: Run Linters
         run: |
           hatch run typing:test

--- a/.github/workflows/buildutils.yml
+++ b/.github/workflows/buildutils.yml
@@ -16,7 +16,6 @@ concurrency:
 permissions:
   contents: read
 
-
 jobs:
   versioning:
     runs-on: ubuntu-latest
@@ -28,12 +27,9 @@ jobs:
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-      - name: Pin click to avoid 8.3.0 issues
-        run: pipx inject --force hatch "click<8.3.0"
-
       - name: Install dependencies
         run: |
-          python -m pip install -U "jupyterlab>=4.5.0a0,<4.6"
+          python -m pip install -U "jupyterlab>=4.5.0a0,<4.6" hatch
           jlpm
           jlpm run build
 

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -11,7 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
-
 jobs:
   check_release:
     runs-on: ubuntu-latest
@@ -19,13 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-
-      - name: Pin click to avoid 8.3.0 issues
-        run: pipx inject --force hatch "click<8.3.0"
-
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:

--- a/.github/workflows/playwright-update.yml
+++ b/.github/workflows/playwright-update.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
 
-
 jobs:
   update-snapshots:
     if: >
@@ -83,9 +82,6 @@ jobs:
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-
-      - name: Pin click to avoid 8.3.0 issues
-        run: pipx inject --force hatch "click<8.3.0"
 
       - name: Build
         uses: ./.github/actions/build-dist

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -23,8 +23,6 @@ on:
         description: "Use PRs with activity since the last stable git tag"
         required: false
         type: boolean
-
-
 jobs:
   prep_release:
     runs-on: ubuntu-latest
@@ -32,9 +30,6 @@ jobs:
       contents: write
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-
-      - name: Pin click to avoid 8.3.0 issues
-        run: pipx inject --force hatch "click<8.3.0"
 
       - name: Prep Release
         id: prep-release

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -9,16 +9,12 @@ on:
         description: "The branch to target"
         required: false
 
-
 jobs:
   publish_changelog:
     runs-on: ubuntu-latest
     environment: release
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-
-      - name: Pin click to avoid 8.3.0 issues
-        run: pipx inject --force hatch "click<8.3.0"
 
       - uses: actions/create-github-app-token@v2
         id: app-token

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,7 +12,6 @@ on:
         description: "Comma separated list of steps to skip"
         required: false
 
-
 jobs:
   publish_release:
     runs-on: ubuntu-latest
@@ -21,12 +20,6 @@ jobs:
       id-token: write
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-
-      - name: Install jupyter-releaser
-        run: pipx install jupyter-releaser
-
-      - name: Pin click to avoid 8.3.0 issues
-        run: pipx inject --force hatch "click<8.3.0"
 
       - uses: actions/create-github-app-token@v2
         id: app-token

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -12,7 +12,6 @@ concurrency:
 permissions:
   contents: read
 
-
 jobs:
   build:
     name: Build
@@ -39,9 +38,6 @@ jobs:
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-
-      - name: Pin click to avoid 8.3.0 issues
-        run: pipx inject --force hatch "click<8.3.0"
 
       - uses: actions/download-artifact@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     "hatchling>=1.11",
     "jupyterlab>=4.5.0a3,<4.6",
-    "click<8.3.0",
 ]
 build-backend = "hatchling.build"
 
@@ -64,7 +63,6 @@ test = [
     "jupyter_server[test]>=2.4.0,<3",
     "jupyterlab_server[test]>=2.27.1,<3",
     "importlib-resources>=5.0;python_version<\"3.10\"",
-    "click<8.3.0",
 ]
 docs = [
     "myst_parser",
@@ -76,8 +74,7 @@ docs = [
 ]
 dev = [
     "pre-commit",
-    "hatch",
-    "click<8.3.0",
+    "hatch"
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
Reverts jupyter/notebook#7729

This should now be fixed by: https://github.com/pypa/hatch/releases/tag/hatch-v1.14.2