### PR TITLE
Add UI test verifying no cell toolbar in file editor

### DIFF
--- a/ui-tests/test/editor.spec.ts
+++ b/ui-tests/test/editor.spec.ts
@@ -32,6 +32,17 @@ test.describe('Editor', () => {
     );
   });
 
+  test('Should not render cell toolbar in file editor', async ({
+    page,
+    tmpPath,
+  }) => {
+    const file = `${tmpPath}/${FILE}`;
+    await page.goto(`edit/${file}`);
+
+    await expect(page.locator('.cm-editor')).toBeVisible();
+    await expect(page.locator('.jp-cell-toolbar')).toHaveCount(0);
+  });
+
   test('Renaming the file by clicking on the title', async ({
     page,
     tmpPath,


### PR DESCRIPTION
## References
#6322 (checklist item: "check micro toolbars are not rendered for terminals and files")

## Code changes
Adds a Playwright test that opens a file in the text editor and asserts that no `.jp-cell-toolbar` element is rendered.

## User-facing changes
None - this is a test.

## Backwards-incompatible changes
None.