### PR TITLE
Add documentation for assigning shortcuts to commands without defaults

### DIFF
--- a/docs/source/configuring/interface_customization.md
+++ b/docs/source/configuring/interface_customization.md
@@ -50,6 +50,46 @@ Refer to the [JupyterLab Layout Documentation](https://jupyterlab.readthedocs.io
 to learn more about the default positioning of other UI elements.
 ```
 
+
+## Keyboard shortcuts
+
+### Assigning a shortcut to a command without a default
+
+Not every command has a default keyboard shortcut. For example, **New Console
+for Notebook** (available from a notebook's right-click menu) has no shortcut
+assigned out of the box, but you can add one yourself in either of two ways.
+
+The quickest way is the add-shortcut tool in the Keyboard Shortcuts settings:
+click the **+** button in the toolbar at the top of the shortcuts list, search
+for the command by name, and press the key combination you want to assign.
+Conflicts with existing shortcuts are flagged as you type so you can adjust
+your choice.
+
+Alternatively, you can define the keybinding in JSON using the Advanced
+Settings Editor, which is convenient when you want to copy settings between
+installations. Add an entry that pairs the command's id with the keys you want:
+
+```json
+{
+  "shortcuts": [
+    {
+      "command": "notebook:create-console",
+      "keys": ["Accel Shift J"],
+      "selector": ".jp-Notebook.jp-mod-commandMode"
+    }
+  ]
+}
+```
+
+With this setting, pressing {kbd}`Ctrl+Shift+J` ({kbd}`Cmd+Shift+J` on macOS)
+while a notebook is focused in command mode opens a console attached to it.
+`Accel` maps to {kbd}`Cmd` on macOS and {kbd}`Ctrl` on other platforms.
+
+To find a command's id, browse the {ref}`command list <commands>` or the
+existing entries in the Keyboard Shortcuts settings. When editing the JSON
+directly, choose a key combination that is not already bound in the same
+context.
+
 ## Toolbars, Menu bar and Context Menu
 
 It is also possible to customize toolbars, menus and context menu entries via the Settings Editor.


### PR DESCRIPTION
Summary
This PR adds documentation explaining how to assign keyboard shortcuts to commands that do not have a default shortcut in Notebook.

Changes
- Added a new section to the interface customization docs
- Documented both methods for assigning a shortcut:
   * using the Keyboard Shortcuts settings UI
   * using the Advanced Settings Editor with JSON
- Included an example for creating a shortcut for the notebook console command

Related issues
- Fixes #7049
- Closes #4583

Why
This improves discoverability for users who want to customize keyboard shortcuts for commands that are available but do not ship with a default binding.