### PR TITLE
Expose the cell toolbar settings

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -319,6 +319,7 @@
         "@jupyterlab/video-extension": true
       },
       "/tree": {
+        "@jupyterlab/cell-toolbar-extension": true,
         "@jupyterlab/extensionmanager-extension": true,
         "@jupyterlab/filebrowser-extension": [
           "@jupyterlab/filebrowser-extension:browser",

--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -280,20 +280,22 @@ const loadPlugins: JupyterFrontEndPlugin<void> = {
 
     app.restored.then(async () => {
       const plugins = await connector.list('all');
-      plugins.ids.forEach(async (id: string) => {
-        const [extension] = id.split(':');
-        // load the plugin if it is built-in the notebook application explicitly
-        // either included as an extension or as a plugin directly
-        const hasPlugin = pluginsSet.has(extension) || pluginsSet.has(id);
-        if (!hasPlugin || isDisabled(id) || id in settingRegistry.plugins) {
-          return;
-        }
-        try {
-          await settingRegistry.load(id);
-        } catch (error) {
-          console.warn(`Settings failed to load for (${id})`, error);
-        }
-      });
+      await Promise.all(
+        plugins.ids.map(async (id: string) => {
+          const [extension] = id.split(':');
+          // load the plugin if it is built-in the notebook application explicitly
+          // either included as an extension or as a plugin directly
+          const hasPlugin = pluginsSet.has(extension) || pluginsSet.has(id);
+          if (!hasPlugin || isDisabled(id) || id in settingRegistry.plugins) {
+            return;
+          }
+          try {
+            await settingRegistry.load(id);
+          } catch (error) {
+            console.warn(`Settings failed to load for (${id})`, error);
+          }
+        })
+      );
     });
   },
 };


### PR DESCRIPTION
Fixed https://github.com/jupyter/notebook/issues/6486

That way, user can more easily add new buttons to the cell toolbar, for example the button to run a cell:

<img width="1462" height="1804" alt="image" src="https://github.com/user-attachments/assets/3adaaf2d-d1fe-4f26-b7ad-4520148aa2ab" />

<img width="820" height="400" alt="image" src="https://github.com/user-attachments/assets/3a24eac7-bb7a-4034-8e55-9005e37105da" />

