### PR TITLE
Fix selector for the `O` keyboard shortcut

### DIFF
--- a/packages/application-extension/schema/shortcuts.json
+++ b/packages/application-extension/schema/shortcuts.json
@@ -8,7 +8,7 @@
       "args": {},
       "command": "notebook:toggle-cell-outputs",
       "keys": ["O"],
-      "selector": ".jp-Notebook.jp-mod-commandMode"
+      "selector": ".jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus"
     }
   ],
   "additionalProperties": false,


### PR DESCRIPTION
Fixes https://github.com/jupyter/notebook/issues/7781

Align the selector with what JupyterLab uses: https://github.com/jupyterlab/jupyterlab/blob/3774ec05ef89e55c55d9c3ca3a564a26e01f2df8/packages/notebook-extension/schema/tracker.json#L375-L378

**Before**

https://github.com/user-attachments/assets/058cbc8e-a446-47f1-b680-fa3173aa8771


**After**


https://github.com/user-attachments/assets/5ba40956-b718-4453-9004-06dadbc8eb11

