### PR TITLE
Show a dialog for the `Help > About Jupyter` menu entry

### DIFF
--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -17,30 +17,14 @@ import { jupyterIcon } from '@jupyter-notebook/ui-components';
 import * as React from 'react';
 
 /**
- * A list of resources to show in the help menu.
- */
-const RESOURCES = [
-  {
-    text: 'About Jupyter',
-    url: 'https://jupyter.org',
-  },
-  {
-    text: 'Markdown Reference',
-    url: 'https://commonmark.org/help/',
-  },
-  {
-    text: 'Documentation',
-    url: 'https://jupyter-notebook.readthedocs.io/en/stable/',
-  },
-];
-
-/**
  * The command IDs used by the help plugin.
  */
 namespace CommandIDs {
   export const open = 'help:open';
 
   export const about = 'help:about';
+
+  export const aboutJupyter = 'help:about-jupyter';
 }
 
 // CVE-2026-40171 / GHSA-rch3-82jr-f9w9
@@ -183,14 +167,97 @@ const about: JupyterFrontEndPlugin<void> = {
       },
     });
 
+    commands.addCommand(CommandIDs.aboutJupyter, {
+      label: trans.__('About Jupyter'),
+      execute: () => {
+        const title = (
+          <>
+            <span className="jp-AboutNotebook-header">
+              <jupyterIcon.react width="196px" height="auto" />
+            </span>
+          </>
+        );
+
+        const jupyterURL = 'https://jupyter.org/about';
+        const contributorURL = 'https://jupyter.org/community';
+        const aboutProjectJupyter = trans.__('ABOUT PROJECT JUPYTER');
+        const communityJupyter = trans.__('JUPYTER COMMUNITY');
+        const externalLinks = (
+          <span>
+            <a
+              href={jupyterURL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="jp-Button-flat jp-AboutNotebook-about-externalLinks"
+            >
+              {aboutProjectJupyter}
+            </a>
+            <a
+              href={contributorURL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="jp-Button-flat jp-AboutNotebook-about-externalLinks"
+            >
+              {communityJupyter}
+            </a>
+          </span>
+        );
+        const description = trans.__(
+          'Project Jupyter exists to develop open-source software, open standards, and services for interactive computing across dozens of programming languages.'
+        );
+        const body = (
+          <>
+            <span className="jp-AboutNotebook-body">{description}</span>
+            <div>{externalLinks}</div>
+          </>
+        );
+
+        const dialog = new Dialog({
+          title,
+          body,
+          buttons: [
+            Dialog.createButton({
+              label: trans.__('Dismiss'),
+              className:
+                'jp-AboutNotebook-about-button jp-mod-reject jp-mod-styled',
+            }),
+          ],
+        });
+        dialog.addClass('jp-AboutNotebook');
+        dialog.addClass('jp-AboutJupyter');
+        void dialog.launch();
+      },
+      describedBy: {
+        args: {
+          type: 'object',
+          properties: {},
+        },
+      },
+    });
+
     if (palette) {
       palette.addItem({ command: CommandIDs.about, category });
+      palette.addItem({ command: CommandIDs.aboutJupyter, category });
     }
 
-    const resourcesGroup = RESOURCES.map((args) => ({
-      args,
-      command: CommandIDs.open,
-    }));
+    const resources = [
+      {
+        text: trans.__('Markdown Reference'),
+        url: 'https://commonmark.org/help/',
+      },
+      {
+        text: trans.__('Documentation'),
+        url: 'https://jupyter-notebook.readthedocs.io/en/stable/',
+      },
+    ];
+
+    const resourcesGroup = [
+      { command: CommandIDs.aboutJupyter },
+      ...resources.map((args) => ({
+        args,
+        command: CommandIDs.open,
+      })),
+    ];
 
     if (menu) {
       menu.helpMenu.addGroup(resourcesGroup, 30);

--- a/packages/help-extension/style/base.css
+++ b/packages/help-extension/style/base.css
@@ -51,3 +51,7 @@
 .jp-AboutNotebook-about-copyright {
   padding-top: 25px;
 }
+
+.jp-AboutJupyter .jp-Dialog-content {
+  max-width: 480px;
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Jupyter Notebook!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyter/notebook/blob/main/CONTRIBUTING.md
-->

## References

Fixes #6782 


## Code changes

- [x] Show a dialog for the "About Jupyter" menu entry for consistency

## User-facing changes

<img width="1280" height="900" alt="aboutdialog" src="https://github.com/user-attachments/assets/4f0094bd-8a5b-4e3b-94da-ffba478d490d" />


## Backwards-incompatible changes

None
