### PR TITLE
ci: add explicit permissions to release workflows

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -23,6 +23,10 @@ on:
         description: "Use PRs with activity since the last stable git tag"
         required: false
         type: boolean
+
+permissions:
+    contents: read
+
 jobs:
   prep_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -9,6 +9,10 @@ on:
         description: "The branch to target"
         required: false
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   publish_changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,6 +12,9 @@ on:
         description: "Comma separated list of steps to skip"
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   publish_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds explicit top-level `permissions: contents: read` to three release
workflows that were missing permissions blocks entirely:

- prep-release.yml
- publish-changelog.yml  
- publish-release.yml

Job-level write permissions are preserved where needed (contents: write
in prep-release, id-token: write in publish-release).

## Why

Without explicit permissions, GitHub Actions defaults the GITHUB_TOKEN
to read-write, which is broader than needed. This is flagged as
Token-Permissions (0/10) in the OpenSSF Scorecard.

Relates to #7941