### PR TITLE
Update JupyterCon 2025 announcement links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -172,7 +172,7 @@ html_theme = "pydata_sphinx_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "announcement": '🚀 Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href="https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463">SCHEDULE</a> · <a href="https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463">REGISTER NOW</a>',
+    "announcement": '🚀 Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href="https://events.linuxfoundation.org/jupytercon/program/schedule/">SCHEDULE</a> · <a href="https://events.linuxfoundation.org/jupytercon/register/">REGISTER NOW</a>',
     "header_links_before_dropdown": 5,
     "icon_links": [
         {


### PR DESCRIPTION
- Mirrors https://github.com/jupyter/jupyter.github.io/pull/824
- Follow-up to https://github.com/jupyter/notebook/pull/7727