### PR TITLE
docs: add documentation version switcher

### DIFF
--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "latest",
+    "version": "latest",
+    "url": "https://jupyter-notebook.readthedocs.io/en/latest/"
+  },
+  {
+    "name": "stable",
+    "version": "stable",
+    "url": "https://jupyter-notebook.readthedocs.io/en/stable/"
+  },
+  {
+    "name": "7.6.1",
+    "version": "v7.6.1",
+    "url": "https://jupyter-notebook.readthedocs.io/en/v7.6.1/"
+  },
+  {
+    "name": "7.5.7",
+    "version": "v7.5.7",
+    "url": "https://jupyter-notebook.readthedocs.io/en/v7.5.7/"
+  },
+  {
+    "name": "7.4.7",
+    "version": "v7.4.7",
+    "url": "https://jupyter-notebook.readthedocs.io/en/v7.4.7/"
+  },
+  {
+    "name": "6.5.4",
+    "version": "v6.5.4",
+    "url": "https://jupyter-notebook.readthedocs.io/en/v6.5.4/"
+  }
+]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -203,7 +203,12 @@ html_theme_options = {
         "image_dark": "_static/logo-rectangle-dark.svg",
     },
     "use_edit_page_button": True,
+    "navbar_start": ["navbar-logo", "version-switcher"],
     "navigation_with_keys": False,
+    "switcher": {
+        "json_url": "https://jupyter-notebook.readthedocs.io/en/latest/_static/switcher.json",
+        "version_match": os.environ.get("READTHEDOCS_VERSION", "latest"),
+    },
 }
 
 # Output for github to be used in links


### PR DESCRIPTION
## References

Fixes #7149.

## Code changes

Add the PyData Sphinx Theme version switcher to the documentation navigation and provide a switcher manifest for the current and historical Notebook documentation versions.

## User-facing changes

Readers can move between the latest, stable, recent 7.x, and Notebook 6.5.4 documentation from the documentation navigation.

## Backwards-incompatible changes

None.

## Validation

The full Sphinx build was not run locally because Sphinx and Hatch are not installed in this checkout; CI remains the source of truth.

This PR was prepared with Codex; the final diff was checked for scope and configuration syntax. 🤖🍆
