### PR TITLE
Enable opening notebooks without a kernel

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -328,6 +328,9 @@
           "@jupyterlab/filebrowser-extension:settings",
           "@jupyterlab/filebrowser-extension:share-file"
         ],
+        "@jupyterlab/notebook-extension": [
+          "@jupyterlab/notebook-extension:open-with-no-kernel"
+        ],
         "@jupyter-notebook/tree-extension": true,
         "@jupyterlab/running-extension": [
           "@jupyterlab/running-extension:plugin"

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -273,7 +273,7 @@ const opener: JupyterFrontEndPlugin<void> = {
             urlParams.get('kernel') === 'none'
               ? { shouldStart: false, shouldReuse: false }
               : undefined;
-          docManager.openOrReveal(
+          const widget = docManager.openOrReveal(
             file,
             factory,
             undefined,
@@ -282,6 +282,35 @@ const opener: JupyterFrontEndPlugin<void> = {
             },
             kernelPreference
           );
+
+          if (kernelPreference && widget) {
+            const { context } = widget;
+            const { sessionContext } = context;
+            const disconnect = () => {
+              sessionContext.kernelChanged.disconnect(clearNoKernelQuery);
+              context.disposed.disconnect(disconnect);
+            };
+            const clearNoKernelQuery = () => {
+              if (!sessionContext.session?.kernel) {
+                return;
+              }
+
+              const url = new URL(window.location.href);
+              if (url.searchParams.get('kernel') === 'none') {
+                url.searchParams.delete('kernel');
+                window.history.replaceState(
+                  window.history.state,
+                  '',
+                  url.toString()
+                );
+              }
+              disconnect();
+            };
+
+            sessionContext.kernelChanged.connect(clearNoKernelQuery);
+            context.disposed.connect(disconnect);
+            clearNoKernelQuery();
+          }
         });
       },
       describedBy: {

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -269,9 +269,19 @@ const opener: JupyterFrontEndPlugin<void> = {
           }
 
           const factory = urlParams.get('factory') ?? defaultFactory;
-          docManager.open(file, factory, undefined, {
-            ref: '_noref',
-          });
+          const kernelPreference =
+            urlParams.get('kernel') === 'none'
+              ? { shouldStart: false, shouldReuse: false }
+              : undefined;
+          docManager.openOrReveal(
+            file,
+            factory,
+            undefined,
+            {
+              ref: '_noref',
+            },
+            kernelPreference
+          );
         });
       },
       describedBy: {

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -284,31 +284,27 @@ const opener: JupyterFrontEndPlugin<void> = {
           );
 
           if (kernelPreference && widget) {
-            const { context } = widget;
-            const { sessionContext } = context;
-            const disconnect = () => {
-              sessionContext.kernelChanged.disconnect(clearNoKernelQuery);
-              context.disposed.disconnect(disconnect);
-            };
+            const { sessionContext } = widget.context;
+            /**
+             * `kernel=none` only describes how to open the notebook. Drop it
+             * as soon as a kernel runs, so a reload reconnects to that session.
+             */
             const clearNoKernelQuery = () => {
               if (!sessionContext.session?.kernel) {
                 return;
               }
 
               const url = new URL(window.location.href);
-              if (url.searchParams.get('kernel') === 'none') {
-                url.searchParams.delete('kernel');
-                window.history.replaceState(
-                  window.history.state,
-                  '',
-                  url.toString()
-                );
-              }
-              disconnect();
+              url.searchParams.delete('kernel');
+              window.history.replaceState(
+                window.history.state,
+                '',
+                url.toString()
+              );
+              sessionContext.kernelChanged.disconnect(clearNoKernelQuery);
             };
 
             sessionContext.kernelChanged.connect(clearNoKernelQuery);
-            context.disposed.connect(disconnect);
             clearNoKernelQuery();
           }
         });

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -72,6 +72,13 @@ const opener: JupyterFrontEndPlugin<IDocumentWidgetOpener> = {
               factory: widgetName,
             });
           }
+          if (
+            route === 'notebooks' &&
+            widget.context.sessionContext.kernelPreference.shouldStart === false
+          ) {
+            searchParams ??= new URLSearchParams();
+            searchParams.set('kernel', 'none');
+          }
 
           pathOpener.open({
             prefix: URLExt.join(baseUrl, route),

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -72,6 +72,8 @@ const opener: JupyterFrontEndPlugin<IDocumentWidgetOpener> = {
               factory: widgetName,
             });
           }
+          // Require both flags: `notebookStartsKernel=False` only sets
+          // `shouldStart: false` and must still reuse a running session.
           if (
             route === 'notebooks' &&
             widget.context.sessionContext.kernelPreference.shouldStart ===

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -74,7 +74,9 @@ const opener: JupyterFrontEndPlugin<IDocumentWidgetOpener> = {
           }
           if (
             route === 'notebooks' &&
-            widget.context.sessionContext.kernelPreference.shouldStart === false
+            widget.context.sessionContext.kernelPreference.shouldStart ===
+              false &&
+            widget.context.sessionContext.kernelPreference.shouldReuse === false
           ) {
             searchParams ??= new URLSearchParams();
             searchParams.set('kernel', 'none');

--- a/ui-tests/test/filebrowser.spec.ts
+++ b/ui-tests/test/filebrowser.spec.ts
@@ -103,6 +103,40 @@ test.describe('File Browser', () => {
     await notebook.close();
   });
 
+  test('Open a notebook without starting a kernel', async ({
+    page,
+    tmpPath,
+  }) => {
+    await page.filebrowser.refresh();
+
+    await page.getByText('empty.ipynb').last().click({ button: 'right' });
+    await page.getByText('Open With', { exact: true }).hover();
+
+    const [notebook] = await Promise.all([
+      page.waitForEvent('popup'),
+      page.getByRole('menuitem', { name: 'Notebook (no kernel)' }).click(),
+    ]);
+
+    await notebook.waitForSelector('.jp-NotebookPanel');
+    const hasRunningSession = await notebook.evaluate(async (notebookPath) => {
+      const app = window.jupyterapp;
+      await app.started;
+      const currentWidget = app.shell.currentWidget as unknown as {
+        sessionContext: { ready: Promise<void> };
+      };
+      await currentWidget.sessionContext.ready;
+      await app.serviceManager.sessions.refreshRunning();
+      return Array.from(app.serviceManager.sessions.running()).some(
+        (session) => session.path === notebookPath
+      );
+    }, `${tmpPath}/empty.ipynb`);
+
+    await expect(notebook.getByTitle('Switch kernel')).toHaveText('No Kernel');
+    expect(hasRunningSession).toBe(false);
+
+    await notebook.close();
+  });
+
   test('Toggle the Date Created column from the header context menu', async ({
     page,
   }) => {

--- a/ui-tests/test/filebrowser.spec.ts
+++ b/ui-tests/test/filebrowser.spec.ts
@@ -4,8 +4,51 @@
 import path from 'path';
 
 import { expect, galata } from '@jupyterlab/galata';
+import type { Page } from '@playwright/test';
 
 import { test } from './fixtures';
+
+async function getNotebookSessionState(page: Page, notebookPath: string) {
+  return page.evaluate(async (path) => {
+    const app = window.jupyterapp;
+    await app.started;
+    const currentWidget = app.shell.currentWidget as unknown as {
+      sessionContext: {
+        ready: Promise<void>;
+        session: { id: string; kernel: unknown | null } | null;
+      };
+    };
+    await currentWidget.sessionContext.ready;
+    await app.serviceManager.sessions.refreshRunning();
+    const sessions = Array.from(app.serviceManager.sessions.running()).filter(
+      (session) => session.path === path
+    );
+    return {
+      currentSessionId: currentWidget.sessionContext.session?.id ?? null,
+      hasKernel: Boolean(currentWidget.sessionContext.session?.kernel),
+      sessionIds: sessions.map((session) => session.id),
+    };
+  }, notebookPath);
+}
+
+async function openWithoutKernel(page: Page): Promise<Page> {
+  await page.getByText('empty.ipynb').last().click({ button: 'right' });
+  await page.getByText('Open With', { exact: true }).hover();
+
+  const [notebook] = await Promise.all([
+    page.waitForEvent('popup'),
+    page.getByRole('menuitem', { name: 'Notebook (no kernel)' }).click(),
+  ]);
+  await notebook.waitForSelector('.jp-NotebookPanel');
+  return notebook;
+}
+
+async function shutdownSession(page: Page, sessionId: string): Promise<void> {
+  await page.evaluate(async (sessionId) => {
+    await window.jupyterapp.started;
+    await window.jupyterapp.serviceManager.sessions.shutdown(sessionId);
+  }, sessionId);
+}
 
 test.describe('File Browser', () => {
   test.beforeEach(async ({ page, tmpPath }) => {
@@ -103,38 +146,157 @@ test.describe('File Browser', () => {
     await notebook.close();
   });
 
-  test('Open a notebook without starting a kernel', async ({
+  test('No-auto-start opening still reuses an existing session', async ({
     page,
     tmpPath,
   }) => {
+    const treeUrl = new URL(page.url());
+    treeUrl.searchParams.set('notebookStartsKernel', 'false');
+    await page.goto(treeUrl.toString());
+
+    const notebookPath = `${tmpPath}/empty.ipynb`;
+    let notebook: Page | null = null;
+    let existingSessionId: string | null = null;
+    try {
+      existingSessionId = await page.evaluate(async (path) => {
+        const app = window.jupyterapp;
+        await app.started;
+        const session = await app.serviceManager.sessions.startNew({
+          path,
+          name: '',
+          type: 'notebook',
+          kernel: { name: 'python3' },
+        });
+        const id = session.id;
+        session.dispose();
+        return id;
+      }, notebookPath);
+
+      await page.filebrowser.refresh();
+
+      [notebook] = await Promise.all([
+        page.waitForEvent('popup'),
+        page.getByText('empty.ipynb').last().dblclick(),
+      ]);
+
+      await notebook.waitForSelector('.jp-NotebookPanel');
+      expect(new URL(notebook.url()).searchParams.get('kernel')).not.toBe(
+        'none'
+      );
+
+      const state = await getNotebookSessionState(notebook, notebookPath);
+      expect(state.currentSessionId).toBe(existingSessionId);
+      expect(state.hasKernel).toBe(true);
+      expect(state.sessionIds).toEqual([existingSessionId]);
+    } finally {
+      try {
+        if (notebook && !notebook.isClosed()) {
+          await notebook.close();
+        }
+      } finally {
+        if (existingSessionId) {
+          await shutdownSession(page, existingSessionId);
+        }
+      }
+    }
+  });
+
+  test('No-kernel launch reconnects after starting a kernel', async ({
+    page,
+    tmpPath,
+  }) => {
+    const notebookPath = `${tmpPath}/empty.ipynb`;
     await page.filebrowser.refresh();
 
-    await page.getByText('empty.ipynb').last().click({ button: 'right' });
-    await page.getByText('Open With', { exact: true }).hover();
-
-    const [notebook] = await Promise.all([
-      page.waitForEvent('popup'),
-      page.getByRole('menuitem', { name: 'Notebook (no kernel)' }).click(),
-    ]);
-
-    await notebook.waitForSelector('.jp-NotebookPanel');
-    const hasRunningSession = await notebook.evaluate(async (notebookPath) => {
-      const app = window.jupyterapp;
-      await app.started;
-      const currentWidget = app.shell.currentWidget as unknown as {
-        sessionContext: { ready: Promise<void> };
-      };
-      await currentWidget.sessionContext.ready;
-      await app.serviceManager.sessions.refreshRunning();
-      return Array.from(app.serviceManager.sessions.running()).some(
-        (session) => session.path === notebookPath
+    let notebook: Page | null = null;
+    let startedSessionId: string | null = null;
+    try {
+      notebook = await openWithoutKernel(page);
+      expect(new URL(notebook.url()).searchParams.get('kernel')).toBe('none');
+      await expect(notebook.getByTitle('Switch kernel')).toHaveText(
+        'No Kernel'
       );
-    }, `${tmpPath}/empty.ipynb`);
+      expect(await getNotebookSessionState(notebook, notebookPath)).toEqual({
+        currentSessionId: null,
+        hasKernel: false,
+        sessionIds: [],
+      });
 
-    await expect(notebook.getByTitle('Switch kernel')).toHaveText('No Kernel');
-    expect(hasRunningSession).toBe(false);
+      await notebook.reload();
+      await notebook.waitForSelector('.jp-NotebookPanel');
+      expect(new URL(notebook.url()).searchParams.get('kernel')).toBe('none');
+      await expect(notebook.getByTitle('Switch kernel')).toHaveText(
+        'No Kernel'
+      );
+      expect(await getNotebookSessionState(notebook, notebookPath)).toEqual({
+        currentSessionId: null,
+        hasKernel: false,
+        sessionIds: [],
+      });
 
-    await notebook.close();
+      await notebook.evaluate(() => {
+        const url = new URL(window.location.href);
+        url.searchParams.set('preserved', 'value');
+        url.hash = 'preserved-fragment';
+        window.history.replaceState(
+          { ...window.history.state, preservedState: 'value' },
+          '',
+          url
+        );
+      });
+
+      startedSessionId = await notebook.evaluate(async () => {
+        const app = window.jupyterapp;
+        await app.started;
+        const currentWidget = app.shell.currentWidget as unknown as {
+          sessionContext: {
+            changeKernel(options: { name: string }): Promise<unknown>;
+            session: { id: string } | null;
+          };
+        };
+        await currentWidget.sessionContext.changeKernel({ name: 'python3' });
+        return currentWidget.sessionContext.session?.id ?? null;
+      });
+      expect(startedSessionId).not.toBeNull();
+
+      await expect
+        .poll(() => new URL(notebook!.url()).searchParams.get('kernel'))
+        .toBeNull();
+      expect(new URL(notebook.url()).searchParams.get('preserved')).toBe(
+        'value'
+      );
+      expect(new URL(notebook.url()).hash).toBe('#preserved-fragment');
+      expect(
+        await notebook.evaluate(() => window.history.state.preservedState)
+      ).toBe('value');
+      expect(await getNotebookSessionState(notebook, notebookPath)).toEqual({
+        currentSessionId: startedSessionId,
+        hasKernel: true,
+        sessionIds: [startedSessionId],
+      });
+
+      await notebook.reload();
+      await notebook.waitForSelector('.jp-NotebookPanel');
+
+      await expect(notebook.getByTitle('Switch kernel')).not.toHaveText(
+        'No Kernel'
+      );
+      expect(await getNotebookSessionState(notebook, notebookPath)).toEqual({
+        currentSessionId: startedSessionId,
+        hasKernel: true,
+        sessionIds: [startedSessionId],
+      });
+    } finally {
+      try {
+        if (notebook && !notebook.isClosed()) {
+          await notebook.close();
+        }
+      } finally {
+        if (startedSessionId) {
+          await shutdownSession(page, startedSessionId);
+        }
+      }
+    }
   });
 
   test('Toggle the Date Created column from the header context menu', async ({

--- a/ui-tests/test/jupyter_server_config.py
+++ b/ui-tests/test/jupyter_server_config.py
@@ -6,3 +6,12 @@ c: Any
 c.JupyterNotebookApp.expose_app_in_browser = True
 
 configure_jupyter_server(c)
+
+
+def page_config_hook(handler: Any, page_config: dict[str, Any]) -> dict[str, Any]:
+    if handler.get_query_argument("notebookStartsKernel", None) == "false":
+        page_config["notebookStartsKernel"] = False
+    return page_config
+
+
+c.ServerApp.tornado_settings = {"page_config_hook": page_config_hook}


### PR DESCRIPTION

## References

Fixes #3170 

Build on top of the upstream JupyterLab changes.

## Code changes

- [x] Allow opening notebooks without a kernel
- [x] Test

## User-facing changes


https://github.com/user-attachments/assets/6003b2d0-9bc8-4162-9494-a5cd8c14c79b



## Backwards-incompatible changes

None