### PR TITLE
Fix `dependabot` PRs: auto-regenerate yarn.lock and group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
     open-pull-requests-limit: 10
     versioning-strategy: increase
     cooldown:
-      default-days: 3
+      default-days: 7
     groups:
       babel:
         patterns:
@@ -52,7 +52,7 @@ updates:
       interval: 'weekly'
     open-pull-requests-limit: 5
     cooldown:
-      default-days: 3
+      default-days: 7
     groups:
       ui-tests-deps:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,44 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+    versioning-strategy: increase
+    groups:
+      babel:
+        patterns:
+          - '@babel/*'
+      jupyterlab:
+        patterns:
+          - '@jupyterlab/*'
+          - '@lumino/*'
+      typescript:
+        patterns:
+          - 'typescript'
+          - '@types/*'
+          - 'ts-*'
+      lint-and-format:
+        patterns:
+          - 'eslint*'
+          - '@typescript-eslint/*'
+          - 'prettier*'
+          - 'stylelint*'
+      dev-dependencies:
+        dependency-type: 'development'
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  - package-ecosystem: 'npm'
+    directory: '/ui-tests'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    groups:
+      ui-tests-deps:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
       interval: 'weekly'
     open-pull-requests-limit: 10
     versioning-strategy: increase
+    cooldown:
+      default-days: 3
     groups:
       babel:
         patterns:
@@ -49,6 +51,8 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
     groups:
       ui-tests-deps:
         patterns:

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,7 +1,7 @@
 name: Dependabot lockfile fix
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
 
 permissions:
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   fix-lockfile:
     if: >-
-      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
       startsWith(github.head_ref, 'dependabot/npm_and_yarn/')
     runs-on: ubuntu-latest
 
@@ -26,10 +26,9 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.DEPENDABOT_LOCKFILE_TOKEN || secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -47,12 +46,15 @@ jobs:
         run: yarn install --mode=update-lockfile
 
       - name: Commit and push if changed
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if [[ -n "$(git status --porcelain)" ]]; then
             git add yarn.lock ui-tests/yarn.lock
             git commit -m "Regenerate yarn.lock [dependabot skip]"
+            git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
             git push
           else
             echo "Lockfiles already in sync — nothing to do."

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,0 +1,59 @@
+name: Dependabot lockfile fix
+
+on:
+  pull_request_target:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dependabot-lockfile-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  fix-lockfile:
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      startsWith(github.head_ref, 'dependabot/npm_and_yarn/')
+    runs-on: ubuntu-latest
+
+    env:
+      YARN_ENABLE_SCRIPTS: 'false'
+      YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.DEPENDABOT_LOCKFILE_TOKEN || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '20.x'
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Regenerate root yarn.lock
+        run: yarn install --mode=update-lockfile
+
+      - name: Regenerate ui-tests yarn.lock
+        working-directory: ui-tests
+        run: yarn install --mode=update-lockfile
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git add yarn.lock ui-tests/yarn.lock
+            git commit -m "Regenerate yarn.lock [dependabot skip]"
+            git push
+          else
+            echo "Lockfiles already in sync — nothing to do."
+          fi


### PR DESCRIPTION
<!--
Thanks for contributing to Jupyter Notebook!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyter/notebook/blob/main/CONTRIBUTING.md
-->

## References

Fixes #7606

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
In this pr we improve our Dependabot setup so dependency update PRs can pass CI more reliably.

What was added:
- A Dependabot config for the `repo` and `ui-tests` so updates are generated in the right places
- and added lock file

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
