### PR TITLE
Pin Node to 22.x in UI tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -38,6 +38,11 @@ jobs:
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          # Pin Node to 22.x: `jlpm playwright install` hangs during browser
+          # extraction on Node >=24.16 when using Playwright <1.60 (this branch
+          # is on @playwright/test ~1.57). See microsoft/playwright#40747.
+          node_version: '22.x'
 
       - uses: actions/download-artifact@v6
         with:


### PR DESCRIPTION
<!--
Thanks for contributing to Jupyter Notebook!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyter/notebook/blob/main/CONTRIBUTING.md
-->

## References

Troubleshooting timeouts on CI.

It's probably fine to just do the pin here on that branch since 7.5.x will soon not be supported anymore, or at least after the node 22 version is end of life.

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
