### PR TITLE
Remove stale plugin references from the plugin lists

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -231,8 +231,7 @@
           "@jupyterlab/application-extension:context-menu",
           "@jupyterlab/application-extension:faviconbusy",
           "@jupyterlab/application-extension:router",
-          "@jupyterlab/application-extension:top-bar",
-          "@jupyterlab/application-extension:top-spacer"
+          "@jupyterlab/application-extension:top-bar"
         ],
         "@jupyterlab/apputils-extension": [
           "@jupyterlab/apputils-extension:kernels-settings",
@@ -325,7 +324,6 @@
           "@jupyterlab/filebrowser-extension:download",
           "@jupyterlab/filebrowser-extension:file-upload-status",
           "@jupyterlab/filebrowser-extension:open-with",
-          "@jupyterlab/filebrowser-extension:search",
           "@jupyterlab/filebrowser-extension:share-file"
         ],
         "@jupyter-notebook/tree-extension": true,


### PR DESCRIPTION
Remove two plugin IDs from the per-page plugin lists in `app/package.json` that do not exist in JupyterLab:

- `@jupyterlab/application-extension:top-spacer` (listed for `/`)
- `@jupyterlab/filebrowser-extension:search` (listed for `/tree`)
