### PR TITLE
Remove Python 3.15 pin on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,9 +118,6 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@95d85449e4f3f352e261221f6529f8ed307f5728 # v1
         with:
           dependency_type: pre
-          # TODO: Remove this pin once rpds-py supports Python 3.15.
-          # Upstream: https://github.com/crate-py/rpds/issues/210
-          python_version: '3.14'
       - name: Run the tests
         run: |
           hatch run test:nowarn || hatch run test:nowarn --lf


### PR DESCRIPTION


## References

Fixes https://github.com/jupyter/notebook/issues/7838

## Code changes

CI maintenance

## User-facing changes

None

## Backwards-incompatible changes

None