### PR TITLE
Remove obsolete datetime warning filters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,8 +211,6 @@ filterwarnings = [
     "ignore:There is no current event loop:DeprecationWarning",
     "ignore:make_current is deprecated; start the event loop first",
     "ignore:clear_current is deprecated",
-    "ignore:datetime.utc.* is deprecated",
-    "ignore:datetime.datetime.* is deprecated",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
## References

Fixes #7017

## Code changes

- Remove the pytest warning filters for the old `datetime.utc*` deprecation warning.
- Leave the remaining event-loop related filters unchanged.

## User-facing changes

None.

## Backwards-incompatible changes

None.

## Validation

- `git diff --check HEAD~1..HEAD`
- `rg -n "datetime\.utc\.|datetime\.datetime\.\* is deprecated|utcnow|utcfromtimestamp" pyproject.toml notebook tests -S` (no matches)
- Not run locally
