### PR TITLE
Add New Folder to File > New menu (#8044)

### DIFF
--- a/packages/tree-extension/src/index.ts
+++ b/packages/tree-extension/src/index.ts
@@ -70,17 +70,20 @@ namespace CommandIDs {
  * Plugin to add extra commands to the file browser to create
  * new notebooks, files, consoles and terminals
  */
+import { IMainMenu } from '@jupyterlab/mainmenu';
+
 const createNew: JupyterFrontEndPlugin<void> = {
   id: '@jupyter-notebook/tree-extension:new',
   description:
     'Plugin to add extra commands to the file browser to create new notebooks, files, consoles and terminals.',
   requires: [ITranslator],
-  optional: [IToolbarWidgetRegistry],
+  optional: [IToolbarWidgetRegistry, IMainMenu],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     translator: ITranslator,
-    toolbarRegistry: IToolbarWidgetRegistry | null
+    toolbarRegistry: IToolbarWidgetRegistry | null,
+    mainMenu: IMainMenu | null
   ) => {
     const { commands, serviceManager } = app;
     const trans = translator.load('notebook');
@@ -134,6 +137,16 @@ const createNew: JupyterFrontEndPlugin<void> = {
           return menubar;
         }
       );
+    }
+
+    // Add "New Folder" to the top File > New menu.
+    // (Notebook, Console, Terminal, and Text File are already registered
+    // there by other plugins/extensions — this adds the missing entry.)
+    if (mainMenu) {
+      mainMenu.fileMenu.newMenu.addItem({
+        command: 'filebrowser:create-new-directory',
+        rank: 100,
+      });
     }
   },
 };


### PR DESCRIPTION
<!--
Thanks for contributing to Jupyter Notebook!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyter/notebook/blob/main/CONTRIBUTING.md
-->
## References
Closes #8044

## Code changes
The `filebrowser:create-new-directory` command already existed and was wired into the file browser toolbar's "New" dropdown (in `packages/tree-extension/src/index.ts`), but it was never registered with the top menu bar's `File > New` submenu (`IMainMenu.fileMenu.newMenu`).

This PR adds `IMainMenu` as an optional dependency to the `createNew` plugin in `packages/tree-extension/src/index.ts` and registers the existing `filebrowser:create-new-directory` command to `mainMenu.fileMenu.newMenu`, so it now appears alongside Console, Notebook, Terminal, Text File, Markdown File, and Python File.

No new commands were created — this only adds a menu registration for an existing command.

## User-facing changes
"New Folder" now appears as an item in `File > New`, in addition to the existing toolbar "New" dropdown in the file browser. It's registered with a high rank so it appears last in the list, consistent with where JupyterLab places it in its own File menu.

Before: `File > New` only listed Console, Notebook, Terminal, Text File, Markdown File, and Python File — no way to create a folder from this menu.
<img width="1466" height="929" alt="Screenshot from 2026-08-27 15-32-42" src="https://github.com/user-attachments/assets/709af288-0662-4dfd-bdc3-c92ab28569a7" />

After: `File > New > New Folder` creates a new folder in the current directory, matching the existing toolbar behavior.
<img width="1466" height="929" alt="Screenshot from 2026-08-27 15-55-50" src="https://github.com/user-attachments/assets/9e8bd9fb-cff8-4502-99e4-75a52673c9f2" />


## Backwards-incompatible changes
None. This is an additive change — no existing commands, APIs, or menu items were modified or removed.