### PR TITLE
Fix broken image path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 The Jupyter notebook is a web-based notebook environment for interactive
 computing.
 
-![Jupyter notebook example](docs/resources/running_code_med.png 'Jupyter notebook example')
+![Jupyter notebook example](notebook/docs/resources/running_code_med.png 'Jupyter notebook example')
 
 ## Maintained versions
 


### PR DESCRIPTION
- Fixes broken image in README caused by incorrect path (`docs/` → `notebook/docs/`)
- Image now renders correctly on GitHub
- No issue required for small doc fixes