### PR TITLE
fix(application): anchor opener route regex for tree paths

### DIFF
--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -73,7 +73,7 @@ import { Menu, Widget } from '@lumino/widgets';
 /**
  * A regular expression to match path to notebooks and documents
  */
-const TREE_PATTERN = new RegExp('/(notebooks|edit)/(.*)');
+const TREE_PATTERN = new RegExp('^/(notebooks|edit)/(.*)$');
 
 /**
  * A regular expression to suppress the file extension from display for .ipynb files.

--- a/ui-tests/test/tree.spec.ts
+++ b/ui-tests/test/tree.spec.ts
@@ -53,6 +53,28 @@ test('Should redirect from notebooks route to tree route for directories', async
   expect(url.pathname).toEqual(`/tree/${dir}`);
 });
 
+test('should not show a file load error when path contains notebooks', async ({
+  page,
+  tmpPath,
+}) => {
+  const nestedPath = `${tmpPath}/test/notebooks/test`;
+  await page.contents.createDirectory(`${tmpPath}/test`);
+  await page.contents.createDirectory(`${tmpPath}/test/notebooks`);
+  await page.contents.createDirectory(nestedPath);
+
+  await page.goto(`tree/${nestedPath}`);
+  await page.waitForSelector('.jp-FileBrowser-crumbs >> text=/test/');
+  await page.waitForSelector('.jp-FileBrowser-crumbs >> text=/notebooks/');
+  expect(new URL(page.url()).pathname).toEqual(`/tree/${nestedPath}`);
+
+  await page.reload({ waitUntil: 'networkidle' });
+  await page.waitForSelector('.jp-FileBrowser-crumbs >> text=/test/');
+  await page.waitForSelector('.jp-FileBrowser-crumbs >> text=/notebooks/');
+  expect(new URL(page.url()).pathname).toEqual(`/tree/${nestedPath}`);
+
+  await expect(page.locator('text=File Load Error')).toHaveCount(0);
+});
+
 test('Should activate file browser tab', async ({ page, tmpPath }) => {
   await page.goto(`tree/${tmpPath}`);
   await page.locator('.jp-TreePanel >> text="Running"').click();


### PR DESCRIPTION
## References

Fixes #7216

## Code changes

- Anchor the opener route regex in the application extension so it only matches true notebook/editor routes:
  - from `/(notebooks|edit)/(.*)`
  - to `^/(notebooks|edit)/(.*)$`
- Add a UI regression test in `ui-tests/test/tree.spec.ts` covering tree navigation/reload when the path contains a directory literally named `notebooks`.

## Problem / root cause

Tree URLs such as `/tree/test/notebooks/test` were being incorrectly matched by the opener route regex because it was not anchored. That caused the router to treat part of a tree URL as a notebook route and attempt to open a file, leading to `File Load Error: Invalid response: 404 Not Found`.

## Solution

Use an anchored regex so the opener only handles paths that begin with `/notebooks/` or `/edit/`.

## User-facing changes

Users can navigate and refresh tree paths containing directories named `notebooks` without spurious file load errors.

## Backwards-incompatible changes

None.
