### PR TITLE
Add top-level permissions blocks to release workflows

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -23,6 +23,10 @@ on:
         description: "Use PRs with activity since the last stable git tag"
         required: false
         type: boolean
+
+permissions:
+  contents: read
+
 jobs:
   prep_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -9,10 +9,15 @@ on:
         description: "The branch to target"
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   publish_changelog:
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: read
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@95d85449e4f3f352e261221f6529f8ed307f5728 # v1
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,6 +12,9 @@ on:
         description: "Comma separated list of steps to skip"
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   publish_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The three release workflows (`prep-release`, `publish-release`, `publish-changelog`) had no top-level `permissions` block, so jobs inherited the broad workflow default. Adds an explicit `permissions: contents: read` at the top of each (least-privilege default). `publish-changelog` also gets a matching job-level read since the actual write goes through the GitHub App token, not `GITHUB_TOKEN`.

Improves the OpenSSF Scorecard `Token-Permissions` check, currently 0/10:
https://scorecard.dev/viewer/?uri=github.com%2Fjupyter%2Fnotebook

Refs #7941

