### PR TITLE
docs: Fix broken links in troubleshooting and migration docs

### DIFF
--- a/docs/source/migrate_to_notebook7.md
+++ b/docs/source/migrate_to_notebook7.md
@@ -56,7 +56,7 @@ continue developing the Jupyter Notebook application and _sunrise_ it as
 Notebook 7.
 
 You can find more details about the changes currently taking place in the
-Jupyter Ecosystem in the [JEP 79] and [team-compass note].
+Jupyter Ecosystem in the [JEP 79][jep 79] and [team-compass note].
 
 ## New features in Notebook 7
 

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -213,7 +213,7 @@ If you can't find an existing answer, you can ask questions at:
 
   > - [jupyter_core](https://github.com/jupyter/jupyter_core) - `secure_write()`
   >   and file path issues
-  > - [jupyter_client](https://github.com/jupyter/jupyter_core) - kernel management
+  > - [jupyter_client](https://github.com/jupyter/jupyter_client) - kernel management
   >   issues found in Notebook server's command window.
   > - [IPython](https://github.com/ipython/ipython) and
   >   [ipykernel](https://github.com/ipython/ipykernel) - kernel runtime issues


### PR DESCRIPTION
This PR fixes two broken documentation links:

1. troubleshooting.md: The jupyter_client link was incorrectly pointing to jupyter/jupyter_core instead of jupyter/jupyter_client

2. migrate_to_notebook7.md: The [JEP 79] reference was missing the link reference, causing a broken link (Markdown reference links are case-sensitive)

These are minor documentation fixes that improve the user experience when navigating the docs.