### PR TITLE
fix: support skip to main link in tree and non-editor views

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -605,6 +605,7 @@ export namespace Private {
      * Construct a new skipLink widget handler.
      */
     constructor(shell: INotebookShell) {
+      this._shell = shell;
       const skipLinkWidget = (this._skipLinkWidget = new Widget());
       const skipToMain = document.createElement('a');
       skipToMain.href = '#first-cell';
@@ -628,9 +629,44 @@ export namespace Private {
     private _focusMain() {
       const input = document.querySelector(
         '#main-panel .jp-InputArea-editor'
-      ) as HTMLInputElement;
-      input.tabIndex = 1;
-      input.focus();
+      ) as HTMLElement | null;
+      if (input) {
+        input.tabIndex = 1;
+        input.focus();
+        return;
+      }
+
+      const dirListing = document.querySelector(
+        '#main-panel .jp-DirListing-content'
+      ) as HTMLElement | null;
+      if (dirListing) {
+        dirListing.tabIndex = 1;
+        dirListing.focus();
+        return;
+      }
+
+      const cmContent = document.querySelector(
+        '#main-panel .cm-content'
+      ) as HTMLElement | null;
+      if (cmContent) {
+        cmContent.focus();
+        return;
+      }
+
+      const currentWidget = this._shell.currentWidget;
+      if (currentWidget) {
+        currentWidget.node.tabIndex = 1;
+        currentWidget.node.focus();
+        return;
+      }
+
+      const mainPanel = document.querySelector(
+        '#main-panel'
+      ) as HTMLElement | null;
+      if (mainPanel) {
+        mainPanel.tabIndex = 1;
+        mainPanel.focus();
+      }
     }
 
     /**
@@ -673,6 +709,7 @@ export namespace Private {
       return this._isDisposed;
     }
 
+    private _shell: INotebookShell;
     private _skipLinkWidget: Widget;
     private _isDisposed = false;
   }

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -578,6 +578,17 @@ export class NotebookShell extends Widget implements JupyterFrontEnd.IShell {
     this._downPanel.hide();
   }
 
+  /**
+   * Dispose of the resources held by the shell.
+   */
+  override dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._skipLinkWidgetHandler.dispose();
+    super.dispose();
+  }
+
   private _topWrapper: Panel;
   private _topHandler: PanelHandler;
   private _menuWrapper: Panel;
@@ -607,7 +618,7 @@ export namespace Private {
     constructor(shell: INotebookShell) {
       this._shell = shell;
       const skipLinkWidget = (this._skipLinkWidget = new Widget());
-      const skipToMain = document.createElement('a');
+      const skipToMain = (this._skipToMain = document.createElement('a'));
       skipToMain.href = '#first-cell';
       skipToMain.tabIndex = 1;
       skipToMain.text = 'Skip to Main';
@@ -627,27 +638,33 @@ export namespace Private {
     }
 
     private _focusMain() {
-      const input = document.querySelector(
-        '#main-panel .jp-InputArea-editor'
-      ) as HTMLElement | null;
+      const root = this._shell.node ?? document;
+      const input = (root.querySelector('#main-panel .jp-InputArea-editor') ??
+        document.querySelector(
+          '#main-panel .jp-InputArea-editor'
+        )) as HTMLElement | null;
       if (input) {
         input.tabIndex = 1;
         input.focus();
         return;
       }
 
-      const dirListing = document.querySelector(
+      const dirListing = (root.querySelector(
         '#main-panel .jp-DirListing-content'
-      ) as HTMLElement | null;
+      ) ??
+        document.querySelector(
+          '#main-panel .jp-DirListing-content'
+        )) as HTMLElement | null;
       if (dirListing) {
         dirListing.tabIndex = 1;
         dirListing.focus();
         return;
       }
 
-      const cmContent = document.querySelector(
-        '#main-panel .cm-content'
-      ) as HTMLElement | null;
+      const cmContent = (root.querySelector('#main-panel .cm-content') ??
+        document.querySelector(
+          '#main-panel .cm-content'
+        )) as HTMLElement | null;
       if (cmContent) {
         cmContent.focus();
         return;
@@ -660,9 +677,8 @@ export namespace Private {
         return;
       }
 
-      const mainPanel = document.querySelector(
-        '#main-panel'
-      ) as HTMLElement | null;
+      const mainPanel = (root.querySelector('#main-panel') ??
+        document.querySelector('#main-panel')) as HTMLElement | null;
       if (mainPanel) {
         mainPanel.tabIndex = 1;
         mainPanel.focus();
@@ -684,7 +700,7 @@ export namespace Private {
         return;
       }
       this._isDisposed = true;
-      this._skipLinkWidget.node.removeEventListener('click', this);
+      this._skipToMain.removeEventListener('click', this);
       this._skipLinkWidget.dispose();
     }
 
@@ -711,6 +727,7 @@ export namespace Private {
 
     private _shell: INotebookShell;
     private _skipLinkWidget: Widget;
+    private _skipToMain: HTMLAnchorElement;
     private _isDisposed = false;
   }
 }

--- a/packages/application/test/shell.spec.ts
+++ b/packages/application/test/shell.spec.ts
@@ -181,4 +181,85 @@ describe('Shell for tree view', () => {
       expect(widgets.length).toBeGreaterThan(0);
     });
   });
+
+  describe('#skipToMain', () => {
+    it('should focus the notebook input area editor if present', () => {
+      const widget = new Widget();
+      const editor = document.createElement('div');
+      editor.className = 'jp-InputArea-editor';
+      widget.node.appendChild(editor);
+      shell.add(widget, 'main');
+
+      const skipLink = shell.node.querySelector(
+        '#jp-skiplink a'
+      ) as HTMLAnchorElement;
+      expect(skipLink).not.toBeNull();
+
+      skipLink.click();
+      expect(document.activeElement).toBe(editor);
+      expect(editor.tabIndex).toBe(1);
+    });
+
+    it('should focus the directory listing content in tree view when editor is absent', () => {
+      const widget = new Widget();
+      const dirListing = document.createElement('div');
+      dirListing.className = 'jp-DirListing-content';
+      widget.node.appendChild(dirListing);
+      shell.add(widget, 'main');
+
+      const skipLink = shell.node.querySelector(
+        '#jp-skiplink a'
+      ) as HTMLAnchorElement;
+      expect(skipLink).not.toBeNull();
+
+      skipLink.click();
+      expect(document.activeElement).toBe(dirListing);
+      expect(dirListing.tabIndex).toBe(1);
+    });
+
+    it('should focus CodeMirror content if present when editor is absent', () => {
+      const widget = new Widget();
+      const cmContent = document.createElement('div');
+      cmContent.className = 'cm-content';
+      cmContent.tabIndex = 0;
+      widget.node.appendChild(cmContent);
+      shell.add(widget, 'main');
+
+      const skipLink = shell.node.querySelector(
+        '#jp-skiplink a'
+      ) as HTMLAnchorElement;
+      expect(skipLink).not.toBeNull();
+
+      skipLink.click();
+      expect(document.activeElement).toBe(cmContent);
+    });
+
+    it('should focus the current widget node if specific content classes are absent', () => {
+      const widget = new Widget();
+      shell.add(widget, 'main');
+
+      const skipLink = shell.node.querySelector(
+        '#jp-skiplink a'
+      ) as HTMLAnchorElement;
+      expect(skipLink).not.toBeNull();
+
+      skipLink.click();
+      expect(document.activeElement).toBe(widget.node);
+      expect(widget.node.tabIndex).toBe(1);
+    });
+
+    it('should focus main panel without throwing if main area is empty', () => {
+      const skipLink = shell.node.querySelector(
+        '#jp-skiplink a'
+      ) as HTMLAnchorElement;
+      expect(skipLink).not.toBeNull();
+
+      expect(() => {
+        skipLink.click();
+      }).not.toThrow();
+
+      const mainPanel = document.querySelector('#main-panel');
+      expect(document.activeElement).toBe(mainPanel);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #6969

The `Skip to Main` accessibility link previously targeted only `#main-panel .jp-InputArea-editor`, throwing a `TypeError` on `/tree` and file editor views where no notebook cells are present. This PR adds fallback focus targets (`.jp-DirListing-content`, `.cm-content`, `currentWidget`, `#main-panel`) so keyboard navigation works reliably across all views.