### PR TITLE
Fix missing filebrowser features

### DIFF
--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -189,11 +189,15 @@ const fileBrowserSettings: JupyterFrontEndPlugin<void> = {
       navigateToCurrentDirectory: false,
       singleClickNavigation: true,
       showLastModifiedColumn: true,
+      showDateCreatedColumn: false,
       showFileSizeColumn: true,
       showHiddenFiles: false,
       showFileCheckboxes: true,
       sortNotebooksFirst: true,
+      sortFileNamesNaturally: true,
       showFullPath: false,
+      clearFilterOnNavigation: true,
+      allowFileUploads: true,
     };
 
     // Apply defaults on plugin activation

--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -203,7 +203,12 @@ const fileBrowserSettings: JupyterFrontEndPlugin<void> = {
     // Apply defaults on plugin activation
     let key: keyof typeof defaultFileBrowserConfig;
     for (key in defaultFileBrowserConfig) {
-      browser[key] = defaultFileBrowserConfig[key];
+      const value = defaultFileBrowserConfig[key];
+      // only set the value if it is different, since some setters trigger
+      // a relayout of the file browser
+      if (browser[key] !== value) {
+        browser[key] = value;
+      }
     }
 
     if (settingRegistry) {
@@ -212,8 +217,9 @@ const fileBrowserSettings: JupyterFrontEndPlugin<void> = {
           let key: keyof typeof defaultFileBrowserConfig;
           for (key in defaultFileBrowserConfig) {
             const value = settings.get(key).user as boolean;
-            // only set the setting if it is defined by the user
-            if (value !== undefined) {
+            // only set the setting if it is defined by the user and different,
+            // since some setters trigger a relayout of the file browser
+            if (value !== undefined && browser[key] !== value) {
               browser[key] = value;
             }
           }

--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -211,6 +211,11 @@ const fileBrowserSettings: JupyterFrontEndPlugin<void> = {
       }
     }
 
+    // Refresh the file browser after applying the defaults, which also
+    // resets the refresh poll in case an earlier tick failed and left it
+    // backing off
+    void browser.model.refresh();
+
     if (settingRegistry) {
       void settingRegistry.load(FILE_BROWSER_PLUGIN_ID).then((settings) => {
         function onSettingsChanged(settings: ISettingRegistry.ISettings): void {

--- a/ui-tests/test/filebrowser.spec.ts
+++ b/ui-tests/test/filebrowser.spec.ts
@@ -3,7 +3,7 @@
 
 import path from 'path';
 
-import { expect } from '@jupyterlab/galata';
+import { expect, galata } from '@jupyterlab/galata';
 
 import { test } from './fixtures';
 
@@ -82,5 +82,39 @@ test.describe('File Browser', () => {
 
     await nb2.waitForLoadState();
     await nb2.close();
+  });
+
+  test('Toggle the Date Created column from the header context menu', async ({
+    page,
+  }) => {
+    await page.filebrowser.refresh();
+
+    const header = page.locator('.jp-DirListing-header');
+    await expect(header.getByText('Date Created')).toBeHidden();
+
+    await header.click({ button: 'right' });
+    await page.getByText('Show Date Created Column').click();
+
+    await expect(header.getByText('Date Created')).toBeVisible();
+  });
+});
+
+test.describe('File Browser settings', () => {
+  test.use({
+    mockSettings: {
+      ...galata.DEFAULT_SETTINGS,
+      '@jupyterlab/filebrowser-extension:browser': {
+        showDateCreatedColumn: true,
+      },
+    },
+  });
+
+  test('Should show the Date Created column when enabled in the settings', async ({
+    page,
+  }) => {
+    await page.filebrowser.refresh();
+
+    const header = page.locator('.jp-DirListing-header');
+    await expect(header.getByText('Date Created')).toBeVisible();
   });
 });

--- a/ui-tests/test/filebrowser.spec.ts
+++ b/ui-tests/test/filebrowser.spec.ts
@@ -90,12 +90,13 @@ test.describe('File Browser', () => {
     await page.filebrowser.refresh();
 
     const header = page.locator('.jp-DirListing-header');
-    await expect(header.getByText('Date Created')).toBeHidden();
+    const dateCreatedColumn = header.locator('.jp-id-created');
+    await expect(dateCreatedColumn).toBeHidden();
 
     await header.click({ button: 'right' });
     await page.getByText('Show Date Created Column').click();
 
-    await expect(header.getByText('Date Created')).toBeVisible();
+    await expect(dateCreatedColumn).toBeVisible();
   });
 });
 
@@ -115,6 +116,6 @@ test.describe('File Browser settings', () => {
     await page.filebrowser.refresh();
 
     const header = page.locator('.jp-DirListing-header');
-    await expect(header.getByText('Date Created')).toBeVisible();
+    await expect(header.locator('.jp-id-created')).toBeVisible();
   });
 });


### PR DESCRIPTION

## References


As noticed when going through the changelog


## Code changes



## User-facing changes

Expose the features that were added in JupyterLab:

- Open in Terminal
- Show the Created date

## Backwards-incompatible changes

None
