### PR TITLE
[7.5.x] Drop Python 3.9 on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         # used by the jupyterlab/maintainer-tools base-setup action
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -125,9 +125,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.9', '3.11', '3.13']
+        python: ['3.10', '3.11', '3.13']
         include:
-          - python: '3.9'
+          - python: '3.10'
             dist: 'notebook*.tar.gz'
           - python: '3.11'
             dist: 'notebook*.whl'


### PR DESCRIPTION

## References

This should hopefully help fix the hatch related CI failure on that branch.

## Code changes


## User-facing changes

None

## Backwards-incompatible changes

None (just CI workflows)