### PR TITLE
Fixed the outdated command in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3749,7 +3749,7 @@ enabled by default. A token is generated and used when your browser is
 opened automatically, so you shouldn't have to enter anything in the
 default circumstances. If you see a login page (e.g. by switching
 browsers, or launching on a new port with `--no-browser`), you get a
-login URL with the token from the command `jupyter notebook list`, which
+login URL with the token from the command `jupyter server list`, which
 you can paste into your browser.
 
 Highlights:


### PR DESCRIPTION
<!--
Thanks for contributing to Jupyter Notebook!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyter/notebook/blob/main/CONTRIBUTING.md
-->

## References

Related PR with wrong file changed - #7756 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Changed ```jupyter notebook list``` to ```jupyter server list```