### PR TITLE
Add UI test for notebooks-to-tree redirect on directories

### DIFF
--- a/ui-tests/test/tree.spec.ts
+++ b/ui-tests/test/tree.spec.ts
@@ -37,6 +37,22 @@ test('should update url when navigating in filebrowser', async ({
   expect(url.pathname).toEqual(`/tree/${tmpPath}/${SUBFOLDER}`);
 });
 
+test('Should redirect from notebooks route to tree route for directories', async ({
+  page,
+  tmpPath,
+}) => {
+  const dir = `${tmpPath}/${SUBFOLDER}`;
+  await page.contents.createDirectory(dir);
+
+  // Navigate to the directory via the /notebooks/ route
+  await page.goto(`notebooks/${dir}`);
+
+  // Should redirect to /tree/ since the path is a directory
+  await page.waitForURL(`**/tree/${dir}`);
+  const url = new URL(page.url());
+  expect(url.pathname).toEqual(`/tree/${dir}`);
+});
+
 test('Should activate file browser tab', async ({ page, tmpPath }) => {
   await page.goto(`tree/${tmpPath}`);
   await page.locator('.jp-TreePanel >> text="Running"').click();


### PR DESCRIPTION
## References
#7454

## Code changes
Adds a Playwright test that navigates to `/notebooks/<directory>/` and verifies the URL redirects to `/tree/<directory>/`.

## User-facing changes
None - this is a test.

## Backwards-incompatible changes
None.