### PR TITLE
Use Node.js 24 / npm 11 to publish releases

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
-          node_version: '24.x'
+          node_version: '24'
 
       - uses: actions/create-github-app-token@v2
         id: app-token


### PR DESCRIPTION
Temporary use node 24 here until the npm 11 issue in the jupyter releaser is fixed and released: https://github.com/jupyter-server/jupyter_releaser/issues/617

To be able to try https://github.com/jupyter/notebook/issues/7745